### PR TITLE
Add filename template support for calendar event notes

### DIFF
--- a/src/services/ICSNoteService.ts
+++ b/src/services/ICSNoteService.ts
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import TaskNotesPlugin from '../main';
 import { ICSEvent, TaskInfo, NoteInfo, TaskCreationData } from '../types';
 import { getCurrentTimestamp, formatDateForStorage } from '../utils/dateUtils';
-import { generateTaskFilename, generateUniqueFilename, FilenameContext } from '../utils/filenameGenerator';
+import { generateTaskFilename, generateICSNoteFilename, generateUniqueFilename, FilenameContext, ICSFilenameContext } from '../utils/filenameGenerator';
 import { ensureFolderExists } from '../utils/helpers';
 import { processTemplate, ICSTemplateData } from '../utils/templateProcessor';
 
@@ -99,17 +99,20 @@ export class ICSNoteService {
             const folder = overrides?.folder || this.plugin.settings.icsIntegration?.defaultNoteFolder || '';
 
             // Generate filename context for ICS events
-            const filenameContext: FilenameContext = {
+            const filenameContext: ICSFilenameContext = {
                 title: noteTitle,
                 priority: '',
                 status: '',
                 date: new Date(icsEvent.start),
                 dueDate: icsEvent.end,
-                scheduledDate: icsEvent.start
+                scheduledDate: icsEvent.start,
+                icsEventTitle: icsEvent.title,
+                icsEventLocation: icsEvent.location,
+                icsEventDescription: icsEvent.description
             };
 
-            // Generate unique filename
-            const baseFilename = generateTaskFilename(filenameContext, this.plugin.settings);
+            // Generate unique filename using ICS-specific filename generator
+            const baseFilename = generateICSNoteFilename(filenameContext, this.plugin.settings);
             const uniqueFilename = await generateUniqueFilename(baseFilename, folder, this.plugin.app.vault);
             const fullPath = folder ? `${folder}/${uniqueFilename}.md` : `${uniqueFilename}.md`;
 

--- a/src/services/ICSNoteService.ts
+++ b/src/services/ICSNoteService.ts
@@ -99,8 +99,9 @@ export class ICSNoteService {
             const folder = overrides?.folder || this.plugin.settings.icsIntegration?.defaultNoteFolder || '';
 
             // Generate filename context for ICS events
+            // Use clean event title for filename template variables, not the formatted noteTitle
             const filenameContext: ICSFilenameContext = {
-                title: noteTitle,
+                title: icsEvent.title, // Use clean event title for {title} variable
                 priority: '',
                 status: '',
                 date: new Date(icsEvent.start),

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -141,7 +141,9 @@ export const DEFAULT_CALENDAR_VIEW_SETTINGS: CalendarViewSettings = {
 
 export const DEFAULT_ICS_INTEGRATION_SETTINGS: ICSIntegrationSettings = {
 	defaultNoteTemplate: '',
-	defaultNoteFolder: ''
+	defaultNoteFolder: '',
+	icsNoteFilenameFormat: 'title', // Default to using the event title for ICS notes
+	customICSNoteFilenameTemplate: '{title}' // Simple title template for ICS notes
 };
 
 export const DEFAULT_SETTINGS: TaskNotesSettings = {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1340,7 +1340,7 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 		if (this.plugin.settings.icsIntegration?.icsNoteFilenameFormat === 'custom') {
 			new Setting(container)
 				.setName('Custom filename template for ICS notes')
-				.setDesc('Template for custom filename format. Available variables: {title}, {date}, {time}, {timestamp}, {icsEventTitle}, etc.')
+				.setDesc('Template for custom filename format. Available variables: {title} (event title), {icsEventTitleWithDate} (event title + date), {icsEventLocation}, {icsEventDescription}, {date}, {time}, {timestamp}, etc.')
 				.addText(text => {
 					text.inputEl.setAttribute('aria-label', 'Custom ICS note filename template with variables');
 					return text

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1280,7 +1280,9 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 					if (!this.plugin.settings.icsIntegration) {
 						this.plugin.settings.icsIntegration = {
 							defaultNoteTemplate: '',
-							defaultNoteFolder: ''
+							defaultNoteFolder: '',
+							icsNoteFilenameFormat: 'title',
+							customICSNoteFilenameTemplate: '{title}'
 						};
 					}
 					this.plugin.settings.icsIntegration.defaultNoteTemplate = value;
@@ -1297,12 +1299,66 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 					if (!this.plugin.settings.icsIntegration) {
 						this.plugin.settings.icsIntegration = {
 							defaultNoteTemplate: '',
-							defaultNoteFolder: ''
+							defaultNoteFolder: '',
+							icsNoteFilenameFormat: 'title',
+							customICSNoteFilenameTemplate: '{title}'
 						};
 					}
 					this.plugin.settings.icsIntegration.defaultNoteFolder = value;
 					await this.plugin.saveSettings();
 				}));
+
+		// Filename settings for ICS event notes
+		new Setting(container).setName('Filename format for calendar event notes').setHeading();
+		
+		new Setting(container)
+			.setName('Filename format')
+			.setDesc('How to name notes created from calendar events')
+			.addDropdown(dropdown => dropdown
+				.addOptions({
+					'title': 'Event title',
+					'zettel': 'Zettelkasten (YYMMDD + time)',
+					'timestamp': 'Timestamp (YYYY-MM-DD-HHMMSS)', 
+					'custom': 'Custom template'
+				})
+				.setValue(this.plugin.settings.icsIntegration?.icsNoteFilenameFormat || 'title')
+				.onChange(async (value: 'title' | 'zettel' | 'timestamp' | 'custom') => {
+					if (!this.plugin.settings.icsIntegration) {
+						this.plugin.settings.icsIntegration = {
+							defaultNoteTemplate: '',
+							defaultNoteFolder: '',
+							icsNoteFilenameFormat: 'title',
+							customICSNoteFilenameTemplate: '{title}'
+						};
+					}
+					this.plugin.settings.icsIntegration.icsNoteFilenameFormat = value;
+					await this.plugin.saveSettings();
+					this.display();
+				}));
+
+		// Custom template setting (conditional)
+		if (this.plugin.settings.icsIntegration?.icsNoteFilenameFormat === 'custom') {
+			new Setting(container)
+				.setName('Custom filename template for ICS notes')
+				.setDesc('Template for custom filename format. Available variables: {title}, {date}, {time}, {timestamp}, {icsEventTitle}, etc.')
+				.addText(text => {
+					text.inputEl.setAttribute('aria-label', 'Custom ICS note filename template with variables');
+					return text
+						.setValue(this.plugin.settings.icsIntegration?.customICSNoteFilenameTemplate || '{title}')
+						.onChange(async (value) => {
+							if (!this.plugin.settings.icsIntegration) {
+								this.plugin.settings.icsIntegration = {
+									defaultNoteTemplate: '',
+									defaultNoteFolder: '',
+									icsNoteFilenameFormat: 'title',
+									customICSNoteFilenameTemplate: '{title}'
+								};
+							}
+							this.plugin.settings.icsIntegration.customICSNoteFilenameTemplate = value;
+							await this.plugin.saveSettings();
+						});
+				});
+		}
 	}
 
 	private renderNotificationsTab(): void {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -135,6 +135,9 @@ export interface ICSIntegrationSettings {
 	defaultNoteTemplate: string;     // Path to template file for notes created from ICS events
 	// Default folders
 	defaultNoteFolder: string;       // Folder for notes created from ICS events
+	// Filename settings for ICS event notes
+	icsNoteFilenameFormat: 'title' | 'zettel' | 'timestamp' | 'custom';
+	customICSNoteFilenameTemplate: string; // Template for custom format
 }
 
 export interface CalendarViewSettings {

--- a/src/utils/filenameGenerator.ts
+++ b/src/utils/filenameGenerator.ts
@@ -68,7 +68,9 @@ export function generateICSNoteFilename(
                     const icsVariables: Record<string, string> = {
                         icsEventTitle: context.icsEventTitle ? sanitizeForFilename(context.icsEventTitle) : sanitizeForFilename(context.title),
                         icsEventLocation: context.icsEventLocation ? sanitizeForFilename(context.icsEventLocation) : '',
-                        icsEventDescription: context.icsEventDescription ? sanitizeForFilename(context.icsEventDescription.substring(0, 50)) : ''
+                        icsEventDescription: context.icsEventDescription ? sanitizeForFilename(context.icsEventDescription.substring(0, 50)) : '',
+                        // Add formatted title with date for users who want the full context
+                        icsEventTitleWithDate: sanitizeForFilename(`${context.icsEventTitle || context.title} - ${format(now, 'PPP')}`)
                     };
                     return generateCustomFilename(context, icsSettings.customICSNoteFilenameTemplate, now, icsVariables);
                     


### PR DESCRIPTION
## Summary
Adds separate filename template configuration for notes created from calendar events, addressing issue #362.

## Changes
- **New Settings**: Added `icsNoteFilenameFormat` and `customICSNoteFilenameTemplate` to ICS integration settings
- **Template Options**: Support for title, zettel, timestamp, and custom formats
- **ICS Variables**: Added `{icsEventTitle}`, `{icsEventLocation}`, `{icsEventDescription}`, `{icsEventTitleWithDate}`
- **UI**: Added filename format settings in ICS Integration tab
- **Fix**: `{title}` now uses clean event title instead of "Event Name - Date"

## Template Variables
- `{title}` - Clean event title: "Team Meeting"
- `{icsEventTitleWithDate}` - Title with date: "Team Meeting - January 15, 2024"  
- `{icsEventLocation}` - Event location
- `{icsEventDescription}` - Event description
- Plus all standard variables: `{date}`, `{time}`, `{timestamp}`, etc.

## Test plan
- [ ] Create calendar event note with different filename formats
- [ ] Verify `{title}` uses clean event title
- [ ] Test custom templates with ICS-specific variables
- [ ] Ensure backward compatibility with existing settings

Fixes #362