### PR TITLE
Fix project consolidation and display

### DIFF
--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -708,37 +708,21 @@ export class FilterService extends EventEmitter {
             
             // Parse the wikilink manually since Obsidian's parseLinktext seems unreliable
             let linkPath = linkContent;
-            let linkAlias = '';
             
             const pipeIndex = linkContent.indexOf('|');
             if (pipeIndex !== -1) {
                 linkPath = linkContent.substring(0, pipeIndex).trim();
-                linkAlias = linkContent.substring(pipeIndex + 1).trim();
-            }
-            
-            // DEBUG: Detailed logging
-            if (typeof window !== 'undefined' && window.console) {
-                console.log(`[DEBUG] Wikilink: "${projectValue}"`);
-                console.log(`[DEBUG] linkContent: "${linkContent}"`);
-                console.log(`[DEBUG] manual parse - path: "${linkPath}", alias: "${linkAlias}"`);
             }
             
             // Always try to resolve using Obsidian's API - this handles relative paths correctly
             const resolvedFile = this.plugin.app.metadataCache.getFirstLinkpathDest(linkPath, '');
             if (resolvedFile) {
-                if (typeof window !== 'undefined' && window.console) {
-                    console.log(`[DEBUG] File resolved: "${resolvedFile.path}"`);
-                }
                 // Return the absolute file path (vault-relative) without .md extension
                 return resolvedFile.path.replace(/\.md$/, '');
             }
             
             // If file doesn't exist, clean up the link path (ignore alias part)
-            const result = linkPath.replace(/\.md$/, '');
-            if (typeof window !== 'undefined' && window.console) {
-                console.log(`[DEBUG] File not found, using linkPath: "${result}"`);
-            }
-            return result;
+            return linkPath.replace(/\.md$/, '');
         }
 
         // Handle pipe syntax like "../projects/Genealogy|Genealogy" - extract path part
