### PR TITLE
style: Add pointer cursor to every button in pomodoro view

### DIFF
--- a/styles/pomodoro-view.css
+++ b/styles/pomodoro-view.css
@@ -15,6 +15,11 @@
     justify-content: center;
     background: var(--tn-bg-primary);
     min-height: 100vh;
+
+	button {
+		cursor: pointer;
+	}
+
 }
 
 /* ================================================


### PR DESCRIPTION
This just makes it more visually clear that the buttons in pomodoro view are clickable.
Right now in pomodoro view, no button has a cursor style.
