### PR TITLE
Move Due Date when recurring task completed

### DIFF
--- a/src/modals/TaskEditModal.ts
+++ b/src/modals/TaskEditModal.ts
@@ -548,9 +548,12 @@ export class TaskEditModal extends TaskModal {
             // If task has recurrence, update scheduled date to next uncompleted occurrence
             if (this.task.recurrence) {
                 const tempTask: TaskInfo = { ...this.task, ...changes };
-                const nextScheduledDate = updateToNextScheduledOccurrence(tempTask);
-                if (nextScheduledDate) {
-                    changes.scheduled = nextScheduledDate;
+                const nextDates = updateToNextScheduledOccurrence(tempTask);
+                if (nextDates.scheduled) {
+                    changes.scheduled = nextDates.scheduled;
+                }
+                if (nextDates.due) {
+                    changes.due = nextDates.due;
                 }
             }
         }


### PR DESCRIPTION
Moves due date when recurring task completed  by the same offset as the original due date is to the original scheduled date to keep same separation

Fixes #470 