### PR TITLE
feat: add tags to sorting and grouping options (#169)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,8 +31,8 @@ export type ColorizeMode = 'tasks' | 'notes' | 'daily';
 export type CalendarDisplayMode = 'month' | 'agenda';
 
 // Task sorting and grouping types
-export type TaskSortKey = 'due' | 'scheduled' | 'priority' | 'title' | 'dateCreated' | `user:${string}`;
-export type TaskGroupKey = 'none' | 'priority' | 'context' | 'project' | 'due' | 'scheduled' | 'status' | `user:${string}`;
+export type TaskSortKey = 'due' | 'scheduled' | 'priority' | 'title' | 'dateCreated' | 'tags' | `user:${string}`;
+export type TaskGroupKey = 'none' | 'priority' | 'context' | 'project' | 'due' | 'scheduled' | 'status' | 'tags' | `user:${string}`;
 export type SortDirection = 'asc' | 'desc';
 
 

--- a/src/ui/FilterBar.ts
+++ b/src/ui/FilterBar.ts
@@ -1284,7 +1284,8 @@ export class FilterBar extends EventEmitter {
             'scheduled': 'Scheduled Date',
             'priority': 'Priority',
             'title': 'Title',
-            'dateCreated': 'Created Date'
+            'dateCreated': 'Created Date',
+            'tags': 'Tags'
         };
         const sortOptions: Record<string, string> = { ...builtInSortOptions };
         const sortUserProps = this.filterOptions.userProperties || [];
@@ -1316,7 +1317,8 @@ export class FilterBar extends EventEmitter {
             'context': 'Context',
             'project': 'Project',
             'due': 'Due Date',
-            'scheduled': 'Scheduled Date'
+            'scheduled': 'Scheduled Date',
+            'tags': 'Tags'
         };
 
         const options: Record<string, string> = { ...builtInGroupOptions };


### PR DESCRIPTION
## Summary
- Adds tags to the sort dropdown for alphabetical sorting by first tag
- Adds tags to the group dropdown with multi-group assignment support
- Tasks with multiple tags appear in multiple groups (like projects)
- Tasks without tags sort last and appear in "No Tags" group

## Test plan
- [ ] Verify "Tags" option appears in sort dropdown
- [ ] Verify "Tags" option appears in group dropdown  
- [ ] Test sorting by tags works alphabetically
- [ ] Test grouping by tags creates separate groups for each tag
- [ ] Verify tasks with multiple tags appear in multiple groups
- [ ] Verify tasks without tags appear in "No Tags" group

Closes #169