### PR TITLE
fix: correctly handle project names with commas in wikilinks across modals and settings

### DIFF
--- a/src/modals/TaskCreationModal.ts
+++ b/src/modals/TaskCreationModal.ts
@@ -7,6 +7,7 @@ import { generateTaskFilename, FilenameContext } from '../utils/filenameGenerato
 import { calculateDefaultDate, sanitizeTags } from '../utils/helpers';
 import { NaturalLanguageParser, ParsedTaskData as NLParsedTaskData } from '../services/NaturalLanguageParser';
 import { combineDateAndTime } from '../utils/dateUtils';
+import { splitListPreservingLinksAndQuotes } from '../utils/stringSplit';
 
 export interface TaskCreationOptions {
     prePopulatedValues?: Partial<TaskInfo>;
@@ -532,7 +533,7 @@ export class TaskCreationModal extends TaskModal {
         
         // Apply default projects
         if (defaults.defaultProjects) {
-            const projectStrings = defaults.defaultProjects.split(',').map(p => p.trim()).filter(p => p.length > 0);
+            const projectStrings = splitListPreservingLinksAndQuotes(defaults.defaultProjects);
             if (projectStrings.length > 0) {
                 this.initializeProjectsFromStrings(projectStrings);
             }
@@ -625,10 +626,7 @@ export class TaskCreationModal extends TaskModal {
             .map(c => c.trim())
             .filter(c => c.length > 0);
             
-        const projectList = this.projects
-            .split(',')
-            .map(p => p.trim())
-            .filter(p => p.length > 0);
+        const projectList = splitListPreservingLinksAndQuotes(this.projects);
             
         const tagList = sanitizeTags(this.tags)
             .split(',')

--- a/src/modals/TaskEditModal.ts
+++ b/src/modals/TaskEditModal.ts
@@ -6,6 +6,7 @@ import { getCurrentTimestamp, formatDateForStorage, generateUTCCalendarDates, ge
 import { formatTimestampForDisplay } from '../utils/dateUtils';
 import { format } from 'date-fns';
 import { generateRecurringInstances, extractTaskInfo, calculateTotalTimeSpent, formatTime, updateToNextScheduledOccurrence, sanitizeTags } from '../utils/helpers';
+import { splitListPreservingLinksAndQuotes } from '../utils/stringSplit';
 import { ReminderContextMenu } from '../components/ReminderContextMenu';
 
 export interface TaskEditOptions {
@@ -483,10 +484,7 @@ export class TaskEditModal extends TaskModal {
         }
 
         // Parse and compare projects
-        const newProjects = this.projects
-            .split(',')
-            .map(p => p.trim())
-            .filter(p => p.length > 0);
+        const newProjects = splitListPreservingLinksAndQuotes(this.projects);
         const oldProjects = this.task.projects || [];
         
         if (JSON.stringify(newProjects.sort()) !== JSON.stringify(oldProjects.sort())) {

--- a/src/services/InstantTaskConvertService.ts
+++ b/src/services/InstantTaskConvertService.ts
@@ -8,6 +8,7 @@ import { calculateDefaultDate } from '../utils/helpers';
 import { StatusManager } from './StatusManager';
 import { PriorityManager } from './PriorityManager';
 import { dispatchTaskUpdate } from '../editor/TaskLinkOverlay';
+import { splitListPreservingLinksAndQuotes } from '../utils/stringSplit';
 
 export class InstantTaskConvertService {
     private plugin: TaskNotesPlugin;
@@ -477,7 +478,7 @@ export class InstantTaskConvertService {
         if (this.plugin.settings.useDefaultsOnInstantConvert) {
             const defaults = this.plugin.settings.taskCreationDefaults;
             if (defaults.defaultProjects) {
-                const defaultProjectsArray = defaults.defaultProjects.split(',').map(s => s.trim()).filter(s => s);
+                const defaultProjectsArray = splitListPreservingLinksAndQuotes(defaults.defaultProjects);
                 projectsArray.push(...defaultProjectsArray);
             }
             

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -8,6 +8,7 @@ import { PriorityManager } from '../services/PriorityManager';
 import { showConfirmationModal } from '../modals/ConfirmationModal';
 import { showStorageLocationConfirmationModal } from '../modals/StorageLocationConfirmationModal';
 import { ProjectSelectModal } from '../modals/ProjectSelectModal';
+import { splitListPreservingLinksAndQuotes } from '../utils/stringSplit';
 
 
 
@@ -2941,7 +2942,7 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 			return;
 		}
 
-		const projectStrings = defaultProjects.split(',').map(p => p.trim()).filter(p => p.length > 0);
+		const projectStrings = splitListPreservingLinksAndQuotes(defaultProjects);
 		this.selectedDefaultProjectFiles = [];
 
 		for (const projectString of projectStrings) {

--- a/tests/unit/modals/TaskCreationModal.projects-with-commas.test.ts
+++ b/tests/unit/modals/TaskCreationModal.projects-with-commas.test.ts
@@ -1,0 +1,62 @@
+import { TaskCreationModal } from '../../../src/modals/TaskCreationModal';
+import { MockObsidian } from '../../__mocks__/obsidian';
+import type { App } from 'obsidian';
+
+// @ts-ignore helper to cast the mock app
+const createMockApp = (mockApp: any): App => mockApp as unknown as App;
+
+// Do NOT mock helpers here to keep sanitizeTags available
+jest.mock('obsidian');
+
+describe('TaskCreationModal - projects with commas', () => {
+  let mockApp: App;
+  let mockPlugin: any;
+
+  beforeEach(() => {
+    MockObsidian.reset();
+    mockApp = createMockApp(MockObsidian.createMockApp());
+
+    mockPlugin = {
+      app: mockApp,
+      settings: {
+        taskTag: 'task',
+        enableNaturalLanguageInput: false,
+        defaultTaskPriority: 'normal',
+        defaultTaskStatus: 'open',
+        taskCreationDefaults: {
+          defaultDueDate: 'none',
+          defaultScheduledDate: 'none',
+          defaultContexts: '',
+          defaultTags: '',
+          defaultTimeEstimate: 0,
+          defaultRecurrence: 'none',
+          defaultReminders: []
+        }
+      },
+    };
+  });
+
+  it('should preserve a wikilink project containing commas as a single entry when building task data', () => {
+    const modal = new TaskCreationModal(mockApp, mockPlugin);
+    (modal as any).title = 'Test';
+    ;(modal as any).projects = '[[Money, Org & Adm]]';
+    ;(modal as any).tags = '';
+
+    const data = (modal as any).buildTaskData();
+    expect(data.projects).toEqual(['[[Money, Org & Adm]]']);
+  });
+
+  it('should preserve multiple mixed projects including wikilinks with commas', () => {
+    const modal = new TaskCreationModal(mockApp, mockPlugin);
+    (modal as any).title = 'Test';
+    ;(modal as any).projects = '[[Money, Org & Adm]], [[Wellbeing|Health, Fitness & Mindset]]';
+    ;(modal as any).tags = '';
+
+    const data = (modal as any).buildTaskData();
+    expect(data.projects).toEqual([
+      '[[Money, Org & Adm]]',
+      '[[Wellbeing|Health, Fitness & Mindset]]'
+    ]);
+  });
+});
+

--- a/tests/unit/modals/TaskEditModal.projects-with-commas.test.ts
+++ b/tests/unit/modals/TaskEditModal.projects-with-commas.test.ts
@@ -1,0 +1,55 @@
+import { TaskEditModal } from '../../../src/modals/TaskEditModal';
+import { MockObsidian, Notice } from '../../__mocks__/obsidian';
+import type { App } from 'obsidian';
+import { TaskInfo } from '../../../src/types';
+
+// @ts-ignore helper to cast the mock app
+const createMockApp = (mockApp: any): App => mockApp as unknown as App;
+
+jest.mock('obsidian');
+
+describe('TaskEditModal - projects with commas', () => {
+  let mockApp: App;
+  let mockPlugin: any;
+
+  beforeEach(() => {
+    MockObsidian.reset();
+    mockApp = createMockApp(MockObsidian.createMockApp());
+
+    mockPlugin = {
+      app: mockApp,
+      settings: {
+        taskTag: 'task',
+        enableNaturalLanguageInput: false,
+        defaultTaskPriority: 'normal',
+        defaultTaskStatus: 'open',
+      },
+      taskService: { updateTask: jest.fn(async (_orig: TaskInfo, changes: Partial<TaskInfo>) => ({ ..._orig, ...changes })) },
+      statusManager: { isCompletedStatus: jest.fn((s: string) => s === 'done') },
+      fieldMapper: { toUserField: jest.fn((k: any) => k) }
+    };
+  });
+
+  it('should not split wikilink with commas when computing changes', async () => {
+    const task: TaskInfo = {
+      title: 'T', status: 'open', priority: 'normal', path: 't.md', archived: false,
+      projects: []
+    } as any;
+    const modal = new TaskEditModal(mockApp, mockPlugin, { task });
+
+    // Set fields directly to avoid dependency on metadataCache during init
+    (modal as any).title = task.title;
+    (modal as any).status = task.status;
+    (modal as any).priority = task.priority;
+    (modal as any).projects = '[[Money, Org & Adm]]';
+    (modal as any).contexts = (task as any).contexts || '';
+    (modal as any).tags = (task as any).tags?.join(', ') || '';
+    (modal as any).timeEstimate = (task as any).timeEstimate || 0;
+
+    // Call private getChanges directly
+    const changes = (modal as any).getChanges();
+
+    expect(changes.projects).toEqual(['[[Money, Org & Adm]]']);
+  });
+});
+

--- a/tests/unit/settings/SettingsDefaults.projects-with-commas.test.ts
+++ b/tests/unit/settings/SettingsDefaults.projects-with-commas.test.ts
@@ -1,0 +1,13 @@
+import { splitListPreservingLinksAndQuotes } from '../../../src/utils/stringSplit';
+
+describe('Settings defaults - projects with commas splitting', () => {
+  it('should preserve commas within wikilinks when splitting defaults', () => {
+    const input = '[[Money, Org & Adm]], [[Wellbeing|Health, Fitness & Mindset]]';
+    const out = splitListPreservingLinksAndQuotes(input);
+    expect(out).toEqual([
+      '[[Money, Org & Adm]]',
+      '[[Wellbeing|Health, Fitness & Mindset]]'
+    ]);
+  });
+});
+


### PR DESCRIPTION
Problem: 
Project names containing commas (e.g., [[Money, Org & Adm]]) were split incorrectly, breaking selection/display and frontmatter storage.

**Fix:** 
Replace naive comma-splitting with splitListPreservingLinksAndQuotes for projects in:

- TaskCreationModal
- TaskEditModal
- InstantTaskConvertService (defaults)
- Settings defaults parsing

**Outcome:** 
- Wikilink projects with commas are preserved as a single entry in UI and frontmatter.

**Tests**
- Task creation modal: single project with comma in filename
- Task creation modal: multiple projects including alias with comma
- Task edit modal: computing changes with a project containing comma
- Settings defaults: splitting default projects with commas inside wikilinks