### PR TITLE
Add All-day slot toggle to calendar view

### DIFF
--- a/docs/views/calendar-views.md
+++ b/docs/views/calendar-views.md
@@ -84,6 +84,9 @@ The Advanced Calendar provides several display options that control what types o
 - **Show recurring**: Display recurring task events
 - **Show ICS events**: Display events from imported ICS calendars
 - **Show time entries**: Display time tracking entries
+- **All-day slot**: Show or hide the all-day event area at the top of time grid views (Week, Day, and Custom views)
+
+The **All-day slot** option is particularly useful when you have many all-day tasks on a single date, as hiding it can resolve scrolling issues and make the hourly time slots more accessible. When disabled, all-day events will not be displayed in time grid views, but they will still appear in month view.
 
 These display options are preserved when you save a view, allowing you to create specialized calendar views that show only specific types of events and maintain those preferences across sessions.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -478,6 +478,7 @@ export interface CalendarViewPreferences {
 	showICSEvents: boolean;
 	showTimeblocks?: boolean;
 	headerCollapsed?: boolean;
+	showAllDaySlot?: boolean;
 }
 
 // All view-specific preferences

--- a/src/views/AdvancedCalendarView.ts
+++ b/src/views/AdvancedCalendarView.ts
@@ -102,6 +102,7 @@ export class AdvancedCalendarView extends ItemView {
     private showRecurring: boolean;
     private showICSEvents: boolean;
     private showTimeblocks: boolean;
+    private showAllDaySlot: boolean;
     
     // Mobile collapsible header state
     private headerCollapsed = true;
@@ -117,6 +118,7 @@ export class AdvancedCalendarView extends ItemView {
         this.showRecurring = this.plugin.settings.calendarViewSettings.defaultShowRecurring;
         this.showICSEvents = this.plugin.settings.calendarViewSettings.defaultShowICSEvents;
         this.showTimeblocks = this.plugin.settings.calendarViewSettings.defaultShowTimeblocks;
+        this.showAllDaySlot = true; // Default to true to match FullCalendar's default
         
         // Initialize with default query - will be properly set when plugin services are ready
         this.currentQuery = {
@@ -166,6 +168,7 @@ export class AdvancedCalendarView extends ItemView {
             this.showICSEvents = savedPreferences.showICSEvents ?? this.plugin.settings.calendarViewSettings.defaultShowICSEvents;
             this.showTimeblocks = savedPreferences.showTimeblocks ?? this.plugin.settings.calendarViewSettings.defaultShowTimeblocks;
             this.headerCollapsed = savedPreferences.headerCollapsed ?? true;
+            this.showAllDaySlot = savedPreferences.showAllDaySlot ?? true;
         }
 
         // Ensure initialization
@@ -353,6 +356,18 @@ export class AdvancedCalendarView extends ItemView {
                     this.saveViewPreferences();
                     this.refreshEvents();
                 }
+            },
+            {
+                id: 'allDaySlot',
+                label: 'All-day slot',
+                value: this.showAllDaySlot,
+                onChange: (value: boolean) => {
+                    this.showAllDaySlot = value;
+                    this.saveViewPreferences();
+                    if (this.calendar) {
+                        this.calendar.setOption('allDaySlot', value);
+                    }
+                }
             }
         ];
         
@@ -408,6 +423,12 @@ export class AdvancedCalendarView extends ItemView {
                 break;
             case 'timeblocks':
                 this.showTimeblocks = enabled;
+                break;
+            case 'allDaySlot':
+                this.showAllDaySlot = enabled;
+                if (this.calendar) {
+                    this.calendar.setOption('allDaySlot', enabled);
+                }
                 break;
         }
         
@@ -574,6 +595,7 @@ export class AdvancedCalendarView extends ItemView {
             // Time grid configurations
             slotDuration: calendarSettings.slotDuration,
             slotLabelInterval: this.getSlotLabelInterval(calendarSettings.slotDuration),
+            allDaySlot: this.showAllDaySlot,
             
             // Time format
             eventTimeFormat: this.getTimeFormat(calendarSettings.timeFormat),
@@ -616,7 +638,8 @@ export class AdvancedCalendarView extends ItemView {
             showRecurring: this.showRecurring,
             showICSEvents: this.showICSEvents,
             showTimeblocks: this.showTimeblocks,
-            headerCollapsed: this.headerCollapsed
+            headerCollapsed: this.headerCollapsed,
+            showAllDaySlot: this.showAllDaySlot
         };
         this.plugin.viewStateManager.setViewPreferences(ADVANCED_CALENDAR_VIEW_TYPE, preferences);
     }
@@ -643,6 +666,12 @@ export class AdvancedCalendarView extends ItemView {
         }
         if (viewOptions.hasOwnProperty('showTimeblocks')) {
             this.showTimeblocks = viewOptions.showTimeblocks;
+        }
+        if (viewOptions.hasOwnProperty('showAllDaySlot')) {
+            this.showAllDaySlot = viewOptions.showAllDaySlot;
+            if (this.calendar) {
+                this.calendar.setOption('allDaySlot', this.showAllDaySlot);
+            }
         }
 
         // Update the view options in the FilterBar to reflect the loaded state


### PR DESCRIPTION
## Summary
- Adds toggle to show/hide the all-day slot in calendar time grid views
- Resolves scrolling issues when many all-day tasks exist on a single date
- Toggle appears in view options alongside other display controls

## Test plan
- [ ] Toggle appears in calendar view filter bar
- [ ] Disabling toggle hides all-day slot in Week/Day/Custom views
- [ ] All-day events still appear in Month view when toggle disabled
- [ ] Setting persists across sessions
- [ ] Setting works with saved views