### PR TITLE
Fix: Add NLP project support for inline task conversion

### DIFF
--- a/docs/features/inline-tasks.md
+++ b/docs/features/inline-tasks.md
@@ -166,6 +166,7 @@ TaskNotes includes a **Natural Language Processor (NLP)** that parses task descr
 The NLP engine supports syntax for:
 
 -   **Tags and Contexts**: `#tag` and `@context` syntax.
+-   **Projects**: `+project` for simple projects or `+[[Project Name]]` for projects with spaces.
 -   **Priority Levels**: Keywords like "high," "normal," and "low".
 -   **Status Assignment**: Keywords like "open," "in-progress," and "done".
 -   **Dates and Times**: Phrases like "tomorrow," "next Friday," and "January 15th at 3pm".

--- a/src/services/NaturalLanguageParser.ts
+++ b/src/services/NaturalLanguageParser.ts
@@ -137,17 +137,22 @@ export class NaturalLanguageParser {
         let workingText = text;
         
         // Extract +[[wikilink]] patterns first (more specific)
-        const wikilinkProjectMatches = workingText.match(/\+\[\[[^\]]+\]\]/g);
+        const wikilinkProjectMatches = workingText.match(/\+\[\[.*?\]\]/g);
         if (wikilinkProjectMatches) {
-            result.projects.push(...wikilinkProjectMatches.map(project => project.slice(3, -2))); // Remove +[[ and ]]
-            workingText = this.cleanupWhitespace(workingText.replace(/\+\[\[[^\]]+\]\]/g, ''));
+            result.projects.push(...wikilinkProjectMatches.map(project => {
+                // Remove the + prefix but keep [[ ]]
+                let projectName = project.slice(1); // Remove just the +
+                // Keep the full wikilink as-is for now - resolution will happen in InstantTaskConvertService
+                return projectName;
+            }));
+            workingText = this.cleanupWhitespace(workingText.replace(/\+\[\[.*?\]\]/g, ''));
         }
         
         // Extract +project patterns (simple word projects)
-        const projectMatches = workingText.match(/\+[\w/]+/g);
+        const projectMatches = workingText.match(/\+[\w/-]+/g);
         if (projectMatches) {
             result.projects.push(...projectMatches.map(project => project.substring(1)));
-            workingText = this.cleanupWhitespace(workingText.replace(/\+[\w/]+/g, ''));
+            workingText = this.cleanupWhitespace(workingText.replace(/\+[\w/-]+/g, ''));
         }
         
         return workingText;

--- a/tests/unit/services/NaturalLanguageParser.test.ts
+++ b/tests/unit/services/NaturalLanguageParser.test.ts
@@ -155,6 +155,67 @@ describe('NaturalLanguageParser', () => {
     });
   });
 
