### PR TITLE
Fix: Improve contrast for INTERRUPTED status badge in pomodoro stats

### DIFF
--- a/styles/pomodoro-stats-view.css
+++ b/styles/pomodoro-stats-view.css
@@ -125,7 +125,7 @@
 }
 
 .tasknotes-plugin .pomodoro-stats-view__overview-change.negative {
-    color: var(--tn-text-error);
+    color: var(--tn-color-error);
 }
 
 /* ================================================
@@ -255,7 +255,7 @@
 }
 
 .tasknotes-plugin .pomodoro-stats-view__session-status--interrupted {
-    background: var(--tn-text-error);
+    background: var(--tn-color-error);
     color: var(--tn-bg-primary);
 }
 


### PR DESCRIPTION
## Summary
- Replace undefined `var(--tn-text-error)` with `var(--tn-color-error)` for better contrast
- Fix background color for interrupted session status badges
- Fix text color for negative overview changes

## Test plan
- [x] Build passes
- [x] CSS changes applied correctly
- [x] Uses consistent error color variable across codebase

Fixes #499