### PR TITLE
fix(#491): align “User fields” column order with “Field mapping”

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1818,7 +1818,7 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 				.setName('User Fields (optional)')
 				.setHeading();
 			container.createEl('p', {
-				text: 'Define one or more custom frontmatter properties to appear as type-aware filter options across views. Each row: Property Name, Display Name, Type.',
+				text: 'Define one or more custom frontmatter properties to appear as type-aware filter options across views. Each row: Display Name, Property Name, Type.',
 				cls: 'settings-help-note'
 			});
 
@@ -1837,8 +1837,8 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 
 			// Column headers
 			const headersRow = container.createDiv('settings-headers-row settings-view__list-headers user-fields');
-			headersRow.createEl('span', { text: 'Property Name', cls: 'settings-column-header settings-view__column-header' });
 			headersRow.createEl('span', { text: 'Display Name', cls: 'settings-column-header settings-view__column-header' });
+			headersRow.createEl('span', { text: 'Property Name', cls: 'settings-column-header settings-view__column-header' });
 			headersRow.createEl('span', { text: 'Type', cls: 'settings-column-header settings-view__column-header' });
 			headersRow.createDiv('settings-header-spacer settings-view__header-spacer'); // For delete button space
 
@@ -1884,18 +1884,6 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 		userFields.forEach((field, index) => {
 			const fieldRow = container.createDiv('settings-item-row settings-view__item-row user-fields');
 
-			// Property Name input
-			const keyInput = fieldRow.createEl('input', {
-				type: 'text',
-				value: field.key || '',
-				cls: 'settings-input key-input settings-view__input settings-view__input--value',
-				attr: {
-					'placeholder': 'effort',
-					'aria-label': `Property name for ${field.displayName || 'user field'}`,
-					'id': `user-field-key-${field.id}`
-				}
-			});
-
 			// Display Name input
 			const nameInput = fieldRow.createEl('input', {
 				type: 'text',
@@ -1905,6 +1893,18 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 					'placeholder': 'Effort',
 					'aria-label': `Display name for ${field.displayName || 'user field'}`,
 					'id': `user-field-name-${field.id}`
+				}
+			});
+
+			// Property Name input
+			const keyInput = fieldRow.createEl('input', {
+				type: 'text',
+				value: field.key || '',
+				cls: 'settings-input key-input settings-view__input settings-view__input--value',
+				attr: {
+					'placeholder': 'effort',
+					'aria-label': `Property name for ${field.displayName || 'user field'}`,
+					'id': `user-field-key-${field.id}`
 				}
 			});
 

--- a/styles/settings-view.css
+++ b/styles/settings-view.css
@@ -274,7 +274,7 @@
 
 /* User fields headers: no drag handle or color indicator columns */
 .tasknotes-plugin .settings-view__list-headers.user-fields {
-    grid-template-columns: 1fr 1fr 160px 80px; /* key | name | type | delete spacer */
+    grid-template-columns: 1fr 1fr 160px 80px; /* name | key | type | delete spacer */
 }
 
 .tasknotes-plugin .settings-view__column-header {
@@ -313,7 +313,7 @@
 
 /* User fields rows: simpler grid with wider inputs */
 .tasknotes-plugin .settings-view__item-row.user-fields {
-    grid-template-columns: 1fr 1fr 160px 80px; /* key | name | type | delete */
+    grid-template-columns: 1fr 1fr 160px 80px; /* name | key | type | delete */
     cursor: default;
 }
 .tasknotes-plugin .settings-view__input.key-input,


### PR DESCRIPTION
- Swap User fields headers and inputs to: Display Name, Property Name, Type
- Update help text and CSS comments to reflect the new order
- No behavior changes; UI consistency only