### PR TITLE
fix(css): enable wrapping for inline task overlay title via white-space

### DIFF
--- a/styles/task-inline-widget.css
+++ b/styles/task-inline-widget.css
@@ -15,21 +15,21 @@
     align-items: center;
     gap: 8px;
     white-space: nowrap;
-    
+
     /* Typography - match editor font */
     font-size: var(--editor-font-size, 16px);
     font-family: var(--editor-font-family, var(--font-interface));
-    
+
     /* Visual styling - clean text appearance */
     padding: 2px 4px;
-    
+
     /* Interactivity */
     cursor: pointer;
-    
+
     /* Prevent text selection issues */
     user-select: none;
     -webkit-user-select: none;
-    
+
     /* Ensure proper vertical alignment with text */
     vertical-align: baseline;
     line-height: 1.4;
@@ -305,7 +305,7 @@
 .tasknotes-plugin .task-inline-preview__title {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: break-spaces;
     color: var(--text-normal);
     font-weight: 500;
     margin: 0;


### PR DESCRIPTION
# Problem
Inline tasks overlay wasn't wrapping in small screens and extended the container beyond screen boundaries, forcing hoirixontal scroll.

<img width="407" height="673" alt="image" src="https://github.com/user-attachments/assets/73b4a3b4-8eb2-42e9-8e00-f50435d95670" />

# Solution
Changed style attribute from nowrap to break-spaces
<img width="453" height="676" alt="image" src="https://github.com/user-attachments/assets/f4cb0a5a-8748-42d2-ab19-f621699144e0" />