+  describe('Projects Extraction', () => {
+    it('should extract simple +project syntax', () => {
+      const result = parser.parseInput('Complete task +project @work');
+
+      expect(result.projects).toEqual(['project']);
+      expect(result.contexts).toEqual(['work']);
+      expect(result.title).toBe('Complete task');
+    });
+
+    it('should extract multiple projects', () => {
+      const result = parser.parseInput('Task +project1 +project2 planning');
+
+      expect(result.projects).toEqual(['project1', 'project2']);
+      expect(result.title).toBe('Task planning');
+    });
+
+    it('should extract +[[wikilink]] project syntax', () => {
+      const result = parser.parseInput('Meeting +[[Project Name With Spaces]]');
+
+      expect(result.projects).toEqual(['[[Project Name With Spaces]]']);
+      expect(result.title).toBe('Meeting');
+    });
+
+    it('should extract mixed simple and wikilink projects', () => {
+      const result = parser.parseInput('Review +simple-project +[[Complex Project Name]]');
+      
+      expect(result.projects).toEqual(['[[Complex Project Name]]', 'simple-project']);
+      expect(result.title).toBe('Review');
+    });
+
+    it('should handle projects with forward slashes', () => {
+      const result = parser.parseInput('Update +project/subproject documentation');
+
+      expect(result.projects).toEqual(['project/subproject']);
+      expect(result.title).toBe('Update documentation');
+    });
+
+    it('should remove duplicate projects', () => {
+      const result = parser.parseInput('Task +project +project progress');
+
+      expect(result.projects).toEqual(['project']);
+      expect(result.title).toBe('Task progress');
+    });
+
+    it('should handle projects alongside tags and contexts', () => {
+      const result = parser.parseInput('Complete #urgent @work +quarterly-review task');
+
+      expect(result.projects).toEqual(['quarterly-review']);
+      expect(result.tags).toEqual(['urgent']);
+      expect(result.contexts).toEqual(['work']);
+      expect(result.title).toBe('Complete task');
+    });
+
+    it('should handle wikilink projects with paths and pipe syntax', () => {
+      const result = parser.parseInput('this is a test +[[../../Untitled 9|Untitled 9]]');
+
+      expect(result.projects).toEqual(['[[../../Untitled 9|Untitled 9]]']);
+      expect(result.title).toBe('this is a test');
+    });
+  });
+
   describe('Priority Extraction', () => {
     it('should extract configured priority values', () => {
       const result = parser.parseInput('urgent task needs completion');
@@ -620,6 +681,7 @@ describe('NaturalLanguageParser', () => {
         dueTime: '14:30',
         tags: ['documentation'],
         contexts: ['work'],
+        projects: [],
         estimate: 120,
         recurrence: 'FREQ=DAILY'
       };
@@ -641,7 +703,8 @@ describe('NaturalLanguageParser', () => {
         title: 'Simple Task',
         priority: 'normal',
         tags: ['test'],
-        contexts: []
+        contexts: [],
+        projects: []
       };
 
       const preview = parser.getPreviewText(parsedData);
@@ -657,7 +720,8 @@ describe('NaturalLanguageParser', () => {
         title: 'Task with long details',
         details: longDetails,
         tags: [],
-        contexts: []
+        contexts: [],
+        projects: []
       };
 
       const preview = parser.getPreviewData(parsedData);
@@ -672,7 +736,8 @@ describe('NaturalLanguageParser', () => {
         title: 'Task',
         recurrence: 'INVALID_RRULE',
         tags: [],
-        contexts: []
+        contexts: [],
+        projects: []
       };
 
       const preview = parser.getPreviewData(parsedData);
@@ -702,7 +767,8 @@ describe('NaturalLanguageParser', () => {
         title: 'Task',
         recurrence: 'FREQ=DAILY',
         tags: [],
-        contexts: []
+        contexts: [],
+        projects: []
       };
 
       // Mock RRule.fromString to throw


### PR DESCRIPTION
## Summary

Adds Natural Language Processing support for projects in inline task conversion, resolving issue #476.

## Changes

- **Fixed project extraction regex**: Updated `/\+[\w/]+/g` to `/\+[\w/-]+/g` to support projects with hyphens (e.g., `+quarterly-review`)
- **Enhanced wikilink parsing**: Added support for complex wikilink syntax including relative paths and pipe syntax (e.g., `+[[../../Project|Display Name]]`)
- **Integrated link resolution**: Uses `metadataCache.fileToLinktext()` to generate proper relative links consistent with TaskModal behavior
- **Added comprehensive tests**: Full test coverage for all project syntax variations
- **Added error handling**: Graceful fallback for test environments and edge cases

## Supported syntax

- Simple projects: `+project`, `+quarterly-review`
- Nested projects: `+project/subproject` 
- Wikilink projects: `+[[Project Name]]`
- Complex wikilinks: `+[[../../Project|Display]]`
- Mixed usage: `Complete +simple +[[Complex Project]] @context #tag`

## Test plan

- [x] All existing tests pass
- [x] New project extraction tests pass
- [x] InstantTaskConvertService tests pass with error handling
- [x] TypeScript compilation succeeds

Closes #476