### PR TITLE
feat: add folder-based task filtering support

### DIFF
--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -1151,7 +1151,8 @@ export class FilterService extends EventEmitter {
             priorities: this.priorityManager.getAllPriorities(),
             contexts: this.cacheManager.getAllContexts(),
             projects: this.cacheManager.getAllProjects(),
-            tags: this.cacheManager.getAllTags()
+            tags: this.cacheManager.getAllTags(),
+            folders: this.extractUniqueFolders()
         };
         
         this.filterOptionsComputeCount++;
@@ -1548,6 +1549,34 @@ export class FilterService extends EventEmitter {
         }
 
         return flatData;
+    }
+
+    /**
+     * Extract unique folder paths from all task paths
+     * Returns an array of folder paths for dropdown filtering
+     */
+    private extractUniqueFolders(): readonly string[] {
+        const allTaskPaths = this.cacheManager.getAllTaskPaths();
+        const folderSet = new Set<string>();
+        
+        for (const taskPath of allTaskPaths) {
+            // Extract the folder part of the path (everything before the last slash)
+            const lastSlashIndex = taskPath.lastIndexOf('/');
+            if (lastSlashIndex > 0) {
+                const folderPath = taskPath.substring(0, lastSlashIndex);
+                folderSet.add(folderPath);
+            }
+            // Also add root-level folder (empty string or "." for tasks in vault root)
+            else if (lastSlashIndex === -1) {
+                folderSet.add(''); // Root folder
+            }
+        }
+        
+        // Convert to sorted array for consistent UI ordering
+        const folders = Array.from(folderSet).sort();
+        
+        // Replace empty string with a user-friendly label for root folder
+        return folders.map(folder => folder === '' ? '(Root)' : folder);
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export type FilterProperty =
 	// Placeholder for "Select..." option
 	| ''
 	// Text properties
-	| 'title'
+	| 'title' | 'path'
 	// Select properties
 	| 'status' | 'priority' | 'tags' | 'contexts' | 'projects'
 	// Date properties
@@ -115,6 +115,7 @@ export interface PropertyDefinition {
 export const FILTER_PROPERTIES: PropertyDefinition[] = [
 	// Text properties
 	{ id: 'title', label: 'Title', category: 'text', supportedOperators: ['is', 'is-not', 'contains', 'does-not-contain', 'is-empty', 'is-not-empty'], valueInputType: 'text' },
+	{ id: 'path', label: 'Path', category: 'select', supportedOperators: ['contains', 'does-not-contain', 'is-empty', 'is-not-empty'], valueInputType: 'select' },
 	
 	// Select properties
 	{ id: 'status', label: 'Status', category: 'select', supportedOperators: ['is', 'is-not', 'is-empty', 'is-not-empty'], valueInputType: 'select' },
@@ -190,6 +191,7 @@ export interface FilterOptions {
 	contexts: readonly string[];
 	projects: readonly string[];
 	tags: readonly string[];
+	folders: readonly string[];
 }
 
 // Time and date related types

--- a/src/ui/FilterBar.ts
+++ b/src/ui/FilterBar.ts
@@ -965,6 +965,11 @@ export class FilterBar extends EventEmitter {
                     dropdown.addOption(option, option);
                 });
                 break;
+            case 'path':
+                this.filterOptions.folders.forEach(option => {
+                    dropdown.addOption(option, option);
+                });
+                break;
         }
 
         setTooltip(dropdown.selectEl, `Select a ${propertyDef.label.toLowerCase()} to filter by`, { placement: 'top' });
@@ -978,6 +983,10 @@ export class FilterBar extends EventEmitter {
             } else {
                 dropdown.setValue(currentValue);
             }
+        } else if (propertyDef.id === 'path') {
+            const currentValue = String(condition.value || '');
+            // Show "(Root)" for empty string path
+            dropdown.setValue(currentValue === '' ? '(Root)' : currentValue);
         } else {
             dropdown.setValue(String(condition.value || ''));
         }
@@ -985,6 +994,8 @@ export class FilterBar extends EventEmitter {
         dropdown.onChange((value) => {
             if (propertyDef.id === 'projects' && value) {
                 condition.value = `[[${value}]]`;
+            } else if (propertyDef.id === 'path' && value === '(Root)') {
+                condition.value = '';
             } else {
                 condition.value = value || null;
             }

--- a/src/utils/FilterUtils.ts
+++ b/src/utils/FilterUtils.ts
@@ -150,6 +150,7 @@ export class FilterUtils {
             
             // Text properties
             'title': ['is', 'is-not', 'contains', 'does-not-contain', 'is-empty', 'is-not-empty'],
+            'path': ['contains', 'does-not-contain', 'is-empty', 'is-not-empty'],
             
             // Select properties
             'status': ['is', 'is-not', 'is-empty', 'is-not-empty'],
@@ -208,6 +209,8 @@ export class FilterUtils {
         switch (property) {
             case 'title':
                 return task.title;
+            case 'path':
+                return task.path;
             case 'status':
                 return task.status;
             case 'priority':


### PR DESCRIPTION
## Summary
Adds the ability to filter tasks by their folder location through the advanced filtering system.

## Changes
- **types.ts**: Added 'path' property to FilterProperty type and FILTER_PROPERTIES array
- **FilterUtils.ts**: Updated getTaskPropertyValue method to handle path property and added path to operator mapping
- **FilterService.ts**: Added extractUniqueFolders() method to gather folder data for dropdown options
- **FilterBar.ts**: Enhanced renderSelectInput method to support path filtering with folder dropdown

## Features
- Filter tasks by folder location using "contains" or "does not contain" operators
- Dropdown selection populated with all unique folder paths found in vault
- Special handling for root-level tasks with user-friendly "(Root)" label
- Support for empty/not-empty operators to find tasks with or without folder paths

## Test plan
- [ ] Verify "Path" appears as a filter property option in the advanced filter dropdown
- [ ] Confirm folder dropdown populates with existing folder paths from tasks
- [ ] Test filtering by specific folders using "contains" operator
- [ ] Test filtering out folders using "does not contain" operator  
- [ ] Verify "(Root)" option filters for tasks in vault root
- [ ] Test empty/not-empty operators work correctly
- [ ] Confirm UI properly handles folder selection and display