### PR TITLE
Fix title truncation in task creation (#378)

### DIFF
--- a/src/modals/TaskCreationModal.ts
+++ b/src/modals/TaskCreationModal.ts
@@ -598,7 +598,15 @@ export class TaskCreationModal extends TaskModal {
             const taskData = this.buildTaskData();
             const result = await this.plugin.taskService.createTask(taskData);
 
-            new Notice(`Task "${result.taskInfo.title}" created successfully`);
+            // Check if filename was changed due to length constraints
+            const expectedFilename = result.taskInfo.title.replace(/[<>:"/\\|?*]/g, '').trim();
+            const actualFilename = result.file.basename;
+            
+            if (actualFilename.startsWith('task-') && actualFilename !== expectedFilename) {
+                new Notice(`Task "${result.taskInfo.title}" created successfully (filename shortened due to length)`);
+            } else {
+                new Notice(`Task "${result.taskInfo.title}" created successfully`);
+            }
 
             if (this.options.onTaskCreated) {
                 this.options.onTaskCreated(result.taskInfo);

--- a/src/services/InstantTaskConvertService.ts
+++ b/src/services/InstantTaskConvertService.ts
@@ -221,7 +221,15 @@ export class InstantTaskConvertService {
                 return;
             }
             
-            new Notice(`Task converted: ${parsedData.title}`);
+            // Check if filename was changed due to length constraints
+            const expectedFilename = this.sanitizeTitle(parsedData.title);
+            const actualFilename = file.basename;
+            
+            if (actualFilename.startsWith('task-') && actualFilename !== expectedFilename) {
+                new Notice(`Task converted: "${parsedData.title}" (filename shortened due to length)`);
+            } else {
+                new Notice(`Task converted: ${parsedData.title}`);
+            }
             
             // Trigger immediate refresh of task link overlays to show the inline widget
             await this.refreshTaskLinkOverlays(editor, file);
@@ -315,9 +323,6 @@ export class InstantTaskConvertService {
             return { isValid: false, error: 'Task title cannot be empty.' };
         }
 
-        if (parsedData.title.length > 200) {
-            return { isValid: false, error: 'Task title is too long (max 200 characters).' };
-        }
 
         // Validate against dangerous characters for file operations
         const basicDangerousChars = /[<>:"/\\|?*]/;

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -107,9 +107,6 @@ export class TaskService {
                 throw new Error('Title is required');
             }
 
-            if (taskData.title.length > 200) {
-                throw new Error('Title is too long (max 200 characters)');
-            }
 
             // Apply defaults for missing fields
             const title = taskData.title.trim();

--- a/src/utils/TasksPluginParser.ts
+++ b/src/utils/TasksPluginParser.ts
@@ -165,9 +165,6 @@ export class TasksPluginParser {
 				throw new Error('Title cannot be empty after parsing');
 			}
 			
-			if (title.length > 200) {
-				throw new Error('Title too long (max 200 characters)');
-			}
 
 			// Determine status based on completion and done date
 			let status: string | undefined = undefined;

--- a/src/utils/filenameGenerator.ts
+++ b/src/utils/filenameGenerator.ts
@@ -38,9 +38,6 @@ export function generateICSNoteFilename(
         throw new Error('Title cannot be empty');
     }
     
-    if (context.title.length > 200) {
-        throw new Error('Title too long for filename generation');
-    }
     
     const now = context.date || new Date();
     
@@ -110,9 +107,6 @@ export function generateTaskFilename(
         throw new Error('Title cannot be empty');
     }
     
-    if (context.title.length > 200) {
-        throw new Error('Title too long for filename generation');
-    }
     
     const now = context.date || new Date();
     
@@ -321,8 +315,6 @@ function sanitizeForFilename(input: string): string {
             })
             // Remove leading/trailing dots
             .replace(/^\.+|\.+$/g, '')
-            // Limit length to reasonable size (100 chars leaves room for extensions)
-            .substring(0, 100)
             // Final trim in case we removed characters at the edges
             .trim();
         


### PR DESCRIPTION
## Summary
Removes artificial length limits that were truncating task titles during creation.

## Changes
- Remove 100-character truncation in filename sanitization
- Remove 200-character validation limits across task creation flows
- Add user notification when filename shortening occurs due to filesystem constraints

## Fix
Tasks with long titles like "This is a very long title. If I use too many characters for it, part of the title will be cut off. This should not be the case." are now preserved in full.

Closes #378