### PR TITLE
feat: Add user field support to task creation/edit modals

### DIFF
--- a/src/modals/TaskCreationModal.ts
+++ b/src/modals/TaskCreationModal.ts
@@ -654,7 +654,9 @@ export class TaskCreationModal extends TaskModal {
             reminders: this.reminders.length > 0 ? this.reminders : undefined,
             creationContext: 'manual-creation', // Mark as manual creation for folder logic
             dateCreated: now,
-            dateModified: now
+            dateModified: now,
+            // Add user fields as custom frontmatter properties
+            customFrontmatter: this.buildCustomFrontmatter()
         };
 
         // Add details if provided
@@ -665,6 +667,19 @@ export class TaskCreationModal extends TaskModal {
         }
 
         return taskData;
+    }
+
+    private buildCustomFrontmatter(): Record<string, any> {
+        const customFrontmatter: Record<string, any> = {};
+        
+        // Add user field values to frontmatter
+        for (const [fieldKey, fieldValue] of Object.entries(this.userFields)) {
+            if (fieldValue !== null && fieldValue !== undefined && fieldValue !== '') {
+                customFrontmatter[fieldKey] = fieldValue;
+            }
+        }
+        
+        return customFrontmatter;
     }
 
     private generateFilename(taskData: TaskCreationData): string {

--- a/src/modals/TaskEditModal.ts
+++ b/src/modals/TaskEditModal.ts
@@ -74,6 +74,39 @@ export class TaskEditModal extends TaskModal {
         
         // Initialize reminders
         this.reminders = this.task.reminders ? [...this.task.reminders] : [];
+
+        // Initialize user fields from frontmatter
+        await this.initializeUserFields();
+    }
+
+    private async initializeUserFields(): Promise<void> {
+        try {
+            // Get the file and read its frontmatter
+            const file = this.app.vault.getAbstractFileByPath(this.task.path);
+            if (!file || !(file instanceof TFile)) {
+                return;
+            }
+
+            const metadata = this.app.metadataCache.getFileCache(file);
+            const frontmatter = metadata?.frontmatter;
+
+            if (!frontmatter) {
+                return;
+            }
+
+            // Load user field values from frontmatter
+            const userFieldConfigs = this.plugin.settings?.userFields || [];
+            for (const field of userFieldConfigs) {
+                if (!field || !field.key) continue;
+
+                const value = frontmatter[field.key];
+                if (value !== undefined) {
+                    this.userFields[field.key] = value;
+                }
+            }
+        } catch (error) {
+            console.error('Error initializing user fields:', error);
+        }
     }
 
     private convertLegacyRecurrenceToString(recurrence: { frequency?: string; days_of_week?: string[]; day_of_month?: number }): string {
@@ -524,6 +557,12 @@ export class TaskEditModal extends TaskModal {
             }
         }
 
+        // Compare user fields and add to changes if modified
+        const userFieldsChanges = this.getUserFieldChanges();
+        if (Object.keys(userFieldsChanges).length > 0) {
+            (changes as any).customFrontmatter = userFieldsChanges;
+        }
+
         // Always update modified timestamp if there are changes
         if (Object.keys(changes).length > 0) {
             changes.dateModified = getCurrentTimestamp();
@@ -532,6 +571,61 @@ export class TaskEditModal extends TaskModal {
         return changes;
     }
 
+    private getUserFieldChanges(): Record<string, any> {
+        const userFieldsChanges: Record<string, any> = {};
+        
+        try {
+            // Get current frontmatter values
+            const file = this.app.vault.getAbstractFileByPath(this.task.path);
+            if (!file || !(file instanceof TFile)) {
+                return userFieldsChanges;
+            }
+
+            const metadata = this.app.metadataCache.getFileCache(file);
+            const frontmatter = metadata?.frontmatter || {};
+
+            // Compare current values with original frontmatter
+            const userFieldConfigs = this.plugin.settings?.userFields || [];
+            for (const field of userFieldConfigs) {
+                if (!field || !field.key) continue;
+
+                const newValue = this.userFields[field.key];
+                const oldValue = frontmatter[field.key];
+
+                // Check if values are different
+                if (this.isDifferent(newValue, oldValue)) {
+                    // Set to null if empty value, otherwise use the new value
+                    userFieldsChanges[field.key] = (newValue === null || newValue === undefined || newValue === '') ? 
+                        null : newValue;
+                }
+            }
+        } catch (error) {
+            console.error('Error comparing user fields:', error);
+        }
+
+        return userFieldsChanges;
+    }
+
+    private isDifferent(newValue: any, oldValue: any): boolean {
+        // Handle null/undefined/empty comparisons
+        const normalizeEmpty = (value: any) => {
+            if (value === null || value === undefined || value === '') {
+                return null;
+            }
+            return value;
+        };
+
+        const normalizedNew = normalizeEmpty(newValue);
+        const normalizedOld = normalizeEmpty(oldValue);
+
+        // For arrays (list fields), compare as JSON strings
+        if (Array.isArray(normalizedNew) || Array.isArray(normalizedOld)) {
+            return JSON.stringify(normalizedNew) !== JSON.stringify(normalizedOld);
+        }
+
+        // For other values, direct comparison
+        return normalizedNew !== normalizedOld;
+    }
 
     private async openTaskNote(): Promise<void> {
         try {

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -26,6 +26,9 @@ export abstract class TaskModal extends Modal {
     protected recurrenceRule = '';
     protected reminders: Reminder[] = [];
     
+    // User-defined fields (dynamic based on settings)
+    protected userFields: Record<string, any> = {};
+    
     // Project link storage
     protected selectedProjectFiles: TAbstractFile[] = [];
     
@@ -285,6 +288,101 @@ export abstract class TaskModal extends Modal {
                         this.timeEstimate = parseInt(value) || 0;
                     });
             });
+
+        // Dynamic user fields
+        this.createUserFields(container);
+    }
+
+    protected createUserFields(container: HTMLElement): void {
+        const userFieldConfigs = this.plugin.settings?.userFields || [];
+        
+        // Add a section separator if there are user fields
+        if (userFieldConfigs.length > 0) {
+            const separator = container.createDiv({ cls: 'user-fields-separator' });
+            separator.createDiv({ text: 'Custom Fields', cls: 'detail-label-section' });
+        }
+
+        for (const field of userFieldConfigs) {
+            if (!field || !field.key || !field.displayName) continue;
+
+            const currentValue = this.userFields[field.key] || '';
+
+            switch (field.type) {
+                case 'boolean':
+                    new Setting(container)
+                        .setName(field.displayName)
+                        .addToggle(toggle => {
+                            toggle.setValue(currentValue === true || currentValue === 'true')
+                                .onChange(value => {
+                                    this.userFields[field.key] = value;
+                                });
+                        });
+                    break;
+
+                case 'number':
+                    new Setting(container)
+                        .setName(field.displayName)
+                        .addText(text => {
+                            text.setPlaceholder('0')
+                                .setValue(currentValue ? String(currentValue) : '')
+                                .onChange(value => {
+                                    const numValue = parseFloat(value);
+                                    this.userFields[field.key] = isNaN(numValue) ? null : numValue;
+                                });
+                        });
+                    break;
+
+                case 'date':
+                    new Setting(container)
+                        .setName(field.displayName)
+                        .addText(text => {
+                            text.setPlaceholder('YYYY-MM-DD')
+                                .setValue(currentValue ? String(currentValue) : '')
+                                .onChange(value => {
+                                    this.userFields[field.key] = value || null;
+                                });
+                        });
+                    break;
+
+                case 'list':
+                    new Setting(container)
+                        .setName(field.displayName)
+                        .addText(text => {
+                            const displayValue = Array.isArray(currentValue) ? 
+                                currentValue.join(', ') : (currentValue ? String(currentValue) : '');
+                            
+                            text.setPlaceholder('item1, item2, item3')
+                                .setValue(displayValue)
+                                .onChange(value => {
+                                    if (!value.trim()) {
+                                        this.userFields[field.key] = null;
+                                    } else {
+                                        this.userFields[field.key] = value.split(',').map(v => v.trim()).filter(v => v);
+                                    }
+                                });
+
+                            // Add autocomplete functionality
+                            new UserFieldSuggest(this.app, text.inputEl, this.plugin, field);
+                        });
+                    break;
+
+                case 'text':
+                default:
+                    new Setting(container)
+                        .setName(field.displayName)
+                        .addText(text => {
+                            text.setPlaceholder(`Enter ${field.displayName.toLowerCase()}...`)
+                                .setValue(currentValue ? String(currentValue) : '')
+                                .onChange(value => {
+                                    this.userFields[field.key] = value || null;
+                                });
+
+                            // Add autocomplete functionality
+                            new UserFieldSuggest(this.app, text.inputEl, this.plugin, field);
+                        });
+                    break;
+            }
+        }
     }
 
 
@@ -899,6 +997,131 @@ class TagSuggest extends AbstractInputSuggest<TagSuggestion> {
         const currentValues = this.input.value.split(',').map((v: string) => v.trim());
         currentValues[currentValues.length - 1] = tagSuggestion.value;
         this.input.value = currentValues.join(', ') + ', ';
+        
+        // Trigger input event to update internal state
+        this.input.dispatchEvent(new Event('input', { bubbles: true }));
+        this.input.focus();
+    }
+}
+
+/**
+ * User field suggestion object
+ */
+interface UserFieldSuggestion {
+    value: string;
+    display: string;
+    type: 'user-field';
+    fieldKey: string;
+    toString(): string;
+}
+
+/**
+ * User field suggestion provider using AbstractInputSuggest
+ */
+class UserFieldSuggest extends AbstractInputSuggest<UserFieldSuggestion> {
+    private plugin: TaskNotesPlugin;
+    private input: HTMLInputElement;
+    private fieldConfig: any; // UserMappedField from settings
+    
+    constructor(app: App, inputEl: HTMLInputElement, plugin: TaskNotesPlugin, fieldConfig: any) {
+        super(app, inputEl);
+        this.plugin = plugin;
+        this.input = inputEl;
+        this.fieldConfig = fieldConfig;
+    }
+    
+    protected async getSuggestions(query: string): Promise<UserFieldSuggestion[]> {
+        // Handle comma-separated values for list fields
+        const isListField = this.fieldConfig.type === 'list';
+        let currentQuery: string;
+        let currentValues: string[] = [];
+
+        if (isListField) {
+            currentValues = this.input.value.split(',').map((v: string) => v.trim());
+            currentQuery = currentValues[currentValues.length - 1];
+        } else {
+            currentQuery = this.input.value.trim();
+        }
+        
+        if (!currentQuery) return [];
+        
+        // Get existing values from all tasks for this user field
+        const existingValues = await this.getExistingUserFieldValues(this.fieldConfig.key);
+        
+        return existingValues
+            .filter(value => value && typeof value === 'string')
+            .filter(value => 
+                value.toLowerCase().includes(currentQuery.toLowerCase()) &&
+                (!isListField || !currentValues.slice(0, -1).includes(value))
+            )
+            .slice(0, 10)
+            .map(value => ({
+                value: value,
+                display: value,
+                type: 'user-field' as const,
+                fieldKey: this.fieldConfig.key,
+                toString() { return this.value; }
+            }));
+    }
+    
+    private async getExistingUserFieldValues(fieldKey: string): Promise<string[]> {
+        try {
+            // Get all tasks and extract unique values for this field
+            const allFiles = this.plugin.app.vault.getMarkdownFiles();
+            const values = new Set<string>();
+            
+            for (const file of allFiles.slice(0, 100)) { // Limit for performance
+                try {
+                    const metadata = this.plugin.app.metadataCache.getFileCache(file);
+                    const frontmatter = metadata?.frontmatter;
+                    
+                    if (frontmatter && frontmatter[fieldKey] !== undefined) {
+                        const value = frontmatter[fieldKey];
+                        
+                        if (Array.isArray(value)) {
+                            // Handle list fields
+                            value.forEach(v => {
+                                if (typeof v === 'string' && v.trim()) {
+                                    values.add(v.trim());
+                                }
+                            });
+                        } else if (typeof value === 'string' && value.trim()) {
+                            values.add(value.trim());
+                        } else if (typeof value === 'number') {
+                            values.add(value.toString());
+                        } else if (typeof value === 'boolean') {
+                            values.add(value.toString());
+                        }
+                    }
+                } catch (error) {
+                    // Skip files with errors
+                    continue;
+                }
+            }
+            
+            return Array.from(values).sort();
+        } catch (error) {
+            console.error('Error getting user field values:', error);
+            return [];
+        }
+    }
+    
+    public renderSuggestion(suggestion: UserFieldSuggestion, el: HTMLElement): void {
+        el.textContent = suggestion.display;
+    }
+    
+    public selectSuggestion(suggestion: UserFieldSuggestion): void {
+        const isListField = this.fieldConfig.type === 'list';
+        
+        if (isListField) {
+            // Handle comma-separated values for list fields
+            const currentValues = this.input.value.split(',').map((v: string) => v.trim());
+            currentValues[currentValues.length - 1] = suggestion.value;
+            this.input.value = currentValues.join(', ') + ', ';
+        } else {
+            // Replace entire value for single-value fields
+            this.input.value = suggestion.value;
+        }
         
         // Trigger input event to update internal state
         this.input.dispatchEvent(new Event('input', { bubbles: true }));

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -226,7 +226,12 @@ export class TaskService {
             
             // Merge template frontmatter with base frontmatter
             // User-defined values take precedence over template frontmatter
-            const finalFrontmatter = mergeTemplateFrontmatter(frontmatter, templateResult.frontmatter);
+            let finalFrontmatter = mergeTemplateFrontmatter(frontmatter, templateResult.frontmatter);
+
+            // Add custom frontmatter properties (including user fields)
+            if (taskData.customFrontmatter) {
+                finalFrontmatter = { ...finalFrontmatter, ...taskData.customFrontmatter };
+            }
             
             // Prepare file content
             const yamlHeader = stringifyYaml(finalFrontmatter);
@@ -914,6 +919,20 @@ export class TaskService {
                         frontmatter[key] = mappedFrontmatter[key];
                     }
                 });
+
+                // Handle custom frontmatter properties (including user fields)
+                if ((updates as any).customFrontmatter) {
+                    Object.keys((updates as any).customFrontmatter).forEach(key => {
+                        const value = (updates as any).customFrontmatter[key];
+                        if (value === null) {
+                            // Remove the property if value is null
+                            delete frontmatter[key];
+                        } else {
+                            // Set the property value
+                            frontmatter[key] = value;
+                        }
+                    });
+                }
 
                 if (updates.hasOwnProperty('due') && updates.due === undefined) delete frontmatter[this.plugin.fieldMapper.toUserField('due')];
                 if (updates.hasOwnProperty('scheduled') && updates.scheduled === undefined) delete frontmatter[this.plugin.fieldMapper.toUserField('scheduled')];

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,6 +245,7 @@ export interface TaskCreationData extends Partial<TaskInfo> {
     details?: string; // Optional details/description for file content
     parentNote?: string; // Optional parent note name/path for template variable
     creationContext?: 'inline-conversion' | 'manual-creation' | 'api' | 'import' | 'ics-event'; // Context for folder determination
+    customFrontmatter?: Record<string, any>; // Custom frontmatter properties (including user fields)
 }
 
 export interface TimeEntry {

--- a/styles/task-modal.css
+++ b/styles/task-modal.css
@@ -29,6 +29,22 @@
     color: var(--color-accent);
 }
 
+/* User fields section styling */
+.user-fields-separator {
+    margin-top: var(--size-4-4);
+    border-top: 1px solid var(--background-modifier-border);
+    padding-top: var(--size-4-3);
+}
+
+.detail-label-section {
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 0.9em;
+    margin-bottom: var(--size-4-2);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
 .modal-header-icon .svg-icon {
     width: 20px !important;
     height: 20px !important;

--- a/tests/unit/modals/TaskModal.user-fields.test.ts
+++ b/tests/unit/modals/TaskModal.user-fields.test.ts
@@ -1,0 +1,99 @@
+describe('TaskModal - User Fields Integration', () => {
+    it('should build custom frontmatter correctly from user fields', () => {
+        const userFields = {
+            'assignee': 'John Doe',
+            'priority_level': 5,
+            'is_completed': true,
+            'custom_tags': ['urgent', 'review'],
+            'empty_field': null,
+            'undefined_field': undefined,
+            'empty_string': ''
+        };
+
+        // Simulate buildCustomFrontmatter logic
+        const customFrontmatter: Record<string, any> = {};
+        for (const [fieldKey, fieldValue] of Object.entries(userFields)) {
+            if (fieldValue !== null && fieldValue !== undefined && fieldValue !== '') {
+                customFrontmatter[fieldKey] = fieldValue;
+            }
+        }
+
+        expect(customFrontmatter).toEqual({
+            'assignee': 'John Doe',
+            'priority_level': 5,
+            'is_completed': true,
+            'custom_tags': ['urgent', 'review']
+        });
+
+        // Verify null/undefined/empty values are excluded
+        expect(customFrontmatter).not.toHaveProperty('empty_field');
+        expect(customFrontmatter).not.toHaveProperty('undefined_field');
+        expect(customFrontmatter).not.toHaveProperty('empty_string');
+    });
+
+    it('should detect user field changes correctly', () => {
+        // Simulate isDifferent logic
+        const isDifferent = (newValue: any, oldValue: any): boolean => {
+            const normalizeEmpty = (value: any) => {
+                if (value === null || value === undefined || value === '') {
+                    return null;
+                }
+                return value;
+            };
+
+            const normalizedNew = normalizeEmpty(newValue);
+            const normalizedOld = normalizeEmpty(oldValue);
+
+            // For arrays (list fields), compare as JSON strings
+            if (Array.isArray(normalizedNew) || Array.isArray(normalizedOld)) {
+                return JSON.stringify(normalizedNew) !== JSON.stringify(normalizedOld);
+            }
+
+            // For other values, direct comparison
+            return normalizedNew !== normalizedOld;
+        };
+
+        // Test different value comparisons
+        expect(isDifferent('new', 'old')).toBe(true);
+        expect(isDifferent('same', 'same')).toBe(false);
+        expect(isDifferent(null, undefined)).toBe(false);
+        expect(isDifferent('', null)).toBe(false);
+        expect(isDifferent(['a', 'b'], ['a', 'b'])).toBe(false);
+        expect(isDifferent(['a', 'b'], ['b', 'a'])).toBe(true);
+        expect(isDifferent(5, '5')).toBe(true);
+        expect(isDifferent(true, 'true')).toBe(true);
+    });
+
+    it('should handle user field value collection for autocomplete', () => {
+        const mockFiles = [
+            { path: 'task1.md' },
+            { path: 'task2.md' },
+            { path: 'task3.md' }
+        ];
+
+        const mockMetadata = {
+            'task1.md': { frontmatter: { assignee: 'John Doe', priority: 5 } },
+            'task2.md': { frontmatter: { assignee: 'Jane Smith', priority: 3 } },
+            'task3.md': { frontmatter: { assignee: 'John Doe', status: 'done' } }
+        };
+
+        // Simulate getExistingUserFieldValues logic
+        const fieldKey = 'assignee';
+        const values = new Set<string>();
+
+        for (const file of mockFiles) {
+            const frontmatter = mockMetadata[file.path as keyof typeof mockMetadata]?.frontmatter;
+            
+            if (frontmatter && frontmatter[fieldKey] !== undefined) {
+                const value = frontmatter[fieldKey];
+                
+                if (typeof value === 'string' && value.trim()) {
+                    values.add(value.trim());
+                }
+            }
+        }
+
+        const result = Array.from(values).sort();
+        expect(result).toEqual(['Jane Smith', 'John Doe']);
+    });
+});


### PR DESCRIPTION
## Summary
- Add user field support to task creation and edit modals
- Store user field values as custom frontmatter properties
- Include autocomplete suggestions from existing field values
- Support text, boolean, number, date, and list field types

## Changes
- Extended TaskModal base class with dynamic user field generation
- Added change detection for edit scenarios
- Implemented UserFieldSuggest for autocomplete functionality
- Added unit tests and CSS styling

## Test Plan
- [x] Create/edit tasks with various user field types
- [x] Test autocomplete and change detection
- [x] Verify frontmatter integration and persistence