### PR TITLE
fix: resolve Outlook calendar 500 errors by using browser-like headers

### DIFF
--- a/src/services/ICSSubscriptionService.ts
+++ b/src/services/ICSSubscriptionService.ts
@@ -152,8 +152,9 @@ export class ICSSubscriptionService extends EventEmitter {
                     url: subscription.url,
                     method: 'GET',
                     headers: {
-                        'Accept': 'text/calendar,application/calendar+xml,text/plain',
-                        'User-Agent': 'TaskNotes-Plugin/1.0'
+                        'Accept': 'text/calendar,*/*;q=0.1',
+                        'Accept-Language': 'en-US,en;q=0.9',
+                        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
                     }
                 });
 
@@ -199,6 +200,8 @@ export class ICSSubscriptionService extends EventEmitter {
             if (subscription.type === 'remote') {
                 if (errorMessage.includes('404')) {
                     new Notice(`Calendar "${subscription.name}" not found (404). Please check the ICS URL is correct and the calendar is publicly accessible.`);
+                } else if (errorMessage.includes('500') || errorMessage.includes('OwaBasicUnsupportedException')) {
+                    new Notice(`Calendar "${subscription.name}" access denied (500). This may be due to Microsoft Outlook server restrictions. Try regenerating the ICS URL from your calendar settings.`);
                 } else {
                     new Notice(`Failed to fetch remote calendar "${subscription.name}": ${errorMessage}`);
                 }


### PR DESCRIPTION
## Summary
- Fixes Microsoft Outlook ICS calendar 500 errors by updating HTTP headers to simulate browser requests
- Improves error handling with specific guidance for Outlook server restrictions
- Resolves issue #458

## Changes Made
- **Updated User-Agent**: Changed from `TaskNotes-Plugin/1.0` to Chrome browser string to bypass Microsoft's automated request filtering
- **Enhanced headers**: Added `Accept-Language` and updated `Accept` headers for better Outlook compatibility
- **Improved error messaging**: Added specific guidance when encountering Outlook 500 errors

## Root Cause
Microsoft Outlook ICS endpoints use server-side filtering that returns HTTP 500 errors (`Microsoft.Exchange.Clients.Owa2.Server.Core.OwaBasicUnsupportedException`) when they detect non-browser User-Agent strings.

## Testing
- ✅ Verified fix works with previously failing Outlook calendar URLs
- ✅ Confirmed existing calendar functionality remains intact
- ✅ Error messages now provide actionable guidance for users

## Test URLs Used
- Working example: `https://outlook.office365.com/owa/calendar/b5ce66c9a9104703bf55ce4b941ef4fc@student.unimelb.edu.au/.../calendar.ics`
- Previously failing (now fixed): `https://outlook.office365.com/owa/calendar/a224d81852684736b79c6d57fed3d368@fusion5.com.au/.../calendar.ics`

Resolves #458