### PR TITLE
fix: Apply comprehensive task creation defaults to REST API endpoints

### DIFF
--- a/src/api/SystemController.ts
+++ b/src/api/SystemController.ts
@@ -137,7 +137,7 @@ export class SystemController extends BaseController {
 			}
 
 			// Apply task creation defaults
-			this.applyTaskCreationDefaults(taskData);
+			await this.applyTaskCreationDefaults(taskData);
 
 			// Create the task
 			const result = await this.taskService.createTask(taskData);
@@ -194,7 +194,7 @@ export class SystemController extends BaseController {
 		}
 	}
 
-	private applyTaskCreationDefaults(taskData: TaskCreationData): void {
+	private async applyTaskCreationDefaults(taskData: TaskCreationData): Promise<void> {
 		const defaults = this.plugin.settings.taskCreationDefaults;
 
 		// Apply default scheduled date if not provided
@@ -220,6 +220,24 @@ export class SystemController extends BaseController {
 		// Apply default time estimate if not provided
 		if (!taskData.timeEstimate && defaults.defaultTimeEstimate > 0) {
 			taskData.timeEstimate = defaults.defaultTimeEstimate;
+		}
+
+		// Apply default tags if not provided
+		if (!taskData.tags && defaults.defaultTags) {
+			taskData.tags = defaults.defaultTags.split(',').map(t => t.trim()).filter(t => t);
+		}
+
+		// Apply default recurrence if not provided
+		if (!taskData.recurrence && defaults.defaultRecurrence && defaults.defaultRecurrence !== 'none') {
+			taskData.recurrence = {
+				frequency: defaults.defaultRecurrence
+			};
+		}
+
+		// Apply default reminders if not provided
+		if (!taskData.reminders && defaults.defaultReminders && defaults.defaultReminders.length > 0) {
+			const { convertDefaultRemindersToReminders } = await import('../utils/settingsUtils');
+			taskData.reminders = convertDefaultRemindersToReminders(defaults.defaultReminders);
 		}
 	}
 

--- a/src/api/TasksController.ts
+++ b/src/api/TasksController.ts
@@ -8,6 +8,7 @@ import { MinimalNativeCache } from '../utils/MinimalNativeCache';
 import { StatusManager } from '../services/StatusManager';
 import TaskNotesPlugin from '../main';
 import { Get, Post, Put, Delete } from '../utils/OpenAPIDecorators';
+import { calculateDefaultDate } from '../utils/helpers';
 
 interface TaskQueryParams {
 	status?: string;
@@ -124,6 +125,9 @@ export class TasksController extends BaseController {
 				this.sendResponse(res, 400, this.errorResponse('Title is required'));
 				return;
 			}
+
+			// Apply task creation defaults
+			await this.applyTaskCreationDefaults(taskData);
 
 			const result = await this.taskService.createTask(taskData);
 			
@@ -378,6 +382,53 @@ export class TasksController extends BaseController {
 			this.sendResponse(res, 200, this.successResponse(stats));
 		} catch (error: any) {
 			this.sendResponse(res, 500, this.errorResponse(error.message));
+		}
+	}
+
+	private async applyTaskCreationDefaults(taskData: TaskCreationData): Promise<void> {
+		const defaults = this.plugin.settings.taskCreationDefaults;
+
+		// Apply default scheduled date if not provided
+		if (!taskData.scheduled && defaults.defaultScheduledDate !== 'none') {
+			taskData.scheduled = calculateDefaultDate(defaults.defaultScheduledDate);
+		}
+
+		// Apply default due date if not provided  
+		if (!taskData.due && defaults.defaultDueDate !== 'none') {
+			taskData.due = calculateDefaultDate(defaults.defaultDueDate);
+		}
+
+		// Apply default contexts if not provided
+		if (!taskData.contexts && defaults.defaultContexts) {
+			taskData.contexts = defaults.defaultContexts.split(',').map(c => c.trim()).filter(c => c);
+		}
+
+		// Apply default projects if not provided
+		if (!taskData.projects && defaults.defaultProjects) {
+			taskData.projects = defaults.defaultProjects.split(',').map(p => p.trim()).filter(p => p);
+		}
+
+		// Apply default time estimate if not provided
+		if (!taskData.timeEstimate && defaults.defaultTimeEstimate > 0) {
+			taskData.timeEstimate = defaults.defaultTimeEstimate;
+		}
+
+		// Apply default tags if not provided
+		if (!taskData.tags && defaults.defaultTags) {
+			taskData.tags = defaults.defaultTags.split(',').map(t => t.trim()).filter(t => t);
+		}
+
+		// Apply default recurrence if not provided
+		if (!taskData.recurrence && defaults.defaultRecurrence && defaults.defaultRecurrence !== 'none') {
+			taskData.recurrence = {
+				frequency: defaults.defaultRecurrence
+			};
+		}
+
+		// Apply default reminders if not provided
+		if (!taskData.reminders && defaults.defaultReminders && defaults.defaultReminders.length > 0) {
+			const { convertDefaultRemindersToReminders } = await import('../utils/settingsUtils');
+			taskData.reminders = convertDefaultRemindersToReminders(defaults.defaultReminders);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes issue where tasks created via the REST API (`POST /api/tasks`) were missing default properties like scheduled dates, tags, reminders, and other configured task creation defaults.

This was affecting browser extension users and other API clients who expected tasks to receive the same defaults as tasks created through the UI or NLP endpoints.

## Root Cause

The `TasksController.createTask()` method was not applying task creation defaults before creating tasks, unlike the NLP endpoint which correctly applied defaults via `applyTaskCreationDefaults()`.

## Changes Made

### TasksController Updates
- ✅ Added `applyTaskCreationDefaults()` method with comprehensive default application
- ✅ Added method call in `createTask()` before task creation
- ✅ Added required import for `calculateDefaultDate` helper

### SystemController Updates  
- ✅ Enhanced existing `applyTaskCreationDefaults()` to include all missing defaults
- ✅ Made method async to handle reminder conversion properly

### Defaults Now Applied
- ✅ **defaultScheduledDate** - Apply configured default scheduled date ('today', 'tomorrow', etc.)
- ✅ **defaultDueDate** - Apply configured default due date  
- ✅ **defaultContexts** - Apply comma-separated default contexts
- ✅ **defaultProjects** - Apply comma-separated default projects
- ✅ **defaultTimeEstimate** - Apply default time estimate in minutes
- ✅ **defaultTags** - Apply comma-separated default tags
- ✅ **defaultRecurrence** - Apply default recurrence pattern (daily/weekly/monthly/yearly)
- ✅ **defaultReminders** - Apply configured default reminder notifications

## Testing

Verified with curl commands that both endpoints now work consistently:

### Before Fix
```json
// POST /api/tasks - Missing scheduled property
{"title": "Test task", "status": "open", "tags": ["task"]}
```

### After Fix
```json
// POST /api/tasks - Now includes all defaults
{
  "title": "Test task", 
  "status": "open",
  "scheduled": "2025-08-25",
  "reminders": [{"id": "rem_...", "type": "relative", "offset": "-PT1M"}],
  "tags": ["task"]
}
```

## Impact

- ✅ **Browser extension** - Tasks now receive expected default scheduling
- ✅ **API consistency** - REST API and NLP API endpoints behave identically  
- ✅ **Explicit values preserved** - User input takes precedence over defaults
- ✅ **No breaking changes** - Only adds missing functionality

## Test Plan

- [x] TypeScript compilation passes
- [x] Build process completes successfully
- [x] Manual testing with curl validates all defaults applied
- [x] Explicit values properly override defaults
- [x] Both API endpoints work consistently