### PR TITLE
feat: add configurable archive folder for moving archived tasks

### DIFF
--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -146,6 +146,8 @@ export const DEFAULT_ICS_INTEGRATION_SETTINGS: ICSIntegrationSettings = {
 
 export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	tasksFolder: 'TaskNotes/Tasks',
+	moveArchivedTasks: false,
+	archiveFolder: 'TaskNotes/Archive',
 	taskTag: 'task',
 	taskIdentificationMethod: 'tag',  // Default to tag-based identification
 	taskPropertyName: '',

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -254,6 +254,36 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(container)
+			.setName('Move archived tasks to folder')
+			.setDesc('Automatically move tasks to a configured folder when archived')
+			.addToggle(toggle => {
+				toggle.toggleEl.setAttribute('aria-label', 'Move archived tasks to folder');
+				return toggle
+					.setValue(this.plugin.settings.moveArchivedTasks)
+					.onChange(async (value) => {
+						this.plugin.settings.moveArchivedTasks = value;
+						await this.plugin.saveSettings();
+						this.renderActiveTab(); // Re-render to show/hide archive folder setting
+					});
+			});
+
+		if (this.plugin.settings.moveArchivedTasks) {
+			new Setting(container)
+				.setName('Archive folder')
+				.setDesc('Folder to move tasks to when archived')
+				.addText(text => {
+					text.inputEl.setAttribute('aria-label', 'Archive folder path');
+					return text
+						.setPlaceholder('TaskNotes/Archive')
+						.setValue(this.plugin.settings.archiveFolder)
+						.onChange(async (value) => {
+							this.plugin.settings.archiveFolder = value;
+							await this.plugin.saveSettings();
+						});
+				});
+		}
+
+		new Setting(container)
 			.setName('Identify tasks by')
 			.setDesc('Choose whether to identify tasks by tag or by a frontmatter property')
 			.addDropdown(dropdown => {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -2,6 +2,8 @@ import { FieldMapping, StatusConfig, PriorityConfig, SavedView, WebhookConfig } 
 
 export interface TaskNotesSettings {
 	tasksFolder: string;  // Now just a default location for new tasks
+	moveArchivedTasks: boolean; // Whether to move tasks to archive folder when archived
+	archiveFolder: string; // Folder to move archived tasks to
 	taskTag: string;      // The tag that identifies tasks
 	taskIdentificationMethod: 'tag' | 'property';  // Method to identify tasks
 	taskPropertyName: string;     // Property name for property-based identification


### PR DESCRIPTION
## Summary
Adds optional functionality to automatically move tasks to a specified archive folder when archived and back to the default tasks folder when unarchived.

## Features
- **Opt-in behavior**: Disabled by default, users must explicitly enable it
- **Bidirectional moves**: Tasks move to archive folder when archived, back to default tasks folder when unarchived
- **Conflict prevention**: Checks for existing files and prevents overwrites
- **Graceful error handling**: Archive operations continue even if file moves fail
- **Safe folder management**: Automatically creates folders as needed

## Changes
### Settings
- Add `moveArchivedTasks` boolean setting (default: false)
- Add `archiveFolder` string setting (default: 'TaskNotes/Archive')
- Update settings UI with toggle and conditional folder input field

### Core Logic
- Implement file moving logic in `TaskService.toggleArchive()`
- Add conflict detection to prevent file overwrites
- Update cache and event handling for moved file paths
- Support both archiving (→ archive folder) and unarchiving (→ default tasks folder)

### UI/UX
- Settings located in: Settings → Task defaults → Task organization
- Archive folder input only appears when toggle is enabled
- Clear error messages for any move failures

## Test plan
- [ ] Enable "Move archived tasks to folder" setting
- [ ] Configure archive folder path
- [ ] Archive a task and verify it moves to archive folder
- [ ] Unarchive the task and verify it moves back to default tasks folder
- [ ] Test conflict handling by trying to archive when file already exists in destination
- [ ] Verify feature works when disabled (tasks stay in current location)
- [ ] Test with empty/invalid folder paths