### PR TITLE
Fix: Refresh task states when date changes at midnight

### DIFF
--- a/src/editor/ProjectNoteDecorations.ts
+++ b/src/editor/ProjectNoteDecorations.ts
@@ -1,5 +1,5 @@
 import { Decoration, DecorationSet, EditorView, PluginSpec, PluginValue, ViewPlugin, ViewUpdate, WidgetType } from '@codemirror/view';
-import { EVENT_DATA_CHANGED, EVENT_TASK_DELETED, EVENT_TASK_UPDATED, FilterQuery, SUBTASK_WIDGET_VIEW_TYPE, TaskInfo } from '../types';
+import { EVENT_DATA_CHANGED, EVENT_TASK_DELETED, EVENT_TASK_UPDATED, EVENT_DATE_CHANGED, FilterQuery, SUBTASK_WIDGET_VIEW_TYPE, TaskInfo } from '../types';
 import { EventRef, TFile, editorInfoField, editorLivePreviewField, setIcon } from 'obsidian';
 import { Extension, RangeSetBuilder, StateEffect } from '@codemirror/state';
 
@@ -618,6 +618,11 @@ class ProjectNoteDecorationsPlugin implements PluginValue {
         
         const taskDeleteListener = this.plugin.emitter.on(EVENT_TASK_DELETED, () => {
             // Refresh tasks for current file when tasks are deleted
+            this.loadTasksForCurrentFile(this.view);
+        });
+        
+        const dateChangeListener = this.plugin.emitter.on(EVENT_DATE_CHANGED, () => {
+            // Refresh tasks for current file when date changes (for recurring task states)
             this.loadTasksForCurrentFile(this.view);
         });
         

--- a/src/editor/ProjectNoteDecorations.ts
+++ b/src/editor/ProjectNoteDecorations.ts
@@ -652,6 +652,7 @@ class ProjectNoteDecorationsPlugin implements PluginValue {
             dataChangeListener, 
             taskUpdateListener, 
             taskDeleteListener,
+            dateChangeListener,
             settingsChangeListener,
             fileUpdateListener,
             fileDeleteListener,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export const EVENT_POMODORO_TICK = 'pomodoro-tick';
 export const EVENT_TIMEBLOCKING_TOGGLED = 'timeblocking-toggled';
 export const EVENT_TIMEBLOCK_UPDATED = 'timeblock-updated';
 export const EVENT_TIMEBLOCK_DELETED = 'timeblock-deleted';
+export const EVENT_DATE_CHANGED = 'date-changed';
 
 // Calendar colorization modes
 export type ColorizeMode = 'tasks' | 'notes' | 'daily';

--- a/src/views/AdvancedCalendarView.ts
+++ b/src/views/AdvancedCalendarView.ts
@@ -1983,7 +1983,7 @@ export class AdvancedCalendarView extends ItemView {
         this.functionListeners = [];
         
         // Listen for data changes
-        this.plugin.emitter.on(EVENT_DATA_CHANGED, async () => {
+        const dataListener = this.plugin.emitter.on(EVENT_DATA_CHANGED, async () => {
             this.refreshEvents();
             // Update FilterBar options when data changes (new properties, contexts, etc.)
             if (this.filterBar) {
@@ -1991,14 +1991,16 @@ export class AdvancedCalendarView extends ItemView {
                 this.filterBar.updateFilterOptions(updatedFilterOptions);
             }
         });
+        this.listeners.push(dataListener);
         
         // Listen for date changes to refresh recurring task states
-        this.plugin.emitter.on(EVENT_DATE_CHANGED, async () => {
+        const dateChangeListener = this.plugin.emitter.on(EVENT_DATE_CHANGED, async () => {
             this.refreshEvents();
         });
+        this.listeners.push(dateChangeListener);
         
         // Listen for task updates
-        this.plugin.emitter.on(EVENT_TASK_UPDATED, async (eventData: any) => {
+        const taskUpdateListener = this.plugin.emitter.on(EVENT_TASK_UPDATED, async (eventData: any) => {
             this.refreshEvents();
             // Update FilterBar options when tasks are updated (may have new properties, contexts, etc.)
             if (this.filterBar) {
@@ -2006,6 +2008,7 @@ export class AdvancedCalendarView extends ItemView {
                 this.filterBar.updateFilterOptions(updatedFilterOptions);
             }
         });
+        this.listeners.push(taskUpdateListener);
         
         // Listen for filter service data changes
         const filterDataListener = this.plugin.filterService.on('data-changed', () => {
@@ -2022,19 +2025,20 @@ export class AdvancedCalendarView extends ItemView {
         }
         
         // Listen for timeblocking toggle changes
-        this.plugin.emitter.on(EVENT_TIMEBLOCKING_TOGGLED, (enabled: boolean) => {
+        const timeblockingListener = this.plugin.emitter.on(EVENT_TIMEBLOCKING_TOGGLED, (enabled: boolean) => {
             // Update visibility and refresh if timeblocking was enabled
             this.showTimeblocks = enabled && this.plugin.settings.calendarViewSettings.defaultShowTimeblocks;
             this.refreshEvents();
             this.setupViewOptions(); // Re-render view options
         });
+        this.listeners.push(timeblockingListener);
 
         // Listen for settings changes to update today highlight and custom view
-        this.plugin.emitter.on('settings-changed', () => {
+        const settingsListener = this.plugin.emitter.on('settings-changed', () => {
             this.updateTodayHighlight();
             this.updateCustomViewConfiguration();
         });
-        
+        this.listeners.push(settingsListener);
     }
 
     /**
@@ -2083,6 +2087,11 @@ export class AdvancedCalendarView extends ItemView {
         
         // Clean up function listeners
         this.functionListeners.forEach(unsubscribe => unsubscribe());
+        this.functionListeners = [];
+
+        // Clean up event listeners
+        this.listeners.forEach(listener => this.plugin.emitter.offref(listener));
+        this.listeners = [];
         
         // Clean up FilterBar
         if (this.filterBar) {

--- a/src/views/AdvancedCalendarView.ts
+++ b/src/views/AdvancedCalendarView.ts
@@ -20,6 +20,7 @@ import {
     ADVANCED_CALENDAR_VIEW_TYPE,
     EVENT_DATA_CHANGED,
     EVENT_TASK_UPDATED,
+    EVENT_DATE_CHANGED,
     EVENT_TIMEBLOCKING_TOGGLED,
     TaskInfo,
     TimeBlock,
@@ -1989,6 +1990,11 @@ export class AdvancedCalendarView extends ItemView {
                 const updatedFilterOptions = await this.plugin.filterService.getFilterOptions();
                 this.filterBar.updateFilterOptions(updatedFilterOptions);
             }
+        });
+        
+        // Listen for date changes to refresh recurring task states
+        this.plugin.emitter.on(EVENT_DATE_CHANGED, async () => {
+            this.refreshEvents();
         });
         
         // Listen for task updates

--- a/src/views/AgendaView.ts
+++ b/src/views/AgendaView.ts
@@ -1,6 +1,7 @@
 import {
     AGENDA_VIEW_TYPE,
     EVENT_DATA_CHANGED,
+    EVENT_DATE_CHANGED,
     EVENT_DATE_SELECTED,
     EVENT_TASK_UPDATED,
     FilterQuery,
@@ -87,6 +88,12 @@ export class AgendaView extends ItemView {
             }
         });
         this.listeners.push(dataListener);
+        
+        // Listen for date changes to refresh recurring task states
+        const dateChangeListener = this.plugin.emitter.on(EVENT_DATE_CHANGED, async () => {
+            this.refresh();
+        });
+        this.listeners.push(dateChangeListener);
         
         // Listen for date selection changes
         const dateListener = this.plugin.emitter.on(EVENT_DATE_SELECTED, (date: Date) => {

--- a/src/views/TaskListView.ts
+++ b/src/views/TaskListView.ts
@@ -5,6 +5,7 @@ import {
     TaskInfo,
     EVENT_DATA_CHANGED,
     EVENT_TASK_UPDATED,
+    EVENT_DATE_CHANGED,
     FilterQuery,
     SavedView
 } from '../types';
@@ -88,6 +89,12 @@ export class TaskListView extends ItemView {
             }
         });
         this.listeners.push(dataListener);
+        
+        // Listen for date changes to refresh recurring task states
+        const dateChangeListener = this.plugin.emitter.on(EVENT_DATE_CHANGED, async () => {
+            this.refresh();
+        });
+        this.listeners.push(dateChangeListener);
         
         // Listen for individual task updates
         const taskUpdateListener = this.plugin.emitter.on(EVENT_TASK_UPDATED, async ({ path, originalTask, updatedTask }) => {


### PR DESCRIPTION
## Summary
Fixes recurring daily tasks remaining visually completed after midnight when Obsidian is left open 24/7.

## Root Cause
When the date rolls over at midnight, TaskNotes did not refresh task completion states, causing recurring tasks to appear completed for the new day until Obsidian was reloaded.

## Solution
- Add date change detection with dual timing mechanism (interval + precise midnight timeout)
- Emit EVENT_DATE_CHANGED when date rollover is detected
- All task views and inline widgets automatically refresh when date changes
- Proper event listener cleanup to prevent memory leaks

## Impact
- Recurring tasks show correct completion state after midnight
- All date-dependent UI elements refresh automatically
- No user action required - works seamlessly in the background
- Handles edge cases like system sleep/wake

Fixes #521