@@ -1115,10 +1099,6 @@ export class FilterService extends EventEmitter {
                     // Add task to each project group, using absolute path for consistent grouping
                     for (const project of filteredProjects) {
                         const absolutePath = this.resolveProjectToAbsolutePath(project);
-                        // TODO: Remove this debug logging
-                        if (typeof window !== 'undefined' && window.console) {
-                            console.log(`[Project Grouping] Task "${task.title}": "${project}" → "${absolutePath}"`);
-                        }
                         if (!groups.has(absolutePath)) {
                             groups.set(absolutePath, []);
                         }

--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -1092,6 +1092,10 @@ export class FilterService extends EventEmitter {
                     // Add task to each project group, using absolute path for consistent grouping
                     for (const project of filteredProjects) {
                         const absolutePath = this.resolveProjectToAbsolutePath(project);
+                        // TODO: Remove this debug logging
+                        if (typeof window !== 'undefined' && window.console) {
+                            console.log(`[Project Grouping] Task "${task.title}": "${project}" → "${absolutePath}"`);
+                        }
                         if (!groups.has(absolutePath)) {
                             groups.set(absolutePath, []);
                         }

--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -700,19 +700,24 @@ export class FilterService extends EventEmitter {
 
         // For wikilink format, try to resolve to actual file
         if (projectValue.startsWith('[[') && projectValue.endsWith(']]')) {
-            const linkPath = this.extractWikilinkPath(projectValue);
-            if (linkPath && this.plugin?.app) {
-                const resolvedFile = this.plugin.app.metadataCache.getFirstLinkpathDest(linkPath, '');
+            const linkContent = projectValue.slice(2, -2);
+            const parsed = parseLinktext(linkContent);
+            
+            if (this.plugin?.app) {
+                const resolvedFile = this.plugin.app.metadataCache.getFirstLinkpathDest(parsed.path, '');
                 if (resolvedFile) {
                     // Return the file basename as the canonical name
                     return resolvedFile.basename;
                 }
                 
-                // If file doesn't exist, extract clean name from path
-                const cleanName = this.extractProjectName(projectValue);
-                if (cleanName) {
-                    return cleanName;
+                // If file doesn't exist, use display text if available, otherwise extract from path
+                if (parsed.subpath) {
+                    return parsed.subpath;
                 }
+                
+                // Extract clean name from path
+                const parts = parsed.path.split('/');
+                return parts[parts.length - 1] || parsed.path;
             }
         }
 

--- a/src/ui/TaskCard.ts
+++ b/src/ui/TaskCard.ts
@@ -1227,15 +1227,24 @@ function renderProjectLinks(container: HTMLElement, projects: string[], plugin: 
         container.appendChild(plusText);
         
         if (isWikilinkProject(project)) {
-            // Extract the note name from [[Note Name]]
-            const noteName = project.slice(2, -2);
+            // Parse the wikilink to separate path and display text
+            const linkContent = project.slice(2, -2);
+            let filePath = linkContent;
+            let displayText = linkContent;
             
-            // Create a clickable link
+            // Handle alias syntax: [[path|alias]]
+            if (linkContent.includes('|')) {
+                const parts = linkContent.split('|');
+                filePath = parts[0];
+                displayText = parts[1];
+            }
+            
+            // Create a clickable link showing the display text (alias if available)
             const linkEl = container.createEl('a', {
                 cls: 'task-card__project-link internal-link',
-                text: noteName,
+                text: displayText,
                 attr: { 
-                    'data-href': noteName,
+                    'data-href': filePath,
                     'role': 'button',
                     'tabindex': '0'
                 }
@@ -1248,17 +1257,17 @@ function renderProjectLinks(container: HTMLElement, projects: string[], plugin: 
                 
                 try {
                     // Resolve the link to get the actual file
-                    const file = plugin.app.metadataCache.getFirstLinkpathDest(noteName, '');
+                    const file = plugin.app.metadataCache.getFirstLinkpathDest(filePath, '');
                     if (file instanceof TFile) {
                         // Open the file in the current leaf
                         await plugin.app.workspace.getLeaf(false).openFile(file);
                     } else {
                         // File not found, show notice
-                        new Notice(`Note "${noteName}" not found`);
+                        new Notice(`Note "${displayText}" not found`);
                     }
                 } catch (error) {
                     console.error('Error opening project link:', error);
-                    new Notice(`Failed to open note "${noteName}"`);
+                    new Notice(`Failed to open note "${displayText}"`);
                 }
             });
             
@@ -1272,14 +1281,14 @@ function renderProjectLinks(container: HTMLElement, projects: string[], plugin: 
             
             // Add hover preview for the project link
             linkEl.addEventListener('mouseover', (event) => {
-                const file = plugin.app.metadataCache.getFirstLinkpathDest(noteName, '');
+                const file = plugin.app.metadataCache.getFirstLinkpathDest(filePath, '');
                 if (file instanceof TFile) {
                     plugin.app.workspace.trigger('hover-link', {
                         event,
                         source: 'tasknotes-project-link',
                         hoverParent: container,
                         targetEl: linkEl,
-                        linktext: noteName,
+                        linktext: filePath,
                         sourcePath: file.path
                     });
                 }

--- a/src/utils/GroupingUtils.ts
+++ b/src/utils/GroupingUtils.ts
@@ -40,6 +40,8 @@ export class GroupingUtils {
             case 'No Scheduled Date':
                 return 'No Scheduled Date';
             default:
+                // For project names that may come from consolidation, return as-is
+                // since they should already be cleaned by FilterService.consolidateProjectName
                 return groupName;
         }
     }

--- a/src/views/KanbanView.ts
+++ b/src/views/KanbanView.ts
@@ -951,7 +951,11 @@ export class KanbanView extends ItemView {
             case 'context':
                 return id === 'uncategorized' ? 'Uncategorized' : `@${id}`;
             case 'project':
-                return id === 'No Project' ? 'No Project' : `+${id}`;
+                if (id === 'No Project') {
+                    return 'No Project';
+                }
+                // Clean project display - just show the project name without + prefix or wikilink formatting
+                return id;
             case 'due':
                 return id;
             case 'none':

--- a/src/views/TaskListView.ts
+++ b/src/views/TaskListView.ts
@@ -742,8 +742,23 @@ export class TaskListView extends ItemView {
             return true;
         }
         
-        // Absolute file path (contains slash)
-        return project.includes('/');
+        // File path (contains slash) or could be a resolved file
+        if (project.includes('/')) {
+            return true;
+        }
+        
+        // Check if it's a resolved file path by trying to find the file
+        if (this.plugin?.app) {
+            const file = this.plugin.app.vault.getAbstractFileByPath(project + '.md');
+            if (file instanceof TFile) {
+                return true;
+            }
+            
+            const resolvedFile = this.plugin.app.metadataCache.getFirstLinkpathDest(project, '');
+            return !!resolvedFile;
+        }
+        
+        return false;
     }
 
     /**

--- a/src/views/TaskListView.ts
+++ b/src/views/TaskListView.ts
@@ -537,8 +537,8 @@ export class TaskListView extends ItemView {
                 // Calculate completion stats for this group
                 const groupStats = GroupCountUtils.calculateGroupStats(tasks, this.plugin);
 
-                // Label: project wikilink -> clickable, else plain text span
-                if (groupingKey === 'project' && this.isWikilinkProject(groupName)) {
+                // Label: project path -> clickable, else plain text span
+                if (groupingKey === 'project' && this.isClickableProject(groupName)) {
                     this.createClickableProjectHeader(headerElement, groupName, groupStats);
                 } else {
                     headerElement.createSpan({ text: this.formatGroupName(groupName) });
@@ -734,58 +734,73 @@ export class TaskListView extends ItemView {
     }
 
     /**
-     * Check if a project string is in wikilink format [[Note Name]]
+     * Check if a project string is a file path that should be made clickable
      */
-    private isWikilinkProject(project: string): boolean {
-        return project.startsWith('[[') && project.endsWith(']]');
+    private isClickableProject(project: string): boolean {
+        // Wikilink format
+        if (project.startsWith('[[') && project.endsWith(']]')) {
+            return true;
+        }
+        
+        // Absolute file path (contains slash)
+        return project.includes('/');
     }
 
     /**
-     * Create a clickable project header for wikilink projects
+     * Create a clickable project header for project file paths
      */
     private createClickableProjectHeader(headerElement: HTMLElement, projectName: string, groupStats?: { completed: number; total: number }): void {
-        if (this.isWikilinkProject(projectName)) {
-            // Extract the note name from [[Note Name]]
-            const noteName = projectName.slice(2, -2);
+        let filePath = projectName;
+        let displayName = projectName;
+        
+        // Handle wikilink format
+        if (projectName.startsWith('[[') && projectName.endsWith(']]')) {
+            const linkContent = projectName.slice(2, -2);
+            filePath = linkContent;
+            displayName = linkContent;
+        }
+        
+        // Create a clickable link
+        const linkEl = headerElement.createEl('a', {
+            cls: 'internal-link task-list-view__project-link',
+            text: displayName
+        });
+        
+        // Add click handler to open the file
+        this.registerDomEvent(linkEl, 'click', async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
             
-            // Create a clickable link
-            const linkEl = headerElement.createEl('a', {
-                cls: 'internal-link task-list-view__project-link',
-                text: noteName
-            });
-            
-            // Add click handler to open the note
-            this.registerDomEvent(linkEl, 'click', async (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                
-                // Resolve the link to get the actual file
-                const file = this.plugin.app.metadataCache.getFirstLinkpathDest(noteName, '');
+            try {
+                // First try to get file by direct path
+                const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
                 if (file instanceof TFile) {
-                    // Open the file in the current leaf
                     await this.plugin.app.workspace.getLeaf(false).openFile(file);
-                } else {
-                    // File not found, show notice
-                    new Notice(`Note "${noteName}" not found`);
+                    return;
                 }
-            });
-            
-            // Add hover preview functionality - resolve the file first
-            const file = this.plugin.app.metadataCache.getFirstLinkpathDest(noteName, '');
-            if (file instanceof TFile) {
-                this.addHoverPreview(linkEl, file.path);
+                
+                // If not found, try to resolve using metadata cache
+                const resolvedFile = this.plugin.app.metadataCache.getFirstLinkpathDest(filePath, '');
+                if (resolvedFile) {
+                    await this.plugin.app.workspace.getLeaf(false).openFile(resolvedFile);
+                } else {
+                    new Notice(`Project file not found: ${displayName}`);
+                }
+            } catch (error) {
+                console.error('Error opening project file:', error);
+                new Notice(`Error opening project: ${displayName}`);
             }
+        });
+        
+        // Add hover preview functionality
+        this.addHoverPreview(linkEl, filePath);
 
-            // Add count with agenda-view__item-count styling if stats provided
-            if (groupStats) {
-                headerElement.createSpan({
-                    text: ` ${GroupCountUtils.formatGroupCount(groupStats.completed, groupStats.total).text}`,
-                    cls: 'agenda-view__item-count'
-                });
-            }
-        } else {
-            // Fallback to plain text
-            headerElement.textContent = this.formatGroupName(projectName);
+        // Add count with agenda-view__item-count styling if stats provided
+        if (groupStats) {
+            headerElement.createSpan({
+                text: ` ${GroupCountUtils.formatGroupCount(groupStats.completed, groupStats.total).text}`,
+                cls: 'agenda-view__item-count'
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes project grouping consolidation and display formatting issues.

## Changes
- **Project Consolidation**: Projects with different formats pointing to same file now group together
- **Clean Display**: Group headers show absolute paths without `.md` extensions and are clickable
- **Alias Support**: Task cards show aliases correctly while grouping ignores them
- **Wikilink Parsing**: Fixed bug where `[[path|alias]]` wasn't parsed correctly
- **Drag Behavior**: Preserves original formats and creates proper wikilinks

## Fixes
- Closes #448: Consolidate project references  
- Closes #469: Improve project name display

## Test Cases
- `[[project]]` and `[[project|alias]]` → same group
- `[[../../project|note]]` resolves correctly
- Single-file projects are clickable
- Task cards show `+alias` format