### PR TITLE
Fix #331: Add tags sanitization to prevent duplicate tags with # prefixes

### DIFF
--- a/src/modals/TaskCreationModal.ts
+++ b/src/modals/TaskCreationModal.ts
@@ -4,7 +4,7 @@ import { TaskModal } from './TaskModal';
 import { TaskInfo, TaskCreationData } from '../types';
 import { getCurrentTimestamp } from '../utils/dateUtils';
 import { generateTaskFilename, FilenameContext } from '../utils/filenameGenerator';
-import { calculateDefaultDate } from '../utils/helpers';
+import { calculateDefaultDate, sanitizeTags } from '../utils/helpers';
 import { NaturalLanguageParser, ParsedTaskData as NLParsedTaskData } from '../services/NaturalLanguageParser';
 import { combineDateAndTime } from '../utils/dateUtils';
 
@@ -480,7 +480,7 @@ export class TaskCreationModal extends TaskModal {
         
         if (parsed.contexts && parsed.contexts.length > 0) this.contexts = parsed.contexts.join(', ');
         // Projects will be handled in the form input update section below
-        if (parsed.tags && parsed.tags.length > 0) this.tags = parsed.tags.join(', ');
+        if (parsed.tags && parsed.tags.length > 0) this.tags = sanitizeTags(parsed.tags.join(', '));
         if (parsed.details) this.details = parsed.details;
         if (parsed.recurrence) this.recurrenceRule = parsed.recurrence;
 
@@ -574,7 +574,7 @@ export class TaskCreationModal extends TaskModal {
             this.renderProjectsList();
         }
         if (values.tags !== undefined) {
-            this.tags = values.tags.filter(tag => tag !== this.plugin.settings.taskTag).join(', ');
+            this.tags = sanitizeTags(values.tags.filter(tag => tag !== this.plugin.settings.taskTag).join(', '));
         }
         if (values.timeEstimate !== undefined) this.timeEstimate = values.timeEstimate;
         if (values.recurrence !== undefined && typeof values.recurrence === 'string') {
@@ -630,7 +630,7 @@ export class TaskCreationModal extends TaskModal {
             .map(p => p.trim())
             .filter(p => p.length > 0);
             
-        const tagList = this.tags
+        const tagList = sanitizeTags(this.tags)
             .split(',')
             .map(t => t.trim())
             .filter(t => t.length > 0);

--- a/src/modals/TaskEditModal.ts
+++ b/src/modals/TaskEditModal.ts
@@ -5,7 +5,7 @@ import { TaskInfo } from '../types';
 import { getCurrentTimestamp, formatDateForStorage, generateUTCCalendarDates, getUTCStartOfWeek, getUTCEndOfWeek, getUTCStartOfMonth, getUTCEndOfMonth, getTodayLocal, parseDateAsLocal } from '../utils/dateUtils';
 import { formatTimestampForDisplay } from '../utils/dateUtils';
 import { format } from 'date-fns';
-import { generateRecurringInstances, extractTaskInfo, calculateTotalTimeSpent, formatTime, updateToNextScheduledOccurrence } from '../utils/helpers';
+import { generateRecurringInstances, extractTaskInfo, calculateTotalTimeSpent, formatTime, updateToNextScheduledOccurrence, sanitizeTags } from '../utils/helpers';
 import { ReminderContextMenu } from '../components/ReminderContextMenu';
 
 export interface TaskEditOptions {
@@ -56,7 +56,7 @@ export class TaskEditModal extends TaskModal {
         }
         
         this.tags = this.task.tags 
-            ? this.task.tags.filter(tag => tag !== this.plugin.settings.taskTag).join(', ') 
+            ? sanitizeTags(this.task.tags.filter(tag => tag !== this.plugin.settings.taskTag).join(', '))
             : '';
         this.timeEstimate = this.task.timeEstimate || 0;
         

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -6,6 +6,7 @@ import { StatusContextMenu } from '../components/StatusContextMenu';
 import { RecurrenceContextMenu } from '../components/RecurrenceContextMenu';
 import { ReminderContextMenu } from '../components/ReminderContextMenu';
 import { getDatePart, getTimePart, combineDateAndTime } from '../utils/dateUtils';
+import { sanitizeTags } from '../utils/helpers';
 import { ProjectSelectModal } from './ProjectSelectModal';
 import { TaskInfo, Reminder } from '../types';
 
@@ -265,7 +266,7 @@ export abstract class TaskModal extends Modal {
                 text.setPlaceholder('tag1, tag2')
                     .setValue(this.tags)
                     .onChange(value => {
-                        this.tags = value;
+                        this.tags = sanitizeTags(value);
                     });
                 
                 // Store reference to input element

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1295,3 +1295,23 @@ export function addDTSTARTToRecurrenceRuleWithDraggedTime(task: TaskInfo, dragge
 	}
 }
 
+/**
+ * Sanitizes tag input by removing # prefixes to prevent duplicate tags
+ * Handles both single tags and comma-separated lists
+ */
+export function sanitizeTags(tags: string): string {
+	if (!tags || typeof tags !== 'string') {
+		return '';
+	}
+	
+	return tags
+		.split(',')
+		.map(tag => {
+			const trimmed = tag.trim();
+			// Remove # prefix if it exists
+			return trimmed.startsWith('#') ? trimmed.slice(1) : trimmed;
+		})
+		.filter(tag => tag.length > 0) // Remove empty tags
+		.join(', ');
+}
+


### PR DESCRIPTION
## Summary
Adds automatic sanitization to remove # prefixes from tag input, preventing duplicate tags like `#tag1` and `##tag1`.

## Changes
- Add `sanitizeTags()` utility function to strip # prefixes
- Apply sanitization in task creation, editing, and real-time input
- Handle both single tags and comma-separated lists

Closes #331