### PR TITLE
Feat/clean bases integration on top of 3.22.1 + All Bases Test Passing + No Console Errors + Advanced Data Logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tasknotes",
-	"version": "3.21.0",
+	"version": "3.22.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tasknotes",
-			"version": "3.21.0",
+			"version": "3.22.1",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/view": "^6.37.2",
@@ -36,6 +36,7 @@
 				"jest": "^30.1.1",
 				"jest-environment-jsdom": "^30.1.1",
 				"obsidian": "latest",
+				"obsidian-typings": "^4.49.0",
 				"ts-jest": "^29.1.1",
 				"tslib": "^2.8.1",
 				"typescript": "^5.9.2"
@@ -53,6 +54,30 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@antfu/install-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+			"integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"package-manager-detector": "^1.3.0",
+				"tinyexec": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/@antfu/utils": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-9.2.0.tgz",
+			"integrity": "sha512-Oq1d9BGZakE/FyoEtcNeSwM7MpDO2vUBi11RWBZXf75zPsbUVWmUs03EqkRFrcgbXyKTas0BdZWC1wcuSoqSAw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -527,6 +552,16 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/runtime": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+			"integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/template": {
 			"version": "7.27.2",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -591,6 +626,94 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@braintree/sanitize-url": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz",
+			"integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@capacitor/core": {
+			"version": "5.7.8",
+			"resolved": "https://registry.npmjs.org/@capacitor/core/-/core-5.7.8.tgz",
+			"integrity": "sha512-rrZcm/2vJM0WdWRQup1TUidbjQV9PfIadSkV4rAGLD7R6PuzZSMPGT0gmoZzCRlXkqrazrWWDkurei3ozU02FA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@chevrotain/cst-dts-gen": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+			"integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/gast": "11.0.3",
+				"@chevrotain/types": "11.0.3",
+				"lodash-es": "4.17.21"
+			}
+		},
+		"node_modules/@chevrotain/gast": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+			"integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/types": "11.0.3",
+				"lodash-es": "4.17.21"
+			}
+		},
+		"node_modules/@chevrotain/regexp-to-ast": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+			"integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@chevrotain/types": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+			"integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@chevrotain/utils": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+			"integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@codemirror/language": {
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
+			"integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.23.0",
+				"@lezer/common": "^1.1.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"node_modules/@codemirror/search": {
+			"version": "6.5.11",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"crelt": "^1.0.5"
+			}
 		},
 		"node_modules/@codemirror/state": {
 			"version": "6.5.2",
@@ -726,6 +849,38 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@electron/get": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -1371,6 +1526,53 @@
 			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@iconify/types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@iconify/utils": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.3.0.tgz",
+			"integrity": "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@antfu/install-pkg": "^1.0.0",
+				"@antfu/utils": "^8.1.0",
+				"@iconify/types": "^2.0.0",
+				"debug": "^4.4.0",
+				"globals": "^15.14.0",
+				"kolorist": "^1.8.0",
+				"local-pkg": "^1.0.0",
+				"mlly": "^1.7.4"
+			}
+		},
+		"node_modules/@iconify/utils/node_modules/@antfu/utils": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-8.1.1.tgz",
+			"integrity": "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/@iconify/utils/node_modules/globals": {
+			"version": "15.15.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+			"integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -2062,11 +2264,48 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@lezer/common": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+			"integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@lezer/highlight": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+			"integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
 		"node_modules/@marijn/find-cluster-break": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"license": "MIT"
+		},
+		"node_modules/@mermaid-js/parser": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.3.0.tgz",
+			"integrity": "sha512-HsvL6zgE5sUPGgkIDlmAWR1HTNHz2Iy11BAWPTa4Jjabkpguy4Ze2gzfLrg6pdRuBvFwgUYyxiaNqZwrEEXepA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"langium": "3.0.0"
+			}
 		},
 		"node_modules/@microsoft/eslint-plugin-sdl": {
 			"version": "0.2.2",
@@ -2104,6 +2343,202 @@
 			"license": "MIT",
 			"dependencies": {
 				"ret": "~0.1.10"
+			}
+		},
+		"node_modules/@napi-rs/canvas": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.78.tgz",
+			"integrity": "sha512-YaBHJvT+T1DoP16puvWM6w46Lq3VhwKIJ8th5m1iEJyGh7mibk5dT7flBvMQ1EH1LYmMzXJ+OUhu+8wQ9I6u7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"workspaces": [
+				"e2e/*"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas-android-arm64": "0.1.78",
+				"@napi-rs/canvas-darwin-arm64": "0.1.78",
+				"@napi-rs/canvas-darwin-x64": "0.1.78",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.78",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.78",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.78",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.78",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.78",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.78",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.78"
+			}
+		},
+		"node_modules/@napi-rs/canvas-android-arm64": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.78.tgz",
+			"integrity": "sha512-N1ikxztjrRmh8xxlG5kYm1RuNr8ZW1EINEDQsLhhuy7t0pWI/e7SH91uFVLZKCMDyjel1tyWV93b5fdCAi7ggw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-arm64": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.78.tgz",
+			"integrity": "sha512-FA3aCU3G5yGc74BSmnLJTObnZRV+HW+JBTrsU+0WVVaNyVKlb5nMvYAQuieQlRVemsAA2ek2c6nYtHh6u6bwFw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-x64": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.78.tgz",
+			"integrity": "sha512-xVij69o9t/frixCDEoyWoVDKgE3ksLGdmE2nvBWVGmoLu94MWUlv2y4Qzf5oozBmydG5Dcm4pRHFBM7YWa1i6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.78.tgz",
+			"integrity": "sha512-aSEXrLcIpBtXpOSnLhTg4jPsjJEnK7Je9KqUdAWjc7T8O4iYlxWxrXFIF8rV8J79h5jNdScgZpAUWYnEcutR3g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.78.tgz",
+			"integrity": "sha512-dlEPRX1hLGKaY3UtGa1dtkA1uGgFITn2mDnfI6YsLlYyLJQNqHx87D1YTACI4zFCUuLr/EzQDzuX+vnp9YveVg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.78.tgz",
+			"integrity": "sha512-TsCfjOPZtm5Q/NO1EZHR5pwDPSPjPEttvnv44GL32Zn1uvudssjTLbvaG1jHq81Qxm16GTXEiYLmx4jOLZQYlg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.78.tgz",
+			"integrity": "sha512-+cpTTb0GDshEow/5Fy8TpNyzaPsYb3clQIjgWRmzRcuteLU+CHEU/vpYvAcSo7JxHYPJd8fjSr+qqh+nI5AtmA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.78.tgz",
+			"integrity": "sha512-wxRcvKfvYBgtrO0Uy8OmwvjlnTcHpY45LLwkwVNIWHPqHAsyoTyG/JBSfJ0p5tWRzMOPDCDqdhpIO4LOgXjeyg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-musl": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.78.tgz",
+			"integrity": "sha512-vQFOGwC9QDP0kXlhb2LU1QRw/humXgcbVp8mXlyBqzc/a0eijlLF9wzyarHC1EywpymtS63TAj8PHZnhTYN6hg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
+			"version": "0.1.78",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.78.tgz",
+			"integrity": "sha512-/eKlTZBtGUgpRKalzOzRr6h7KVSuziESWXgBcBnXggZmimwIJWPJlEcbrx5Tcwj8rPuZiANXQOG9pPgy9Q4LTQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -2157,6 +2592,434 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@pixi/accessibility": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.2.4.tgz",
+			"integrity": "sha512-EVjuqUqv9FeYFXCv0S0qj1hgCtbAMNBPCbOGEtiMogpM++/IySxBZvcOYg3rRgo9inwt2s4Bi7kUiqMPD8hItw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/events": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/app": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.2.4.tgz",
+			"integrity": "sha512-eJ2jpu5P28ip07nLItw6sETXn45P4KR/leMJ6zPHRlhT1m8t5zTsWr3jK4Uj8LF2E+6KlPNzLQh5Alf/unn/aQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/assets": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.2.4.tgz",
+			"integrity": "sha512-7199re3wvMAlVqXLaCyAr8IkJSXqkeVAxcYyB2rBu4Id5m2hhlGX1dQsdMBiCXLwu6/LLVqDvJggSNVQBzL6ZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/css-font-loading-module": "^0.0.7"
+			},
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/utils": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/assets/node_modules/@types/css-font-loading-module": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+			"integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@pixi/color": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.2.4.tgz",
+			"integrity": "sha512-B/+9JRcXe2uE8wQfsueFRPZVayF2VEMRB7XGeRAsWCryOX19nmWhv0Nt3nOU2rvzI0niz9XgugJXsB6vVmDFSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"colord": "^2.9.3"
+			}
+		},
+		"node_modules/@pixi/compressed-textures": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.2.4.tgz",
+			"integrity": "sha512-atnWyw/ot/Wg69qhgskKiuTYCZx15IxV35sa0KyXMthyjyvDLCIvOn0nczM6wCBy9H96SjJbfgynVWhVrip6qw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/assets": "7.2.4",
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/constants": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.2.4.tgz",
+			"integrity": "sha512-hKuHBWR6N4Q0Sf5MGF3/9l+POg/G5rqhueHfzofiuelnKg7aBs3BVjjZ+6hZbd6M++vOUmxYelEX/NEFBxrheA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@pixi/core": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.2.4.tgz",
+			"integrity": "sha512-0XtvrfxHlS2T+beBBSpo7GI8+QLyyTqMVQpNmPqB4woYxzrOEJ9JaUFBaBfCvycLeUkfVih1u6HAbtF+2d1EjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pixi/color": "7.2.4",
+				"@pixi/constants": "7.2.4",
+				"@pixi/extensions": "7.2.4",
+				"@pixi/math": "7.2.4",
+				"@pixi/runner": "7.2.4",
+				"@pixi/settings": "7.2.4",
+				"@pixi/ticker": "7.2.4",
+				"@pixi/utils": "7.2.4",
+				"@types/offscreencanvas": "^2019.6.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/pixijs"
+			}
+		},
+		"node_modules/@pixi/display": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.2.4.tgz",
+			"integrity": "sha512-w5tqb8cWEO5qIDaO9GEqRvxYhL0iMk0Wsngw23bbLm1gLEQmrFkB2tpJlRAqd7H82C3DrDDeWvkrrxW6+m4apg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/events": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.2.4.tgz",
+			"integrity": "sha512-/JtmoB98fzIU8giN9xvlRvmvOi6u4MaD2DnKNOMHkQ1MBraj3pmrXM9fZ0JbNzi+324GraAAY76QidgHjIYoYQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/extensions": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.2.4.tgz",
+			"integrity": "sha512-Mnqv9scbL1ARD3QFKfOWs2aSVJJfP1dL8g5UiqGImYO3rZbz/9QCzXOeMVIZ5n3iaRyKMNhFFr84/zUja2H7Dw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@pixi/extract": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.2.4.tgz",
+			"integrity": "sha512-wlXZg+J2L/1jQhRi5nZQP/cXshovhjksjss91eAKMvY5aGxNAQovCP4xotJ/XJjfTvPMpeRzHPFYzm3PrOPQ7g==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/filter-alpha": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.2.4.tgz",
+			"integrity": "sha512-UTUMSGyktUr+I9vmigqJo9iUhb0nwGyqTTME2xBWZvVGCnl5z+/wHxvIBBCe5pNZ66IM15pGXQ4cDcfqCuP2kA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/filter-blur": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.2.4.tgz",
+			"integrity": "sha512-aLyXIoxy14bTansCPtbY8x7Sdn2OrrqkF/pcKiRXHJGGhi7wPacvB/NcmYJdnI/n2ExQ6V5Njuj/nfrsejVwcA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/filter-color-matrix": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.2.4.tgz",
+			"integrity": "sha512-DFtayybYXoUh73eHUFRK5REbi1t3FZuVUnaQTj+euHKF9L7EaYc3Q9wctpx1WPRcwkqEX50M4SNFhxpA7Pxtaw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/filter-displacement": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.2.4.tgz",
+			"integrity": "sha512-Simq3IBJKt7+Gvk4kK7OFkfoeYUMhNhIyATCdeT+Jkdkq5WV7pYnH5hqO0YW7eAHrgjV13yn6t4H/GC4+6LhEA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/filter-fxaa": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.2.4.tgz",
+			"integrity": "sha512-qzKjdL+Ih18uGTJLg8tT/H+YCsTeGkw2uF7lyKnw/lxGLJQhLWIhM95M9qSNgxbXyW1vp7SbG81a9aAEz2HAhA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/filter-noise": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.2.4.tgz",
+			"integrity": "sha512-QAU9Ybj2ZQrWM9ZEjTTC0iLnQcuyNoZNRinxSbg1G0yacpmsSb9wvV5ltIZ66+hfY+90+u2Nudt/v9g6pvOdGg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/graphics": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.2.4.tgz",
+			"integrity": "sha512-3A2EumTjWJgXlDLOyuBrl9b6v1Za/E+/IjOGUIX843HH4NYaf1a2sfDfljx6r3oiDvy+VhuBFmgynRcV5IyA0Q==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/sprite": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/math": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.2.4.tgz",
+			"integrity": "sha512-LJB+mozyEPllxa0EssFZrKNfVwysfaBun4b2dJKQQInp0DafgbA0j7A+WVg0oe51KhFULTJMpDqbLn/ITFc41A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@pixi/mesh": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.2.4.tgz",
+			"integrity": "sha512-wiALIqcRKib2BqeH9kOA5fOKWN352nqAspgbDa8gA7OyWzmNwqIedIlElixd0oLFOrIN5jOZAdzeKnoYQlt9Aw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/mesh-extras": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.2.4.tgz",
+			"integrity": "sha512-Lxqq/1E2EmDgjZX8KzjhBy3VvITIQ00arr2ikyHYF1d0XtQTKEYpr8VKzhchqZ5/9DuyTDbDMYGhcxoNXQmZrQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/mesh": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/mixin-cache-as-bitmap": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.2.4.tgz",
+			"integrity": "sha512-95L/9nzfLHw6GoeqqRl/RjSloKvRt0xrc2inCmjMZvMsFUEtHN2F8IWd1k5vcv0S+83NCreFkJg6nJm1m5AZqg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/sprite": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/mixin-get-child-by-name": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.2.4.tgz",
+			"integrity": "sha512-9g17KgSBEEhkinnKk4dqmxagzHOCPSTvGB6lOopBq4yyXmr/2WVv+QGjuzE0O+p80szQeBJjPBQxzrfBILaSRw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/display": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/mixin-get-global-position": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.2.4.tgz",
+			"integrity": "sha512-UrAUF2BXCeWtFgR2m+er41Ky7zShT7r228cZkB6ZfYwMeThhwqG5mH68UeCyP6p68JMpT1gjI2DPfeSRY3ecnA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/particle-container": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.2.4.tgz",
+			"integrity": "sha512-tpSzilZGFtAoi8XhzL0TecLPNRQAbY8nWV9XNGXJDw+nxXp18GCe8L6eEmnHLlAug67BRHl65DtrdvTknPX+4g==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/sprite": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/prepare": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.2.4.tgz",
+			"integrity": "sha512-Yff5Sh4kTLdKc5VkkM44LW9gpj7Izw8ns3P1TzWxqeGjzPZ3folr/tQujGL+Qw+8A9VESp+hX9MSIHyw+jpyrg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/graphics": "7.2.4",
+				"@pixi/text": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/runner": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.2.4.tgz",
+			"integrity": "sha512-YtyqPk1LA+0guEFKSFx6t/YSvbEQwajFwi4Ft8iDhioa6VK2MmTir1GjWwy7JQYLcDmYSAcQjnmFtVTZohyYSw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@pixi/settings": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.2.4.tgz",
+			"integrity": "sha512-ZPKRar9EwibijGmH8EViu4Greq1I/O7V/xQx2rNqN23XA7g09Qo6yfaeQpufu5xl8+/lZrjuHtQSnuY7OgG1CA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pixi/constants": "7.2.4",
+				"@types/css-font-loading-module": "^0.0.7",
+				"ismobilejs": "^1.1.0"
+			}
+		},
+		"node_modules/@pixi/settings/node_modules/@types/css-font-loading-module": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+			"integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@pixi/sprite": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.2.4.tgz",
+			"integrity": "sha512-DhR1B+/d0eXpxHIesJMXcVPrKFwQ+zRA1LvEIFfzewqfaRN3X6PMIuoKX8SIb6tl+Hq8Ba9Pe28zI7d2rmRzrA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/sprite-animated": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.2.4.tgz",
+			"integrity": "sha512-9eRriPSC0QVS7U9zQlrG3uEI5+h3fi+mqofXy+yjk1sGCmXSIJME5p2wg2mzxoJk3qkSMagQA9QHtL26Fti8Iw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/sprite": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/sprite-tiling": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.2.4.tgz",
+			"integrity": "sha512-nGfxQoACRx49dUN0oW1vFm3141M+7gkAbzoNJym2Pljd2dpLME9fb5E6Lyahu0yWMaPRhhGorn6z9VIGmTF3Jw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/sprite": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/spritesheet": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.2.4.tgz",
+			"integrity": "sha512-LNmlavyiMQeCF0U4S+yhzxUYmPmat6EpLjLnkGukQTZV5CZkxDCVgXM9uKoRF2DvNydj4yuwZ6+JjK8QssHI8Q==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/assets": "7.2.4",
+				"@pixi/core": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/text": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.2.4.tgz",
+			"integrity": "sha512-DGu7ktpe+zHhqR2sG9NsJt4mgvSObv5EqXTtUxD4Z0li1gmqF7uktpLyn5I6vSg1TTEL4TECClRDClVDGiykWw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/sprite": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/text-bitmap": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.2.4.tgz",
+			"integrity": "sha512-3u2CP4VN+muCaq/jtj7gn0hb3DET/X2S04zTBcgc2WVGufJc62yz+UDzS9jC+ellotVdt9c8U74++vpz3zJGfw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/assets": "7.2.4",
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/mesh": "7.2.4",
+				"@pixi/text": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/text-html": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.2.4.tgz",
+			"integrity": "sha512-0NfLAE/w51ZtatxVqLvDS62iO0VLKsSdctqTAVv4Zlgdk9TKJmX1WUucHJboTvbm2SbDjNDGfZ6qXM5nAslIDQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/sprite": "7.2.4",
+				"@pixi/text": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/ticker": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.2.4.tgz",
+			"integrity": "sha512-hQQHIHvGeFsP4GNezZqjzuhUgNQEVgCH9+qU05UX1Mc5UHC9l6OJnY4VTVhhcHxZjA6RnyaY+1zBxCnoXuazpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pixi/extensions": "7.2.4",
+				"@pixi/settings": "7.2.4",
+				"@pixi/utils": "7.2.4"
+			}
+		},
+		"node_modules/@pixi/utils": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.2.4.tgz",
+			"integrity": "sha512-VUGQHBOINIS4ePzoqafwxaGPVRTa3oM/mEutIIHbNGI3b+QvSO+1Dnk40M0zcH6Bo+MxQZbOZK5X/wO9oU5+LQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pixi/color": "7.2.4",
+				"@pixi/constants": "7.2.4",
+				"@pixi/settings": "7.2.4",
+				"@types/earcut": "^2.1.0",
+				"earcut": "^2.2.4",
+				"eventemitter3": "^4.0.0",
+				"url": "^0.11.0"
+			}
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2188,6 +3051,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -2206,6 +3082,19 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@tybys/wasm-util": {
@@ -2264,6 +3153,19 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
+			}
+		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -2272,6 +3174,315 @@
 			"dependencies": {
 				"@types/tern": "*"
 			}
+		},
+		"node_modules/@types/css-font-loading-module": {
+			"version": "0.0.14",
+			"resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.14.tgz",
+			"integrity": "sha512-+EwJ/RW2vPqbYn0JXRHy593huPCtgmLF/kg57iLK9KUn6neTqGGOTZ0CbssP8Uou/gqT/5XmWKQ8A7ve7xNV6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+			"integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/d3-axis": "*",
+				"@types/d3-brush": "*",
+				"@types/d3-chord": "*",
+				"@types/d3-color": "*",
+				"@types/d3-contour": "*",
+				"@types/d3-delaunay": "*",
+				"@types/d3-dispatch": "*",
+				"@types/d3-drag": "*",
+				"@types/d3-dsv": "*",
+				"@types/d3-ease": "*",
+				"@types/d3-fetch": "*",
+				"@types/d3-force": "*",
+				"@types/d3-format": "*",
+				"@types/d3-geo": "*",
+				"@types/d3-hierarchy": "*",
+				"@types/d3-interpolate": "*",
+				"@types/d3-path": "*",
+				"@types/d3-polygon": "*",
+				"@types/d3-quadtree": "*",
+				"@types/d3-random": "*",
+				"@types/d3-scale": "*",
+				"@types/d3-scale-chromatic": "*",
+				"@types/d3-selection": "*",
+				"@types/d3-shape": "*",
+				"@types/d3-time": "*",
+				"@types/d3-time-format": "*",
+				"@types/d3-timer": "*",
+				"@types/d3-transition": "*",
+				"@types/d3-zoom": "*"
+			}
+		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+			"integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-axis": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+			"integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-brush": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+			"integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-chord": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+			"integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-contour": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-dispatch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+			"integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-drag": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+			"integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-dsv": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+			"integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-fetch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+			"integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-dsv": "*"
+			}
+		},
+		"node_modules/@types/d3-force": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-format": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-geo": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+			"integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-hierarchy": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-interpolate": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-color": "*"
+			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-polygon": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+			"integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-quadtree": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+			"integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-random": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+			"integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-selection": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+			"integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-time-format": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-transition": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+			"integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-zoom": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+			"integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-interpolate": "*",
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/dompurify": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.1.tgz",
+			"integrity": "sha512-ubq8VKmf8W+U48jUOiZO4BoSGS7NnbITPMvrF+7HgMN4L+eezCKv8QBPB8p3o4YPicLMmNeTyDkE5X4c2ViHJQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/jsdom": "*",
+				"@types/trusted-types": "*"
+			}
+		},
+		"node_modules/@types/earcut": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+			"integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/eslint": {
 			"version": "8.56.2",
@@ -2288,6 +3499,20 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
 			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+			"license": "MIT"
+		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
@@ -2354,6 +3579,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "24.3.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
@@ -2370,6 +3605,30 @@
 			"integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/offscreencanvas": {
+			"version": "2019.7.3",
+			"resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+			"integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/prismjs": {
+			"version": "1.26.5",
+			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+			"integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/semver": {
 			"version": "7.7.0",
@@ -2401,6 +3660,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/turndown": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
+			"integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/yaml": {
 			"version": "1.9.6",
 			"resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.9.6.tgz",
@@ -2427,6 +3700,17 @@
 			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.29.0",
@@ -3159,9 +4443,9 @@
 			]
 		},
 		"node_modules/acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -3564,6 +4848,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/boolean": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3644,6 +4937,16 @@
 				"node-int64": "^0.4.0"
 			}
 		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3659,6 +4962,51 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
+		"node_modules/cacheable-request": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cacheable-request/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3782,6 +5130,34 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/chevrotain": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/cst-dts-gen": "11.0.3",
+				"@chevrotain/gast": "11.0.3",
+				"@chevrotain/regexp-to-ast": "11.0.3",
+				"@chevrotain/types": "11.0.3",
+				"@chevrotain/utils": "11.0.3",
+				"lodash-es": "4.17.21"
+			}
+		},
+		"node_modules/chevrotain-allstar": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lodash-es": "^4.17.21"
+			},
+			"peerDependencies": {
+				"chevrotain": "^11.0.0"
+			}
+		},
 		"node_modules/chrono-node": {
 			"version": "2.8.4",
 			"resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.4.tgz",
@@ -3832,6 +5208,19 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3870,10 +5259,34 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/confbox": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+			"integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3883,6 +5296,16 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/cose-base": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+			"integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"layout-base": "^1.0.0"
+			}
 		},
 		"node_modules/crelt": {
 			"version": "1.0.6",
@@ -3917,6 +5340,547 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/cytoscape": {
+			"version": "3.33.1",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/cytoscape-cose-bilkent": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+			"integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cose-base": "^1.0.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cose-base": "^2.2.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/cose-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"layout-base": "^2.0.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/layout-base": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/d3": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+			"integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "3",
+				"d3-axis": "3",
+				"d3-brush": "3",
+				"d3-chord": "3",
+				"d3-color": "3",
+				"d3-contour": "4",
+				"d3-delaunay": "6",
+				"d3-dispatch": "3",
+				"d3-drag": "3",
+				"d3-dsv": "3",
+				"d3-ease": "3",
+				"d3-fetch": "3",
+				"d3-force": "3",
+				"d3-format": "3",
+				"d3-geo": "3",
+				"d3-hierarchy": "3",
+				"d3-interpolate": "3",
+				"d3-path": "3",
+				"d3-polygon": "3",
+				"d3-quadtree": "3",
+				"d3-random": "3",
+				"d3-scale": "4",
+				"d3-scale-chromatic": "3",
+				"d3-selection": "3",
+				"d3-shape": "3",
+				"d3-time": "3",
+				"d3-time-format": "4",
+				"d3-timer": "3",
+				"d3-transition": "3",
+				"d3-zoom": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-axis": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+			"integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-brush": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "3",
+				"d3-transition": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-chord": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"delaunator": "5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-drag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+			"integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-selection": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"commander": "7",
+				"iconv-lite": "0.6",
+				"rw": "1"
+			},
+			"bin": {
+				"csv2json": "bin/dsv2json.js",
+				"csv2tsv": "bin/dsv2dsv.js",
+				"dsv2dsv": "bin/dsv2dsv.js",
+				"dsv2json": "bin/dsv2json.js",
+				"json2csv": "bin/json2dsv.js",
+				"json2dsv": "bin/json2dsv.js",
+				"json2tsv": "bin/json2dsv.js",
+				"tsv2csv": "bin/dsv2dsv.js",
+				"tsv2json": "bin/dsv2json.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-fetch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+			"integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dsv": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.5.0 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-polygon": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+			"integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-quadtree": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-random": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-sankey": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-array": "1 - 2",
+				"d3-shape": "^1.2.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-array": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"internmap": "^1.0.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-path": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/d3-sankey/node_modules/d3-shape": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-path": "1"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/internmap": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-interpolate": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-selection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-transition": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+			"integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-dispatch": "1 - 3",
+				"d3-ease": "1 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"d3-selection": "2 - 3"
+			}
+		},
+		"node_modules/d3-zoom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+			"integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "2 - 3",
+				"d3-transition": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/dagre-d3-es": {
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.11.tgz",
+			"integrity": "sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"d3": "^7.9.0",
+				"lodash-es": "^4.17.21"
 			}
 		},
 		"node_modules/data-urls": {
@@ -4028,6 +5992,35 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decompress-response/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/dedent": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -4058,6 +6051,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/defer-to-connect": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/define-data-property": {
@@ -4096,6 +6099,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/delaunator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+			"integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"robust-predicates": "^3.0.2"
+			}
+		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -4105,6 +6118,14 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -4132,6 +6153,16 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dompurify": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+			"integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+			"dev": true,
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4147,6 +6178,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/earcut": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+			"integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4154,12 +6192,48 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/electron": {
+			"version": "37.4.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-37.4.0.tgz",
+			"integrity": "sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/get": "^2.0.0",
+				"@types/node": "^22.7.7",
+				"extract-zip": "^2.0.1"
+			},
+			"bin": {
+				"electron": "cli.js"
+			},
+			"engines": {
+				"node": ">= 12.20.55"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.171",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.171.tgz",
 			"integrity": "sha512-scWpzXEJEMrGJa4Y6m/tVotb0WuvNmasv3wWVzUAeCgKU0ToFOhUW6Z+xWnRQANMYGxN4ngJXIThgBJOqzVPCQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/electron/node_modules/@types/node": {
+			"version": "22.18.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+			"integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/electron/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/emittery": {
 			"version": "0.13.1",
@@ -4181,6 +6255,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
 		"node_modules/entities": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -4192,6 +6276,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/error-ex": {
@@ -4352,6 +6446,14 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/esbuild": {
 			"version": "0.25.9",
@@ -5185,6 +7287,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5235,6 +7344,50 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/exsolve": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+			"integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/extract-zip/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -5323,6 +7476,16 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"bser": "2.1.1"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -5434,6 +7597,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -5641,6 +7819,25 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/global-agent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"es6-error": "^4.1.1",
+				"matcher": "^3.0.0",
+				"roarr": "^2.15.3",
+				"semver": "^7.3.2",
+				"serialize-error": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=10.0"
+			}
+		},
 		"node_modules/globals": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -5705,6 +7902,32 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/got": {
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5716,6 +7939,13 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hachure-fill": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+			"integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5855,6 +8085,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5867,6 +8104,20 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -5891,6 +8142,38 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/i18next": {
+			"version": "25.2.1",
+			"resolved": "https://registry.npmjs.org/i18next/-/i18next-25.2.1.tgz",
+			"integrity": "sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://locize.com"
+				},
+				{
+					"type": "individual",
+					"url": "https://locize.com/i18next.html"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.27.1"
+			},
+			"peerDependencies": {
+				"typescript": "^5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ical.js": {
@@ -6001,6 +8284,16 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -6464,6 +8757,13 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/ismobilejs": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+			"integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -7428,6 +9728,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true
+		},
 		"node_modules/json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7460,6 +9768,16 @@
 				"url": "https://github.com/sponsors/ota-meshi"
 			}
 		},
+		"node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
 		"node_modules/jsx-ast-utils": {
 			"version": "3.3.5",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -7476,6 +9794,33 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/katex": {
+			"version": "0.16.22",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+			"integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+			"dev": true,
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7485,6 +9830,43 @@
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
+		},
+		"node_modules/khroma": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+			"dev": true
+		},
+		"node_modules/kolorist": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+			"integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/langium": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-3.0.0.tgz",
+			"integrity": "sha512-+Ez9EoiByeoTu/2BXmEaZ06iPNXM6thWJp02KfBO/raSMyCJ4jw7AkWWa+zBCTm0+Tw1Fj9FOxdqSskyN5nAwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chevrotain": "~11.0.3",
+				"chevrotain-allstar": "~0.3.0",
+				"vscode-languageserver": "~9.0.1",
+				"vscode-languageserver-textdocument": "~1.0.11",
+				"vscode-uri": "~3.0.8"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/layout-base": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+			"integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/leven": {
 			"version": "3.1.0",
@@ -7517,6 +9899,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/local-pkg": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+			"integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mlly": "^1.7.4",
+				"pkg-types": "^2.3.0",
+				"quansync": "^0.2.11"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7532,6 +9932,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash-es": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
@@ -7558,6 +9965,16 @@
 			},
 			"bin": {
 				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -7603,6 +10020,33 @@
 				"tmpl": "1.0.5"
 			}
 		},
+		"node_modules/marked": {
+			"version": "13.0.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
+			"integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/matcher": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7630,6 +10074,35 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/mermaid": {
+			"version": "11.4.1",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.4.1.tgz",
+			"integrity": "sha512-Mb01JT/x6CKDWaxigwfZYuYmDZ6xtrNwNlidKZwkSrDaY9n90tdrJTV5Umk+wP1fZscGptmKFXHsXMDEVZ+Q6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@braintree/sanitize-url": "^7.0.1",
+				"@iconify/utils": "^2.1.32",
+				"@mermaid-js/parser": "^0.3.0",
+				"@types/d3": "^7.4.3",
+				"cytoscape": "^3.29.2",
+				"cytoscape-cose-bilkent": "^4.1.0",
+				"cytoscape-fcose": "^2.2.0",
+				"d3": "^7.9.0",
+				"d3-sankey": "^0.12.3",
+				"dagre-d3-es": "7.0.11",
+				"dayjs": "^1.11.10",
+				"dompurify": "^3.2.1",
+				"katex": "^0.16.9",
+				"khroma": "^2.1.0",
+				"lodash-es": "^4.17.21",
+				"marked": "^13.0.2",
+				"roughjs": "^4.6.6",
+				"stylis": "^4.3.1",
+				"ts-dedent": "^2.2.0",
+				"uuid": "^9.0.1"
+			}
+		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7652,6 +10125,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/minimatch": {
@@ -7685,6 +10168,38 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mlly": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.1"
+			}
+		},
+		"node_modules/mlly/node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mlly/node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
 			}
 		},
 		"node_modules/moment": {
@@ -7755,6 +10270,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -7965,6 +10493,54 @@
 			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
 			"license": "0BSD"
 		},
+		"node_modules/obsidian-typings": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/obsidian-typings/-/obsidian-typings-4.49.0.tgz",
+			"integrity": "sha512-3yZgI8/phSA7UKydNj3k/w0MHFu0KmkuT3LOBuf6HPSngtci1HSWbQiHNOu8gBuK3oWDzCbTr2X8xbNoYuJN2A==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@antfu/utils": "9.2.0",
+				"@capacitor/core": "5.7.8",
+				"@codemirror/language": "6.11.2",
+				"@codemirror/search": "6.5.11",
+				"@codemirror/state": "6.5.2",
+				"@lezer/common": "1.2.3",
+				"@pixi/color": "7.2.4",
+				"@pixi/events": "7.2.4",
+				"@pixi/settings": "7.2.4",
+				"@types/codemirror": "5.60.16",
+				"@types/css-font-loading-module": "0.0.14",
+				"@types/dompurify": "3.0.1",
+				"@types/node": "^18.17.0 || >=20.1.0",
+				"@types/prismjs": "1.26.5",
+				"@types/turndown": "5.0.5",
+				"colord": "2.9.3",
+				"electron": ">=1.6.10",
+				"i18next": "25.2.1",
+				"mermaid": "11.4.1",
+				"moment": "2.29.4",
+				"obsidian": "1.8.7",
+				"pdfjs-dist": "5.3.31",
+				"pixi.js": "7.2.4",
+				"scrypt-js": "3.0.1",
+				"style-mod": "4.1.2"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.0"
+			}
+		},
+		"node_modules/obsidian-typings/node_modules/@types/codemirror": {
+			"version": "5.60.16",
+			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.16.tgz",
+			"integrity": "sha512-V/yHdamffSS075jit+fDxaOAmdP2liok8NSNJnAZfDJErzOheuygHZEhAJrfmk5TEyM32MhkZjwo/idX791yxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/tern": "*"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8027,6 +10603,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8076,6 +10662,13 @@
 			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
+		"node_modules/package-manager-detector": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.3.0.tgz",
+			"integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8120,6 +10713,13 @@
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
+		},
+		"node_modules/path-data-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -8192,6 +10792,33 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pdfjs-dist": {
+			"version": "5.3.31",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.3.31.tgz",
+			"integrity": "sha512-EhPdIjNX0fcdwYQO+e3BAAJPXt+XI29TZWC7COhIXs/K0JHcUt1Gdz1ITpebTwVMFiLsukdUZ3u0oTO7jij+VA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=20.16.0 || >=22.3.0"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas": "^0.1.67"
+			}
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8220,6 +10847,49 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pixi.js": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.2.4.tgz",
+			"integrity": "sha512-nBH60meoLnHxoMFz17HoMxXS4uJpG5jwIdL+Gx2S11TzWgP3iKF+/WLOTrkSdyuQoQSdIBxVqpnYii0Wiox15A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pixi/accessibility": "7.2.4",
+				"@pixi/app": "7.2.4",
+				"@pixi/assets": "7.2.4",
+				"@pixi/compressed-textures": "7.2.4",
+				"@pixi/core": "7.2.4",
+				"@pixi/display": "7.2.4",
+				"@pixi/events": "7.2.4",
+				"@pixi/extensions": "7.2.4",
+				"@pixi/extract": "7.2.4",
+				"@pixi/filter-alpha": "7.2.4",
+				"@pixi/filter-blur": "7.2.4",
+				"@pixi/filter-color-matrix": "7.2.4",
+				"@pixi/filter-displacement": "7.2.4",
+				"@pixi/filter-fxaa": "7.2.4",
+				"@pixi/filter-noise": "7.2.4",
+				"@pixi/graphics": "7.2.4",
+				"@pixi/mesh": "7.2.4",
+				"@pixi/mesh-extras": "7.2.4",
+				"@pixi/mixin-cache-as-bitmap": "7.2.4",
+				"@pixi/mixin-get-child-by-name": "7.2.4",
+				"@pixi/mixin-get-global-position": "7.2.4",
+				"@pixi/particle-container": "7.2.4",
+				"@pixi/prepare": "7.2.4",
+				"@pixi/sprite": "7.2.4",
+				"@pixi/sprite-animated": "7.2.4",
+				"@pixi/sprite-tiling": "7.2.4",
+				"@pixi/spritesheet": "7.2.4",
+				"@pixi/text": "7.2.4",
+				"@pixi/text-bitmap": "7.2.4",
+				"@pixi/text-html": "7.2.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/pixijs"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -8291,6 +10961,36 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pkg-types": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+			"integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.2.2",
+				"exsolve": "^1.0.7",
+				"pathe": "^2.0.3"
+			}
+		},
+		"node_modules/points-on-curve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+			"integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/points-on-path": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+			"integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-data-parser": "0.1.0",
+				"points-on-curve": "0.2.0"
+			}
+		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8349,6 +11049,16 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8367,6 +11077,17 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/pump": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -8395,6 +11116,39 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/qs": {
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/quansync": {
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+			"integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/antfu"
+				},
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/sxzz"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8415,6 +11169,19 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/react-is": {
 			"version": "18.3.1",
@@ -8537,6 +11304,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/resolve-cwd": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -8568,6 +11342,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ret": {
@@ -8606,6 +11393,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/roarr": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"detect-node": "^2.0.4",
+				"globalthis": "^1.0.1",
+				"json-stringify-safe": "^5.0.1",
+				"semver-compare": "^1.0.0",
+				"sprintf-js": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/roarr/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/robust-predicates": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+			"integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+			"dev": true,
+			"license": "Unlicense"
+		},
+		"node_modules/roughjs": {
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+			"integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hachure-fill": "^0.5.2",
+				"path-data-parser": "^0.1.0",
+				"points-on-curve": "^0.2.0",
+				"points-on-path": "^0.2.1"
 			}
 		},
 		"node_modules/rrule": {
@@ -8647,6 +11481,13 @@
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
+		},
+		"node_modules/rw": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/safe-array-concat": {
 			"version": "1.1.3",
@@ -8754,6 +11595,13 @@
 				"node": ">=v12.22.7"
 			}
 		},
+		"node_modules/scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "7.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -8765,6 +11613,45 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/serialize-error": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"type-fest": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/serialize-error/node_modules/type-fest": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -9195,6 +12082,26 @@
 			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
 			"license": "MIT"
 		},
+		"node_modules/stylis": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+			"integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/sumchecker": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+			"integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.1.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9264,6 +12171,13 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+			"integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -9360,6 +12274,16 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
+			}
+		},
+		"node_modules/ts-dedent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+			"integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.10"
 			}
 		},
 		"node_modules/ts-jest": {
@@ -9884,6 +12808,13 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/ufo": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/uglify-js": {
 			"version": "3.19.3",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -9923,6 +12854,16 @@
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
 		"node_modules/unrs-resolver": {
 			"version": "1.11.1",
@@ -10000,6 +12941,41 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/url": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+			"integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^1.4.1",
+				"qs": "^6.12.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/url/node_modules/punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -10014,6 +12990,61 @@
 			"engines": {
 				"node": ">=10.12.0"
 			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
@@ -10396,6 +13427,17 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"jest": "^30.1.1",
 		"jest-environment-jsdom": "^30.1.1",
 		"obsidian": "latest",
+		"obsidian-typings": "^4.49.0",
 		"ts-jest": "^29.1.1",
 		"tslib": "^2.8.1",
 		"typescript": "^5.9.2"

--- a/src/bases/agenda-view.ts
+++ b/src/bases/agenda-view.ts
@@ -141,6 +141,15 @@ export function buildTasknotesAgendaViewFactory(plugin: TaskNotesPlugin) {
       if (!currentRoot) return;
       try {
         const dataItems = extractDataItems();
+        try {
+          if (plugin.settings?.basesAdvancedDataLogs) {
+            const raw = Array.from(((basesContainer as any)?.results as Map<any, any> | undefined)?.entries?.() || []);
+            console.log('[TaskNotes][Bases][ADVANCED-DUMP]', {
+              size: (basesContainer as any)?.results instanceof Map ? (basesContainer as any).results.size : undefined,
+              results: raw
+            });
+          }
+        } catch (_) { /* ignore */ }
         const taskNotes = await identifyTaskNotesFromBasesData(dataItems);
 
         // Reset controls and container (preserve search input)

--- a/src/bases/agenda-view.ts
+++ b/src/bases/agenda-view.ts
@@ -245,6 +245,12 @@ export function buildTasknotesAgendaViewFactory(plugin: TaskNotesPlugin) {
           if (svg) { svg.classList.add('chevron'); svg.setAttribute('width', '16'); svg.setAttribute('height', '16'); } else { toggleBtn.textContent = '▸'; }
           header.appendChild(toggleBtn);
 
+          // Add a consistent group label span used by tests and for copyable day key
+          const labelSpan = document.createElement('span');
+          labelSpan.className = 'tn-bases-group-label';
+          labelSpan.textContent = dayKey;
+          header.appendChild(labelSpan);
+
           const headerText = document.createElement('div');
           headerText.className = 'agenda-view__day-header-text';
           const displayDate = convertUTCToLocalCalendarDate(date);

--- a/src/bases/agenda-view.ts
+++ b/src/bases/agenda-view.ts
@@ -1,0 +1,376 @@
+import TaskNotesPlugin from '../main';
+import { TextComponent, debounce, setTooltip, ButtonComponent, setIcon } from 'obsidian';
+import { BasesDataItem, identifyTaskNotesFromBasesData, renderTaskNotesInBasesView } from './helpers';
+import { getTaskNotesTasklistRows } from './tasklist-rows';
+import { buildSearchIndex, filterTasksBySearch } from './search';
+import { TaskNotesBasesTaskListComponent } from './component';
+import { GroupCountUtils } from '../utils/GroupCountUtils';
+import { GroupingUtils } from '../utils/GroupingUtils';
+import { BASES_TASK_LIST_VIEW_TYPE } from '../types';
+import { addDays, startOfWeek, endOfWeek } from 'date-fns';
+import { convertUTCToLocalCalendarDate, createUTCDateFromLocalCalendarDate, formatDateForStorage, isTodayUTC } from '../utils/dateUtils';
+
+
+export interface BasesContainerLike {
+  results?: Map<any, any>;
+  query?: { on?: (event: string, cb: () => void) => void; off?: (event: string, cb: () => void) => void };
+  viewContainerEl?: HTMLElement;
+}
+
+// Simplified date extraction from task properties for grouping
+function getTaskDates(props: Record<string, any>): string[] {
+  const out: string[] = [];
+  const due = props['due'] ?? props['note.due'];
+  const scheduled = props['scheduled'] ?? props['note.scheduled'];
+  const push = (v: any) => {
+    if (!v) return;
+    if (Array.isArray(v)) v.forEach((x) => { if (x) out.push(String(x)); });
+    else out.push(String(v));
+  };
+  push(due);
+  push(scheduled);
+  // normalize to YYYY-MM-DD if possible (already expected)
+  return out.filter(Boolean);
+}
+
+// Bases agenda period config: number of days or "week"; fallback to 7 days
+function readAgendaPeriod(basesContainer: any, plugin: TaskNotesPlugin): { daysToShow: number; weekMode: boolean } {
+  try {
+    const controller = (basesContainer?.controller ?? basesContainer) as any;
+    const query = (basesContainer?.query ?? controller?.query) as any;
+    const fullCfg = controller?.getViewConfig?.() ?? {};
+    const data = (fullCfg as any)?.data ?? {};
+    let raw = data['tasknotes.agenda']
+      ?? data?.tasknotes?.agenda
+      ?? (fullCfg as any)['tasknotes.agenda']
+      ?? (fullCfg as any)?.tasknotes?.agenda;
+    if (!raw) {
+      try { raw = query?.getViewConfig?.('tasknotes.agenda') ?? (query?.getViewConfig?.('tasknotes') as any)?.agenda; } catch (_) {}
+    }
+
+    let period = (raw && typeof raw === 'object') ? (raw as any).period : raw;
+    if (period === 'week') return { daysToShow: -1, weekMode: true };
+    const n = parseInt(String(period ?? '7'), 10);
+    if (!isNaN(n) && n > 0) return { daysToShow: n, weekMode: false };
+  } catch (_) {}
+  return { daysToShow: 7, weekMode: false };
+}
+
+function getAgendaDates(selectedDate: Date, daysToShow: number, firstDay: number): Date[] {
+  const dates: Date[] = [];
+  if (daysToShow === -1) {
+    const weekStart = startOfWeek(selectedDate, { weekStartsOn: firstDay as 0|1|2|3|4|5|6 });
+    const weekEnd = endOfWeek(selectedDate, { weekStartsOn: firstDay as 0|1|2|3|4|5|6 });
+    let current = weekStart;
+    while (current <= weekEnd) {
+      const normalized = createUTCDateFromLocalCalendarDate(current);
+      dates.push(normalized);
+      current = addDays(current, 1);
+    }
+  } else {
+    for (let i = 0; i < daysToShow; i++) {
+      const target = addDays(selectedDate, i);
+      const normalized = createUTCDateFromLocalCalendarDate(target);
+      dates.push(normalized);
+    }
+  }
+  return dates;
+}
+
+export function buildTasknotesAgendaViewFactory(plugin: TaskNotesPlugin) {
+  return function tasknotesAgendaViewFactory(basesContainer: BasesContainerLike) {
+    let currentRoot: HTMLElement | null = null;
+
+    const viewContainerEl = (basesContainer as any)?.viewContainerEl as HTMLElement | undefined;
+    if (!viewContainerEl) {
+      console.error('[TaskNotes][BasesPOC] No viewContainerEl found');
+      return { destroy: () => {} } as any;
+    }
+
+    viewContainerEl.innerHTML = '';
+
+    // Root & controls
+    const root = document.createElement('div');
+    root.className = 'tn-bases-integration tasknotes-plugin tasknotes-container';
+    viewContainerEl.appendChild(root);
+    currentRoot = root;
+
+    const controls = document.createElement('div');
+    controls.className = 'filter-bar__top-controls';
+    root.appendChild(controls);
+
+    let currentSearchTerm = '';
+    try {
+      const searchInput = new TextComponent(controls).setPlaceholder('Search path | title | aliases');
+      searchInput.inputEl.addClass('filter-bar__search-input');
+      setTooltip(searchInput.inputEl, 'Quick search (ephemeral)', { placement: 'top' } as any);
+      const triggerSearch = debounce(() => { currentSearchTerm = searchInput.getValue(); void render(); }, 800);
+      searchInput.onChange(() => triggerSearch());
+    } catch (_) {
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.placeholder = 'Search path | title | aliases';
+      input.className = 'filter-bar__search-input';
+      input.addEventListener('input', debounce(() => { currentSearchTerm = input.value; void render(); }, 800));
+      controls.appendChild(input);
+    }
+
+    const itemsContainer = document.createElement('div');
+    itemsContainer.className = 'tn-bases-items-container';
+    itemsContainer.style.cssText = 'margin-top: 12px;';
+    root.appendChild(itemsContainer);
+
+    const extractDataItems = (): BasesDataItem[] => {
+      const dataItems: BasesDataItem[] = [];
+      const results = (basesContainer as any)?.results as Map<any, any> | undefined;
+      if (results && results instanceof Map) {
+        for (const [, value] of results.entries()) {
+          dataItems.push({
+            key: (value as any)?.file?.path || (value as any)?.path,
+            data: value,
+            file: (value as any)?.file,
+            path: (value as any)?.file?.path || (value as any)?.path,
+            properties: (value as any)?.properties || (value as any)?.frontmatter
+          });
+        }
+      }
+      return dataItems;
+    };
+
+    const render = async () => {
+      if (!currentRoot) return;
+      try {
+        const dataItems = extractDataItems();
+        const taskNotes = await identifyTaskNotesFromBasesData(dataItems);
+
+        // Reset controls and container (preserve search input)
+        itemsContainer.innerHTML = '';
+        controls.querySelectorAll('.filter-bar__expand-groups, .filter-bar__collapse-groups').forEach(el => el.remove());
+
+        if (taskNotes.length === 0) {
+          const empty = document.createElement('div');
+          empty.className = 'tn-bases-empty';
+          empty.style.cssText = 'padding: 20px; text-align: center; color: #666;';
+          empty.textContent = 'No TaskNotes tasks found for this Base.';
+          itemsContainer.appendChild(empty);
+          return;
+        }
+
+        // path -> props for property rendering
+        const pathToProps = new Map<string, Record<string, any>>(
+          dataItems.filter(i => !!i.path).map(i => [i.path!, (i as any).properties || (i as any).frontmatter || {}])
+        );
+
+        // Extra property rows
+        const rows = getTaskNotesTasklistRows(basesContainer as any, pathToProps);
+        let extraRows = [rows.row3, rows.row4].filter(Boolean) as any[];
+        if (extraRows.length === 0) {
+          const { getBasesPropertyRowConfig } = await import('./property-selection');
+          const fallback = getBasesPropertyRowConfig(basesContainer as any, pathToProps) || undefined;
+          if (fallback) extraRows = [fallback] as any[];
+        }
+
+        // Search
+        const getAliases = (p: string): string[] => {
+          const props = pathToProps.get(p) || {};
+          const v = (props as any)['note.aliases'] ?? (props as any)['aliases'];
+          if (Array.isArray(v)) return v.filter((x: any) => !!x).map(String);
+          if (typeof v === 'string' && v.trim()) return [v];
+          return [];
+        };
+        const searchIndex = buildSearchIndex(taskNotes, { getAliases });
+
+        // Compute agenda dates exactly like AgendaView
+        const selected = new Date(plugin.selectedDate);
+        const firstDay = (plugin.settings?.calendarViewSettings?.firstDay ?? 0) as number;
+        const { daysToShow } = readAgendaPeriod(basesContainer as any, plugin);
+        const agendaDates = getAgendaDates(selected, daysToShow, firstDay);
+
+        // Build a base query similar to AgendaView
+        const baseQuery: any = {
+          type: 'group', id: 'bases-agenda', conjunction: 'and', children: [],
+          sortKey: 'due', sortDirection: 'asc', groupKey: 'none'
+        };
+
+        // Gather tasks per day using FilterService when available, else fallback to raw tasks
+        const agendaData: Array<{ date: Date; tasks: any[] }> = [];
+        for (const date of agendaDates) {
+          if ((plugin as any).filterService?.getTasksForDate) {
+            try {
+              const tasksForDate = await (plugin as any).filterService.getTasksForDate(date, baseQuery, true);
+              agendaData.push({ date, tasks: filterTasksBySearch(tasksForDate, searchIndex, currentSearchTerm) });
+            } catch {
+              // Fallback: approximate by checking task props against this date
+              const dayKey = formatDateForStorage(date);
+              const approx = taskNotes.filter(t => {
+                const props = pathToProps.get(t.path) || {};
+                const keys = getTaskDates(props);
+                return keys.includes(dayKey);
+              });
+              agendaData.push({ date, tasks: filterTasksBySearch(approx, searchIndex, currentSearchTerm) });
+            }
+          } else {
+            const dayKey = formatDateForStorage(date);
+            const approx = taskNotes.filter(t => {
+              const props = pathToProps.get(t.path) || {};
+              const keys = getTaskDates(props);
+              return keys.includes(dayKey);
+            });
+            agendaData.push({ date, tasks: filterTasksBySearch(approx, searchIndex, currentSearchTerm) });
+          }
+        }
+
+        // Render sections in chronological order with Agenda header styling
+        const groupSections: HTMLElement[] = [];
+        for (const { date, tasks } of agendaData) {
+          const hasItems = (tasks?.length || 0) > 0;
+          if (!hasItems) continue;
+
+          const dayKey = formatDateForStorage(date);
+
+          const section = document.createElement('section');
+          section.className = 'agenda-view__day-section task-group';
+          section.setAttribute('data-day', dayKey);
+
+          // Header (similar to AgendaView.createDayHeader)
+          const header = document.createElement('div');
+          header.className = 'agenda-view__day-header task-group-header';
+          header.setAttribute('data-day', dayKey);
+
+          const toggleBtn = document.createElement('button');
+          toggleBtn.className = 'task-group-toggle';
+          toggleBtn.setAttribute('aria-label', 'Toggle day');
+          try { setIcon(toggleBtn, 'chevron-right'); } catch (_) {}
+          const svg = toggleBtn.querySelector('svg');
+          if (svg) { svg.classList.add('chevron'); svg.setAttribute('width', '16'); svg.setAttribute('height', '16'); } else { toggleBtn.textContent = '▸'; }
+          header.appendChild(toggleBtn);
+
+          const headerText = document.createElement('div');
+          headerText.className = 'agenda-view__day-header-text';
+          const displayDate = convertUTCToLocalCalendarDate(date);
+          const { format } = await import('date-fns');
+          const dayName = format(displayDate, 'EEEE');
+          const dateFormatted = format(displayDate, 'MMMM d');
+          if (isTodayUTC(date)) {
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'agenda-view__day-name agenda-view__day-name--today';
+            nameSpan.textContent = 'Today';
+            headerText.appendChild(nameSpan);
+            const dateSpan = document.createElement('span');
+            dateSpan.className = 'agenda-view__day-date';
+            dateSpan.textContent = ` • ${dateFormatted}`;
+            headerText.appendChild(dateSpan);
+          } else {
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'agenda-view__day-name';
+            nameSpan.textContent = dayName;
+            headerText.appendChild(nameSpan);
+            const dateSpan = document.createElement('span');
+            dateSpan.className = 'agenda-view__day-date';
+            dateSpan.textContent = ` • ${dateFormatted}`;
+            headerText.appendChild(dateSpan);
+          }
+          header.appendChild(headerText);
+
+          // Count badge (tasks completion)
+          const stats = GroupCountUtils.calculateGroupStats(tasks as any, plugin);
+          const countSpan = document.createElement('span');
+          countSpan.className = 'agenda-view__item-count';
+          countSpan.textContent = `${GroupCountUtils.formatGroupCount(stats.completed, stats.total).text}`;
+          header.appendChild(countSpan);
+
+          section.appendChild(header);
+
+          const list = document.createElement('div');
+          list.className = 'agenda-view__day-items';
+          section.appendChild(list);
+
+          const collapsedInitially = GroupingUtils.isGroupCollapsed(
+            BASES_TASK_LIST_VIEW_TYPE,
+            'bases:agenda',
+            dayKey,
+            plugin
+          );
+          if (collapsedInitially) {
+            section.classList.add('is-collapsed');
+            list.style.display = 'none';
+          }
+          toggleBtn.setAttribute('aria-expanded', String(!collapsedInitially));
+
+          const toggle = () => {
+            const willCollapse = !section.classList.contains('is-collapsed');
+            GroupingUtils.setGroupCollapsed(BASES_TASK_LIST_VIEW_TYPE, 'bases:agenda', dayKey, willCollapse, plugin);
+            section.classList.toggle('is-collapsed', willCollapse);
+            list.style.display = willCollapse ? 'none' : '';
+            toggleBtn.setAttribute('aria-expanded', String(!willCollapse));
+          };
+          header.addEventListener('click', (e) => { const target = e.target as HTMLElement; if (target.closest('a')) return; toggle(); });
+          toggleBtn.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); toggle(); });
+
+          await renderTaskNotesInBasesView(list, tasks as any, plugin, { extraPropertiesRows: extraRows as any });
+
+          itemsContainer.appendChild(section);
+          groupSections.push(section);
+        }
+
+        // Expand/Collapse all
+        try {
+          const expandAllBtn = new ButtonComponent(controls)
+            .setIcon('list-tree')
+            .setTooltip('Expand All Groups')
+            .setClass('filter-bar__expand-groups');
+          (expandAllBtn as any).buttonEl.classList.add('clickable-icon');
+          expandAllBtn.onClick(() => {
+            for (const section of groupSections) {
+              section.classList.remove('is-collapsed');
+              const list = section.querySelector('.agenda-view__day-items') as HTMLElement | null;
+              if (list) list.style.display = '';
+              const name = section.getAttribute('data-day') || '';
+              GroupingUtils.setGroupCollapsed(BASES_TASK_LIST_VIEW_TYPE, 'bases:agenda', name, false, plugin);
+              const btn = section.querySelector('.task-group-toggle');
+              btn?.setAttribute('aria-expanded', 'true');
+            }
+          });
+
+          const collapseAllBtn = new ButtonComponent(controls)
+            .setIcon('list-collapse')
+            .setTooltip('Collapse All Groups')
+            .setClass('filter-bar__collapse-groups');
+          (collapseAllBtn as any).buttonEl.classList.add('clickable-icon');
+          collapseAllBtn.onClick(() => {
+            const names = groupSections.map(s => s.getAttribute('data-day') || '');
+            for (const section of groupSections) {
+              const list = section.querySelector('.agenda-view__day-items') as HTMLElement | null;
+              const hasTasks = !!list && list.children.length > 0;
+              if (hasTasks) {
+                section.classList.add('is-collapsed');
+                if (list) list.style.display = 'none';
+                const btn = section.querySelector('.task-group-toggle');
+                btn?.setAttribute('aria-expanded', 'false');
+              }
+            }
+            GroupingUtils.collapseAllGroups(BASES_TASK_LIST_VIEW_TYPE, 'bases:agenda', names, plugin);
+          });
+        } catch (_) { /* ignore */ }
+      } catch (error) {
+        console.error('[TaskNotes][BasesPOC] Error rendering Bases Agenda:', error);
+      }
+    };
+
+    const component = new TaskNotesBasesTaskListComponent({
+      getContainer: () => currentRoot,
+      setContainer: (el) => { currentRoot = el; },
+      refresh: render,
+      attachQueryListener: (handler) => (basesContainer as any)?.query?.on?.('change', handler),
+      detachQueryListener: (handler) => (basesContainer as any)?.query?.off?.('change', handler)
+    });
+
+    (component as any).load = component.onload.bind(component);
+    (component as any).unload = component.onunload.bind(component);
+
+    void render();
+
+    return component as any;
+  };
+}
+

--- a/src/bases/component.ts
+++ b/src/bases/component.ts
@@ -1,0 +1,56 @@
+import { Component } from 'obsidian';
+
+export interface BasesComponentHooks {
+  getContainer: () => HTMLElement | null;
+  setContainer: (el: HTMLElement | null) => void;
+  refresh: () => Promise<void> | void;
+  attachQueryListener?: (handler: () => void) => void;
+  detachQueryListener?: (handler: () => void) => void;
+}
+
+/**
+ * Minimal Obsidian Component subclass for Bases lifecycle management.
+ * The concrete rendering and event wiring are provided via hooks.
+ */
+export class TaskNotesBasesTaskListComponent extends Component {
+  private destroyed = false;
+  private readonly onQueryChanged = () => {
+    if (this.destroyed) return;
+    void Promise.resolve(this.hooks.refresh());
+  };
+
+  constructor(private hooks: BasesComponentHooks) {
+    super();
+  }
+
+  getViewType() { return 'tasknotes-task-list'; }
+  getDisplayText() { return 'TaskNotes Task List'; }
+  getEphemeralState() { return { type: 'tasknotes', scrollTop: this.hooks.getContainer()?.scrollTop || 0 }; }
+  setEphemeralState(state: any) {
+    const c = this.hooks.getContainer();
+    if (state?.scrollTop && c) c.scrollTop = state.scrollTop;
+  }
+  onResize() { /* no-op for now */ }
+
+  // Called by Bases when the underlying data changes
+  onDataUpdated(..._args: any[]): void {
+    if (this.destroyed) return;
+    void Promise.resolve(this.hooks.refresh());
+  }
+
+  onload(): void {
+    this.destroyed = false;
+    if (this.hooks.attachQueryListener) this.hooks.attachQueryListener(this.onQueryChanged);
+  }
+
+  onunload(): void {
+    if (this.hooks.detachQueryListener) this.hooks.detachQueryListener(this.onQueryChanged);
+    const c = this.hooks.getContainer();
+    if (c) {
+      c.remove();
+      this.hooks.setContainer(null);
+    }
+    this.destroyed = true;
+  }
+}
+

--- a/src/bases/group-by.ts
+++ b/src/bases/group-by.ts
@@ -1,0 +1,93 @@
+import { BASES_TASK_LIST_VIEW_TYPE } from '../types';
+
+export interface BasesGroupByConfig {
+  normalizedId: string;
+  displayName: string;
+  getGroupValues: (taskPath: string) => string[];
+}
+
+function isNonEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function toStringTokens(value: unknown): string[] {
+  if (!isNonEmpty(value)) return ['none'];
+  if (Array.isArray(value)) {
+    const out: string[] = [];
+    for (const v of value) {
+      if (!isNonEmpty(v)) continue;
+      out.push(String(v));
+    }
+    return out.length ? out : ['none'];
+  }
+  return [String(value)];
+}
+
+/**
+ * Read Bases view groupBy config and normalize it against query.properties
+ * Returns a config object or null if groupBy is absent.
+ */
+export function getBasesGroupByConfig(basesContainer: any, pathToProps: Map<string, any>): BasesGroupByConfig | null {
+  try {
+    const controller = (basesContainer?.controller ?? basesContainer) as any;
+    const query = (basesContainer?.query ?? controller?.query) as any;
+    if (!controller) return null;
+
+    const fullCfg = controller?.getViewConfig?.() ?? {};
+
+    // Try multiple locations to fetch groupBy
+    let groupBy: any;
+    try {
+      groupBy = query?.getViewConfig?.('groupBy');
+    } catch (_) {
+      // ignore
+    }
+    if (groupBy == null) groupBy = (fullCfg as any)?.groupBy;
+
+    if (!groupBy) return null; // No grouping configured
+
+    // Accept string or first element from array-like inputs
+    const token = Array.isArray(groupBy) ? groupBy[0] : groupBy;
+    if (!token || typeof token !== 'string') return null;
+
+    // Build property id index from query.properties
+    const propsMap: Record<string, any> | undefined = query?.properties;
+    const idIndex = new Map<string, string>();
+    if (propsMap && typeof propsMap === 'object') {
+      for (const id of Object.keys(propsMap)) {
+        idIndex.set(id, id);
+        const last = id.includes('.') ? id.split('.').pop()! : id;
+        idIndex.set(last, id);
+        const dn = propsMap[id]?.getDisplayName?.();
+        if (typeof dn === 'string' && dn.trim()) idIndex.set(dn.toLowerCase(), id);
+      }
+    }
+
+    const normalizeToId = (t: string): string | undefined => {
+      if (!t) return undefined;
+      return idIndex.get(t) || idIndex.get(t.toLowerCase()) || t;
+    };
+
+    const normalizedId = normalizeToId(token);
+    if (!normalizedId) return null;
+
+    const displayName: string = propsMap?.[normalizedId]?.getDisplayName?.() ?? normalizedId;
+
+    const getGroupValues = (taskPath: string): string[] => {
+      const props = pathToProps.get(taskPath) || {};
+      const v = props[normalizedId];
+      if (isNonEmpty(v)) return toStringTokens(v);
+      const last = normalizedId.includes('.') ? normalizedId.split('.').pop()! : normalizedId;
+      return toStringTokens(props[last]);
+    };
+
+    return { normalizedId, displayName, getGroupValues };
+  } catch (e) {
+    console.debug('[TaskNotes][Bases] getBasesGroupByConfig failed:', e);
+    return null;
+  }
+}
+

--- a/src/bases/group-ordering.ts
+++ b/src/bases/group-ordering.ts
@@ -1,0 +1,25 @@
+import { coerceForCompare } from './sorting';
+
+/** Build a comparator for group names based on a property values domain
+ * Strategy:
+ *  - If groupBy property is the same as first sort key -> order groups using that sort key (ASC/DESC)
+ *  - Else default to alphabetical ASC
+ */
+export function getGroupNameComparator(
+  firstSortEntry: { id: string; direction: 'ASC' | 'DESC' } | null
+): ((a: string, b: string) => number) {
+  if (!firstSortEntry) {
+    return (a, b) => String(a).localeCompare(String(b));
+  }
+  const dir = firstSortEntry.direction;
+  return (a, b) => {
+    const ca = coerceForCompare(a);
+    const cb = coerceForCompare(b);
+    let cmp = 0;
+    if (typeof ca === 'number' && typeof cb === 'number') cmp = ca - cb;
+    else if (typeof ca === 'string' && typeof cb === 'string') cmp = ca.localeCompare(cb);
+    else cmp = String(ca).localeCompare(String(cb));
+    return dir === 'DESC' ? -cmp : cmp;
+  };
+}
+

--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -1,0 +1,154 @@
+import TaskNotesPlugin from '../main';
+import { TaskInfo } from '../types';
+
+export interface BasesDataItem {
+  key?: string;
+  data?: any;
+  file?: { path?: string } | any;
+  path?: string;
+  properties?: Record<string, any>;
+  frontmatter?: Record<string, any>;
+  name?: string;
+}
+
+/**
+ * Create TaskInfo object from a single Bases data item
+ */
+export function createTaskInfoFromBasesData(basesItem: BasesDataItem): TaskInfo | null {
+  if (!basesItem?.path) return null;
+
+  const props = basesItem.properties || basesItem.frontmatter || {};
+
+  const taskInfo: TaskInfo = {
+    title: props.title || basesItem.name || basesItem.path!.split('/').pop()?.replace('.md', '') || 'Untitled',
+    status: props.status || 'open',
+    priority: props.priority || 'normal',
+    path: basesItem.path!,
+    archived: props.archived || false,
+    due: props.due,
+    scheduled: props.scheduled,
+    contexts: Array.isArray(props.contexts) ? props.contexts : (props.contexts ? [props.contexts] : undefined),
+    projects: Array.isArray(props.projects) ? props.projects : (props.projects ? [props.projects] : undefined),
+    tags: Array.isArray(props.tags) ? props.tags : (props.tags ? [props.tags] : undefined),
+    timeEstimate: props.timeEstimate,
+    completedDate: props.completedDate,
+    recurrence: props.recurrence,
+    dateCreated: props.dateCreated,
+    dateModified: props.dateModified,
+    timeEntries: props.timeEntries,
+    reminders: props.reminders,
+    icsEventId: props.icsEventId
+  };
+
+  return taskInfo;
+}
+
+/**
+ * Identify TaskNotes from Bases data by converting all items to TaskInfo
+ */
+export async function identifyTaskNotesFromBasesData(
+  dataItems: BasesDataItem[],
+  toTaskInfo: (item: BasesDataItem) => TaskInfo | null = createTaskInfoFromBasesData
+): Promise<TaskInfo[]> {
+  const taskNotes: TaskInfo[] = [];
+  for (const item of dataItems) {
+    if (!item?.path) continue;
+    try {
+      const taskInfo = toTaskInfo(item);
+      if (taskInfo) taskNotes.push(taskInfo);
+    } catch (error) {
+      console.warn('[TaskNotes][BasesPOC] Error converting Bases item to TaskInfo:', error);
+    }
+  }
+  return taskNotes;
+}
+
+/**
+ * Render TaskNotes using TaskCard component into a container
+ */
+export async function renderTaskNotesInBasesView(
+  container: HTMLElement,
+  taskNotes: TaskInfo[],
+  plugin: TaskNotesPlugin,
+  extraOptions: Partial<import('../ui/TaskCard').TaskCardOptions> = {}
+): Promise<void> {
+  const { createTaskCard, DEFAULT_TASK_CARD_OPTIONS } = await import('../ui/TaskCard');
+
+  const taskListEl = document.createElement('div');
+  taskListEl.className = 'tn-bases-tasknotes-list';
+  taskListEl.style.cssText = 'display: flex; flex-direction: column; gap: 1px;';
+  container.appendChild(taskListEl);
+
+  const cardOptions = {
+    ...DEFAULT_TASK_CARD_OPTIONS,
+    showCheckbox: false,
+    showDueDate: true,
+    showArchiveButton: false,
+    showTimeTracking: false,
+    ...extraOptions
+  };
+
+  for (const taskInfo of taskNotes) {
+    const taskCard = createTaskCard(taskInfo, plugin, undefined, cardOptions);
+    taskListEl.appendChild(taskCard);
+  }
+}
+
+/**
+ * Render a raw Bases data item for debugging/inspection
+ */
+export function renderBasesDataItem(container: HTMLElement, item: BasesDataItem, index: number): void {
+  const itemEl = document.createElement('div');
+  itemEl.className = 'tn-bases-data-item';
+  itemEl.style.cssText = 'padding: 12px; margin: 8px 0; background: #fff; border: 1px solid #ddd; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);';
+
+  const header = document.createElement('div');
+  header.style.cssText = 'font-weight: bold; margin-bottom: 8px; color: #333;';
+  itemEl.appendChild(header);
+
+  if ((item as any).path) {
+    const pathEl = document.createElement('div');
+    pathEl.style.cssText = 'font-size: 12px; color: #666; margin-bottom: 6px; font-family: monospace;';
+    itemEl.appendChild(pathEl);
+  }
+
+  const props = (item as any).properties;
+  if (props && typeof props === 'object') {
+    const propsEl = document.createElement('div');
+    propsEl.style.cssText = 'font-size: 12px; margin-top: 8px;';
+
+    const propsHeader = document.createElement('div');
+    propsHeader.style.cssText = 'font-weight: bold; margin-bottom: 4px; color: #555;';
+    propsHeader.textContent = 'Properties:';
+    propsEl.appendChild(propsHeader);
+
+    const propsList = document.createElement('ul');
+    propsList.style.cssText = 'margin: 0; padding-left: 16px; list-style-type: disc;';
+
+    Object.entries(props).forEach(([key, value]) => {
+      const li = document.createElement('li');
+      li.style.cssText = 'margin: 2px 0; color: #444;';
+      propsList.appendChild(li);
+    });
+
+    propsEl.appendChild(propsList);
+    itemEl.appendChild(propsEl);
+  }
+
+  const rawDataEl = document.createElement('details');
+  rawDataEl.style.cssText = 'margin-top: 8px; font-size: 11px;';
+
+  const summary = document.createElement('summary');
+  summary.style.cssText = 'cursor: pointer; color: #666; font-weight: bold;';
+  summary.textContent = 'Raw Data Structure';
+  rawDataEl.appendChild(summary);
+
+  const pre = document.createElement('pre');
+  pre.style.cssText = 'margin: 8px 0 0 0; padding: 8px; background: #f8f8f8; border-radius: 4px; overflow-x: auto; font-size: 10px;';
+  pre.textContent = JSON.stringify(item, null, 2);
+  rawDataEl.appendChild(pre);
+
+  itemEl.appendChild(rawDataEl);
+  container.appendChild(itemEl);
+}
+

--- a/src/bases/kanban-view.ts
+++ b/src/bases/kanban-view.ts
@@ -1,0 +1,303 @@
+import TaskNotesPlugin from '../main';
+import { TextComponent, debounce, setTooltip, Notice } from 'obsidian';
+import { BasesDataItem, identifyTaskNotesFromBasesData, renderTaskNotesInBasesView } from './helpers';
+import { getTaskNotesTasklistRows } from './tasklist-rows';
+import { getBasesGroupByConfig } from './group-by';
+import { getBasesSortComparator } from './sorting';
+import { buildSearchIndex, filterTasksBySearch } from './search';
+import { TaskNotesBasesTaskListComponent } from './component';
+
+export interface BasesContainerLike {
+  results?: Map<any, any>;
+  query?: { on?: (event: string, cb: () => void) => void; off?: (event: string, cb: () => void) => void };
+  viewContainerEl?: HTMLElement;
+}
+
+/**
+ * Build a Kanban view factory for Obsidian Bases integration following the Task List pattern.
+ * - Columns are defined by Bases groupBy configuration
+ * - Supports ephemeral search filter
+ * - Renders TaskNotes TaskCard(s) with extraPropertiesRows from tasknotes.tasklist config
+ * - Minimal drag-and-drop support across columns (status/priority/context/project)
+ */
+export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
+  return function tasknotesKanbanViewFactory(basesContainer: BasesContainerLike) {
+    let currentRoot: HTMLElement | null = null;
+
+    // Guard
+    const viewContainerEl = (basesContainer as any)?.viewContainerEl as HTMLElement | undefined;
+    if (!viewContainerEl) {
+      console.error('[TaskNotes][BasesPOC] No viewContainerEl found');
+      return { destroy: () => {} } as any;
+    }
+
+    // Ensure clean container
+    viewContainerEl.innerHTML = '';
+
+    // Root container
+    const root = document.createElement('div');
+    root.className = 'tn-bases-integration tasknotes-plugin kanban-view';
+    viewContainerEl.appendChild(root);
+    currentRoot = root;
+
+    // Controls (search)
+    const controls = document.createElement('div');
+    controls.className = 'filter-bar__top-controls';
+    root.appendChild(controls);
+
+    let currentSearchTerm = '';
+    try {
+      const searchInput = new TextComponent(controls).setPlaceholder('Search path | title | aliases');
+      searchInput.inputEl.addClass('filter-bar__search-input');
+      setTooltip(searchInput.inputEl, 'Quick search (ephemeral)', { placement: 'top' } as any);
+      const triggerSearch = debounce(() => { currentSearchTerm = searchInput.getValue(); void render(); }, 800);
+      searchInput.onChange(() => triggerSearch());
+    } catch (_) {
+      // Fallback in unit-test or non-Obsidian environment
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.placeholder = 'Search path | title | aliases';
+      input.className = 'filter-bar__search-input';
+      input.addEventListener('input', debounce(() => {
+        currentSearchTerm = input.value;
+        void render();
+      }, 800));
+      controls.appendChild(input);
+    }
+
+    // Board container
+    const board = document.createElement('div');
+    board.className = 'kanban-view__board';
+    board.style.marginTop = '12px';
+    root.appendChild(board);
+
+    // Helpers
+    const extractDataItems = (): BasesDataItem[] => {
+      const dataItems: BasesDataItem[] = [];
+      const results = (basesContainer as any)?.results as Map<any, any> | undefined;
+      if (results && results instanceof Map) {
+        for (const [, value] of results.entries()) {
+          dataItems.push({
+            key: (value as any)?.file?.path || (value as any)?.path,
+            data: value,
+            file: (value as any)?.file,
+            path: (value as any)?.file?.path || (value as any)?.path,
+            properties: (value as any)?.properties || (value as any)?.frontmatter
+          });
+        }
+      }
+      return dataItems;
+    };
+
+    const render = async () => {
+      if (!currentRoot) return;
+      try {
+        const dataItems = extractDataItems();
+        const taskNotes = await identifyTaskNotesFromBasesData(dataItems);
+
+        // Clear board
+        board.innerHTML = '';
+
+        if (taskNotes.length === 0) {
+          const empty = document.createElement('div');
+          empty.className = 'tn-bases-empty';
+          empty.style.cssText = 'padding: 20px; text-align: center; color: #666;';
+          empty.textContent = 'No TaskNotes tasks found for this Base.';
+          board.appendChild(empty);
+          return;
+        }
+
+        // Map path -> properties/frontmatter for property value resolution
+        const pathToProps = new Map<string, Record<string, any>>(
+          dataItems.filter(i => !!i.path).map(i => [i.path!, (i as any).properties || (i as any).frontmatter || {}])
+        );
+
+        // Extra property rows for TaskCard from tasknotes.tasklist
+        const rows = getTaskNotesTasklistRows(basesContainer as any, pathToProps);
+        let extraRows = [rows.row3, rows.row4].filter(Boolean) as any[];
+        if (extraRows.length === 0) {
+          const { getBasesPropertyRowConfig } = await import('./property-selection');
+          const fallback = getBasesPropertyRowConfig(basesContainer as any, pathToProps) || undefined;
+          if (fallback) extraRows = [fallback] as any[];
+        }
+
+        // Search
+        const getAliases = (p: string): string[] => {
+          const props = pathToProps.get(p) || {};
+          const v = props['note.aliases'] ?? props['aliases'];
+          if (Array.isArray(v)) return v.filter((x: any) => !!x).map(String);
+          if (typeof v === 'string' && v.trim()) return [v];
+          return [];
+        };
+        const searchIndex = buildSearchIndex(taskNotes, { getAliases });
+        const searchedTasks = filterTasksBySearch(taskNotes, searchIndex, currentSearchTerm);
+
+        // Grouping (required for Kanban)
+        const groupCfg = getBasesGroupByConfig(basesContainer as any, pathToProps);
+        if (!groupCfg) {
+          const msg = document.createElement('div');
+          msg.className = 'tn-bases-warning';
+          msg.textContent = 'Kanban requires a groupBy configuration in this Base.';
+          board.appendChild(msg);
+          return;
+        }
+
+        // Sort according to Bases sort if present
+        const cmp = getBasesSortComparator(basesContainer as any, pathToProps);
+        const tasksForGrouping = cmp ? [...searchedTasks].sort(cmp) : searchedTasks;
+
+        // Build groups
+        const groups = new Map<string, typeof taskNotes>();
+        for (const t of tasksForGrouping) {
+          const values = groupCfg.getGroupValues(t.path) || ['none'];
+          for (const v of values) {
+            const key = String(v ?? 'none');
+            if (!groups.has(key)) groups.set(key, []);
+            groups.get(key)!.push(t);
+          }
+        }
+
+        // Column names: include all statuses/priorities as empty columns when applicable
+        const namesSet = new Set<string>(Array.from(groups.keys()));
+        const groupDomain = groupCfg.normalizedId.includes('.') ? groupCfg.normalizedId.split('.').pop()! : groupCfg.normalizedId;
+        try {
+          if (groupDomain === 'status') {
+            const allStatuses = plugin.statusManager.getAllStatuses().map(s => s.value);
+            for (const s of allStatuses) namesSet.add(String(s));
+          } else if (groupDomain === 'priority') {
+            const allPriorities = plugin.priorityManager.getAllPriorities().map(p => p.value);
+            for (const p of allPriorities) namesSet.add(String(p));
+          }
+        } catch (_) { /* ignore if managers not available */ }
+
+        let columnNames = Array.from(namesSet);
+        if (cmp && (cmp as any).__basesSortEntries && (cmp as any).__basesSortEntries.length > 0) {
+          const first = (cmp as any).__basesSortEntries[0];
+          const { getGroupNameComparator } = await import('./group-ordering');
+          columnNames = columnNames.sort(getGroupNameComparator(first));
+        } else {
+          columnNames = columnNames.sort((a, b) => a.localeCompare(b));
+        }
+
+        // Render columns
+        for (const colName of columnNames) {
+          const column = document.createElement('div');
+          column.className = 'kanban-view__column';
+          column.setAttribute('data-column-id', colName);
+
+          const header = document.createElement('div');
+          header.className = 'kanban-view__column-header';
+          const title = document.createElement('div');
+          title.className = 'kanban-view__column-title';
+          title.textContent = colName;
+          header.appendChild(title);
+          const count = document.createElement('div');
+          count.className = 'kanban-view__column-count';
+          count.textContent = `${(groups.get(colName) || []).length} tasks`;
+          header.appendChild(count);
+          column.appendChild(header);
+
+          const body = document.createElement('div');
+          body.className = 'kanban-view__column-body';
+          const tasksContainer = document.createElement('div');
+          tasksContainer.className = 'kanban-view__tasks-container';
+          body.appendChild(tasksContainer);
+          column.appendChild(body);
+
+          // Render tasks using helper to ensure TaskCard consistency (with extra rows)
+          const tasks = groups.get(colName) || [];
+          await renderTaskNotesInBasesView(tasksContainer, tasks, plugin, { extraPropertiesRows: extraRows as any });
+
+          // Make task cards draggable
+          for (const card of Array.from(tasksContainer.querySelectorAll('.task-card')) as HTMLElement[]) {
+            const p = card.getAttribute('data-task-path');
+            if (p) {
+              card.draggable = true;
+              card.addEventListener('dragstart', (e) => {
+                if (e.dataTransfer) {
+                  e.dataTransfer.setData('text/plain', p);
+                  e.dataTransfer.effectAllowed = 'move';
+                }
+                window.setTimeout(() => card.classList.add('task-card--dragging'), 0);
+              });
+              card.addEventListener('dragend', () => card.classList.remove('task-card--dragging'));
+            }
+          }
+
+          // Accept drops on column
+          addColumnDropHandlers(column, async (taskPath: string, targetColumnId: string) => {
+            try {
+              const last = groupCfg.normalizedId.includes('.') ? groupCfg.normalizedId.split('.').pop()! : groupCfg.normalizedId;
+              let propertyToUpdate: any; let valueToSet: any;
+              switch (last) {
+                case 'status': propertyToUpdate = 'status'; valueToSet = targetColumnId; break;
+                case 'priority': propertyToUpdate = 'priority'; valueToSet = targetColumnId; break;
+                case 'context':
+                case 'contexts': propertyToUpdate = 'contexts'; valueToSet = [targetColumnId]; break;
+                case 'project':
+                case 'projects': propertyToUpdate = 'projects'; valueToSet = [targetColumnId]; break;
+                default:
+                  throw new Error(`Unsupported groupBy for drag-and-drop: ${groupCfg.normalizedId}`);
+              }
+              const task = await plugin.cacheManager.getCachedTaskInfo(taskPath);
+              if (task) {
+                await plugin.updateTaskProperty(task, propertyToUpdate, valueToSet, { silent: true });
+                new Notice(`Task moved to "${targetColumnId}"`);
+              }
+            } catch (e) {
+              console.error('[TaskNotes][BasesPOC] Move failed:', e);
+              new Notice('Failed to move task');
+            } finally {
+              void render();
+            }
+          });
+
+          board.appendChild(column);
+        }
+      } catch (error) {
+        console.error('[TaskNotes][BasesPOC] Error rendering Kanban:', error);
+      }
+    };
+
+    function addColumnDropHandlers(columnEl: HTMLElement, onDropTask: (taskPath: string, targetColumnId: string) => void | Promise<void>) {
+      columnEl.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+        columnEl.classList.add('kanban-view__column--dragover');
+      });
+      columnEl.addEventListener('dragleave', (e) => {
+        if (!columnEl.contains(e.relatedTarget as Node)) {
+          columnEl.classList.remove('kanban-view__column--dragover');
+        }
+      });
+      columnEl.addEventListener('drop', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        columnEl.classList.remove('kanban-view__column--dragover');
+        const data = e.dataTransfer?.getData('text/plain');
+        const taskPath = data;
+        const targetColumnId = columnEl.getAttribute('data-column-id') || '';
+        if (taskPath && targetColumnId) await onDropTask(taskPath, targetColumnId);
+      });
+    }
+
+    // Build component with lifecycle hooks mirroring Task List component
+    const component = new TaskNotesBasesTaskListComponent({
+      getContainer: () => currentRoot,
+      setContainer: (el) => { currentRoot = el; },
+      refresh: render,
+      attachQueryListener: (handler) => (basesContainer as any)?.query?.on?.('change', handler),
+      detachQueryListener: (handler) => (basesContainer as any)?.query?.off?.('change', handler)
+    });
+
+    // Add Bases lifecycle shims
+    (component as any).load = component.onload.bind(component);
+    (component as any).unload = component.onunload.bind(component);
+
+    // Kick off initial async render
+    void render();
+
+    return component as any;
+  };
+}
+

--- a/src/bases/kanban-view.ts
+++ b/src/bases/kanban-view.ts
@@ -93,6 +93,15 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
       if (!currentRoot) return;
       try {
         const dataItems = extractDataItems();
+        try {
+          if (plugin.settings?.basesAdvancedDataLogs) {
+            const raw = Array.from(((basesContainer as any)?.results as Map<any, any> | undefined)?.entries?.() || []);
+            console.log('[TaskNotes][Bases][ADVANCED-DUMP]', {
+              size: (basesContainer as any)?.results instanceof Map ? (basesContainer as any).results.size : undefined,
+              results: raw
+            });
+          }
+        } catch (_) { /* ignore */ }
         const taskNotes = await identifyTaskNotesFromBasesData(dataItems);
 
         // Clear board

--- a/src/bases/property-selection.ts
+++ b/src/bases/property-selection.ts
@@ -1,0 +1,97 @@
+import type { TaskCardOptions } from '../ui/TaskCard';
+
+export interface BasesSelectedProperty { id: string; displayName: string; visible: boolean }
+export interface BasesPropertyRowConfig {
+  selected: BasesSelectedProperty[];
+  getValue: (taskPath: string, propId: string) => unknown;
+}
+
+function isNonEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+export function getBasesPropertyRowConfig(basesContainer: any, pathToProps: Map<string, any>): BasesPropertyRowConfig | null {
+  try {
+    const controller = (basesContainer?.controller ?? basesContainer) as any;
+    const query = (basesContainer?.query ?? controller?.query) as any;
+
+    if (!controller) return null;
+
+    // Build index from available properties
+    const propsMap: Record<string, any> | undefined = query?.properties;
+    const idIndex = new Map<string, string>();
+    if (propsMap && typeof propsMap === 'object') {
+      for (const id of Object.keys(propsMap)) {
+        idIndex.set(id, id);
+        const last = id.includes('.') ? id.split('.').pop()! : id;
+        idIndex.set(last, id);
+        const dn = propsMap[id]?.getDisplayName?.();
+        if (typeof dn === 'string' && dn.trim()) idIndex.set(dn.toLowerCase(), id);
+      }
+    }
+
+    const normalizeToId = (token: string): string | undefined => {
+      if (!token) return undefined;
+      return idIndex.get(token) || idIndex.get(token.toLowerCase()) || token;
+    };
+
+    // Determine visible selection exclusively from the 'order' section (Bases standard)
+    const fullCfg = controller?.getViewConfig?.() ?? {};
+
+    // Try multiple locations to fetch order
+    let order: string[] | undefined;
+    try {
+      order = (query?.getViewConfig?.('order') as string[] | undefined)
+        ?? (fullCfg as any)?.order
+        ?? (fullCfg as any)?.columns?.order;
+    } catch (_) {
+      order = (fullCfg as any)?.order ?? (fullCfg as any)?.columns?.order;
+    }
+
+    // If no order is defined, do not render a third row (avoid showing everything)
+    if (!order || !Array.isArray(order) || order.length === 0) return null;
+
+    // Build the selection list strictly from the order tokens
+    const orderedIds: string[] = order
+      .map(normalizeToId)
+      .filter((id): id is string => !!id);
+
+    const selected = orderedIds.map(id => ({
+      id,
+      displayName: propsMap?.[id]?.getDisplayName?.() ?? id,
+      visible: true
+    }));
+
+    // Debug logging
+    try {
+      const tnCfg = (fullCfg?.tasknotes ?? {}) as any;
+      const debug = !!(tnCfg?.debug ?? fullCfg?.['tasknotes.debug']);
+      if (debug) {
+        console.debug('[TaskNotes][Bases] Third-row selection from order:', { orderedIds, selected });
+        // Log up to 3 samples of available keys per item for formula detection
+        let sampled = 0;
+        for (const [_path, props] of pathToProps.entries()) {
+          console.debug('[TaskNotes][Bases] Sample properties keys for', _path, Object.keys(props || {}));
+          if (++sampled >= 3) break;
+        }
+      }
+    } catch (_) { /* ignore */ }
+
+    const getValue = (taskPath: string, propId: string): unknown => {
+      const props = pathToProps.get(taskPath) || {};
+      const v = props[propId];
+      if (isNonEmpty(v)) return v;
+      const last = propId.includes('.') ? propId.split('.').pop()! : propId;
+      return props[last];
+    };
+
+    return { selected, getValue };
+  } catch (e) {
+    console.debug('[TaskNotes][Bases] getBasesPropertyRowConfig failed:', e);
+    return null;
+  }
+}
+

--- a/src/bases/property-selection.ts
+++ b/src/bases/property-selection.ts
@@ -65,10 +65,11 @@ export function getBasesPropertyRowConfig(basesContainer: any, pathToProps: Map<
       visible: true
     }));
 
-    // Debug logging
+    // Debug logging (only when TaskNotes Bases logs are enabled in settings)
     try {
+      const settingsLogsOn = !!((controller?.plugin?.settings?.basesPOCLogs));
       const tnCfg = (fullCfg?.tasknotes ?? {}) as any;
-      const debug = !!(tnCfg?.debug ?? fullCfg?.['tasknotes.debug']);
+      const debug = settingsLogsOn && !!(tnCfg?.debug ?? fullCfg?.['tasknotes.debug']);
       if (debug) {
         console.debug('[TaskNotes][Bases] Third-row selection from order:', { orderedIds, selected });
         // Log up to 3 samples of available keys per item for formula detection

--- a/src/bases/registration.ts
+++ b/src/bases/registration.ts
@@ -1,0 +1,142 @@
+import TaskNotesPlugin from '../main';
+import { WorkspaceLeaf, requireApiVersion } from 'obsidian';
+import { BASES_TASK_LIST_VIEW_TYPE } from '../types';
+import { buildTasknotesTaskListViewFactory } from './view-factory';
+
+/**
+ * Discover Bases and register the TaskNotes Task List view when enabled.
+ * - Attempts early, retries until Bases is ready (startup restore case)
+ * - Refreshes existing Bases leaves after registration
+ */
+export async function registerBasesTaskList(plugin: TaskNotesPlugin): Promise<void> {
+  if (!plugin.settings?.enableBasesPOC) return;
+  if (!requireApiVersion('1.9.12')) return;
+
+  // Optional: register a simple ItemView for manual inspection
+  try {
+    const existing = (plugin.app as any)?.viewRegistry?.getViewCreatorByType?.(BASES_TASK_LIST_VIEW_TYPE);
+    if (!existing && !(plugin as any).basesTaskListViewRegistered) {
+      // Provide a simple ItemView for manual inspection
+      const { BasesTaskListView } = await import('../views/BasesTaskListView');
+      plugin.registerView(
+        BASES_TASK_LIST_VIEW_TYPE,
+        (leaf: WorkspaceLeaf) => new BasesTaskListView(leaf, plugin)
+      );
+      (plugin as any).basesTaskListViewRegistered = true;
+    }
+  } catch (e) {
+    console.warn('[TaskNotes][Bases] Could not register BasesTaskListView:', e);
+  }
+
+  const tryRegisterWithBases = async (): Promise<boolean> => {
+    try {
+      const { InternalPluginName } = await import('obsidian-typings/implementations');
+      const bases: any = ((plugin.app as any).internalPlugins as any).getEnabledPluginById?.(InternalPluginName.Bases);
+      if (!bases?.registrations) return false;
+
+      // Register Task List under a specific key for future multi-view support
+      const factory = buildTasknotesTaskListViewFactory(plugin);
+      const registration = {
+        name: 'TaskNotes Task List',
+        icon: 'check-square',
+        factory,
+        options: () => ({ description: 'TaskNotes Task List view' })
+      } as const;
+
+      if (!bases.registrations.tasknotesTaskList) {
+        bases.registrations.tasknotesTaskList = registration;
+        console.log('[TaskNotes][Bases] Registered TaskNotes Task List (key: tasknotesTaskList)');
+      }
+
+      // Register Kanban view using same pattern
+      try {
+        const { buildTasknotesKanbanViewFactory } = await import('./kanban-view');
+        const kanbanFactory = buildTasknotesKanbanViewFactory(plugin);
+        const kanbanRegistration = {
+          name: 'TaskNotes Kanban',
+          icon: 'layout-grid',
+          factory: kanbanFactory,
+          options: () => ({ description: 'TaskNotes Kanban view' })
+        } as const;
+        if (!bases.registrations.tasknotesKanban) {
+          bases.registrations.tasknotesKanban = kanbanRegistration;
+          console.log('[TaskNotes][Bases] Registered TaskNotes Kanban (key: tasknotesKanban)');
+        }
+      } catch (e) {
+        console.warn('[TaskNotes][Bases] Could not register TaskNotes Kanban:', e);
+
+	      // Register Agenda view using same pattern
+	      try {
+	        const { buildTasknotesAgendaViewFactory } = await import('./agenda-view');
+	        const agendaFactory = buildTasknotesAgendaViewFactory(plugin);
+	        const agendaRegistration = {
+	          name: 'TaskNotes Agenda',
+	          icon: 'calendar',
+	          factory: agendaFactory,
+	          options: () => ({ description: 'TaskNotes Agenda view' })
+	        } as const;
+	        if (!bases.registrations.tasknotesAgenda) {
+	          bases.registrations.tasknotesAgenda = agendaRegistration;
+	          console.log('[TaskNotes][Bases] Registered TaskNotes Agenda (key: tasknotesAgenda)');
+	        }
+	      } catch (e) {
+	        console.warn('[TaskNotes][Bases] Could not register TaskNotes Agenda:', e);
+	      }
+
+      }
+
+	      // Register Agenda view using same pattern (outside Kanban try/catch)
+	      try {
+	        const { buildTasknotesAgendaViewFactory } = await import('./agenda-view');
+	        const agendaFactory = buildTasknotesAgendaViewFactory(plugin);
+	        const agendaRegistration = {
+	          name: 'TaskNotes Agenda',
+	          icon: 'calendar',
+	          factory: agendaFactory,
+	          options: () => ({ description: 'TaskNotes Agenda view' })
+	        } as const;
+	          if (!bases.registrations.tasknotesAgenda) {
+	            bases.registrations.tasknotesAgenda = agendaRegistration;
+	            console.log('[TaskNotes][Bases] Registered TaskNotes Agenda (key: tasknotesAgenda)');
+	          }
+	      } catch (e) {
+	        console.warn('[TaskNotes][Bases] Could not register TaskNotes Agenda:', e);
+	      }
+
+
+      // Best-effort refresh of existing Bases leaves (handles restored tabs)
+      try {
+        plugin.app.workspace.iterateAllLeaves((leaf) => {
+          if (leaf.view?.getViewType?.() === 'bases') {
+            const view = leaf.view as any;
+            if (typeof view.refresh === 'function') view.refresh();
+            else if (typeof view.onResize === 'function') view.onResize();
+          }
+        });
+      } catch (refreshError) {
+        console.warn('[TaskNotes][Bases] Could not refresh Bases views:', refreshError);
+      }
+
+      return true;
+    } catch (e) {
+      console.warn('[TaskNotes][Bases] Discovery/registration failed:', e);
+      return false;
+    }
+  };
+
+  // Attempt immediately, then retry a few times to cover startup timing
+  const immediate = await tryRegisterWithBases();
+  if (immediate) return;
+
+  // Retry with short backoff (total ~3s)
+  for (let i = 0; i < 12; i++) {
+    await new Promise((r) => setTimeout(r, 250));
+    if (await tryRegisterWithBases()) return;
+  }
+
+  // Also try once when layout is ready (in case Bases initializes after layout)
+  plugin.app.workspace.onLayoutReady(async () => {
+    await tryRegisterWithBases();
+  });
+}
+

--- a/src/bases/search.ts
+++ b/src/bases/search.ts
@@ -1,0 +1,34 @@
+import type { TaskInfo } from '../types';
+
+export interface SearchIndex extends Map<string, string> {}
+
+export interface SearchDeps {
+  getAliases: (taskPath: string) => string[];
+}
+
+/** Build a simple lowercased index for quick substring search */
+export function buildSearchIndex(tasks: TaskInfo[], deps: SearchDeps): SearchIndex {
+  const index: SearchIndex = new Map();
+  for (const t of tasks) {
+    const aliases = deps.getAliases(t.path).join(' ');
+    const blob = `${t.title || ''} ${t.path || ''} ${aliases}`.toLowerCase();
+    index.set(t.path, blob);
+  }
+  return index;
+}
+
+/** Apply AND search over whitespace-separated tokens in raw string */
+export function filterTasksBySearch(tasks: TaskInfo[], index: SearchIndex, raw: string): TaskInfo[] {
+  const q = (raw || '').trim().toLowerCase();
+  if (!q) return tasks;
+  const tokens = q.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return tasks;
+  return tasks.filter(t => {
+    const blob = index.get(t.path) || '';
+    for (const token of tokens) {
+      if (!blob.includes(token)) return false;
+    }
+    return true;
+  });
+}
+

--- a/src/bases/sorting.ts
+++ b/src/bases/sorting.ts
@@ -1,0 +1,144 @@
+import type { TaskInfo } from '../types';
+
+export interface BasesSortEntry { id: string; direction: 'ASC' | 'DESC'; }
+
+export interface BasesSortConfig {
+  entries: BasesSortEntry[];
+  // Retrieve comparable value for a given task and property id
+  getValue: (taskPath: string, propId: string) => unknown;
+}
+
+function normalizeDirection(dir: any): 'ASC' | 'DESC' {
+  const d = String(dir || 'ASC').toUpperCase();
+  return d === 'DESC' ? 'DESC' : 'ASC';
+}
+
+/** Try to coerce value to a comparison-friendly primitive */
+export function coerceForCompare(v: unknown): number | string {
+  if (v == null) return '';
+  if (Array.isArray(v)) return coerceForCompare(v[0]);
+  if (typeof v === 'number') return v;
+  if (typeof v === 'boolean') return v ? 1 : 0;
+  const s = String(v).trim();
+  // Try number
+  const num = Number(s);
+  if (!Number.isNaN(num) && s !== '') return num;
+  // Try date
+  const t = Date.parse(s);
+  if (!Number.isNaN(t)) return t;
+  return s.toLowerCase();
+}
+
+/** Build a normalization map from Bases query.properties */
+function buildPropertyIdIndex(propsMap: Record<string, any> | undefined): Map<string, string> {
+  const idIndex = new Map<string, string>();
+  if (!propsMap) return idIndex;
+  for (const id of Object.keys(propsMap)) {
+    idIndex.set(id, id);
+    const last = id.includes('.') ? id.split('.').pop()! : id;
+    idIndex.set(last, id);
+    const dn = propsMap[id]?.getDisplayName?.();
+    if (typeof dn === 'string' && dn.trim()) idIndex.set(dn.toLowerCase(), id);
+  }
+  return idIndex;
+}
+
+/**
+ * Read Bases sort configuration and produce a comparator for TaskInfo[]
+ * Supported sort tokens:
+ *  - Built-ins: file.basename, file.path, title, due, scheduled, priority
+ *  - Any property id from query.properties (note.*)
+ */
+export function getBasesSortComparator(
+  basesContainer: any,
+  pathToProps: Map<string, any>
+): ((a: TaskInfo, b: TaskInfo) => number) | null {
+  try {
+    const controller = (basesContainer?.controller ?? basesContainer) as any;
+    const query = (basesContainer?.query ?? controller?.query) as any;
+    if (!controller) return null;
+
+    const fullCfg = controller?.getViewConfig?.() ?? {};
+
+    // Extract sort configuration (array of entries)
+    let sort: any;
+    try { sort = query?.getViewConfig?.('sort'); } catch (_) {}
+    if (sort == null) sort = (fullCfg as any)?.sort;
+
+    if (!Array.isArray(sort) || sort.length === 0) return null;
+
+    const propsMap: Record<string, any> | undefined = query?.properties;
+    const idIndex = buildPropertyIdIndex(propsMap);
+
+    const normalizeToId = (token: string): string | undefined => {
+      if (!token) return undefined;
+      return idIndex.get(token) || idIndex.get(token.toLowerCase()) || token;
+    };
+
+    // Normalize entries
+    const entries: BasesSortEntry[] = [];
+    for (const entry of sort) {
+      if (!entry) continue;
+      const token = typeof entry === 'string' ? entry : (entry.property || entry.id || entry.key);
+      if (!token) continue;
+      const id = normalizeToId(String(token));
+      if (!id) continue;
+      const direction = normalizeDirection((entry as any)?.direction);
+      entries.push({ id, direction });
+    }
+    if (entries.length === 0) return null;
+
+    const getValue = (taskPath: string, propId: string): unknown => {
+      // Built-ins
+      if (propId === 'file.basename') {
+        const base = taskPath.split('/').pop() || '';
+        return base.replace(/\.md$/i, '');
+      }
+      if (propId === 'file.path') return taskPath;
+
+      // task.* fields
+      // Note: pathToProps covers note.*; we get task.* via the TaskInfo object in comparator below
+      const props = pathToProps.get(taskPath) || {};
+      if (Object.prototype.hasOwnProperty.call(props, propId)) return props[propId];
+      const last = propId.includes('.') ? propId.split('.').pop()! : propId;
+      if (Object.prototype.hasOwnProperty.call(props, last)) return props[last];
+      return undefined;
+    };
+
+    const compare = (a: TaskInfo, b: TaskInfo): number => {
+      for (const { id, direction } of entries) {
+        let va: unknown;
+        let vb: unknown;
+        switch (id) {
+          case 'title': va = a.title; vb = b.title; break;
+          case 'due': va = a.due; vb = b.due; break;
+          case 'scheduled': va = a.scheduled; vb = b.scheduled; break;
+          case 'priority': va = a.priority; vb = b.priority; break;
+          case 'file.basename':
+          case 'file.path':
+            va = getValue(a.path, id);
+            vb = getValue(b.path, id);
+            break;
+          default:
+            va = getValue(a.path, id);
+            vb = getValue(b.path, id);
+        }
+        const ca = coerceForCompare(va);
+        const cb = coerceForCompare(vb);
+        let cmp = 0;
+        if (typeof ca === 'number' && typeof cb === 'number') cmp = ca - cb;
+        else if (typeof ca === 'string' && typeof cb === 'string') cmp = ca.localeCompare(cb);
+        else cmp = String(ca).localeCompare(String(cb));
+        if (cmp !== 0) return direction === 'DESC' ? -cmp : cmp;
+      }
+      return 0;
+    };
+
+    (compare as any).__basesSortEntries = entries;
+    return compare;
+  } catch (e) {
+    console.debug('[TaskNotes][Bases] getBasesSortComparator failed:', e);
+    return null;
+  }
+}
+

--- a/src/bases/tasklist-rows.ts
+++ b/src/bases/tasklist-rows.ts
@@ -114,17 +114,19 @@ export function getTaskNotesTasklistRows(basesContainer: any, pathToProps: Map<s
     let row3Ids: string[] | undefined;
     let row4Ids: string[] | undefined;
 
-    // Debug logging (support both full config and query lookups)
-    let debug = !!(data['tasknotes.debug']
+    // Debug logging (support both full config and query lookups) but only if settings logs are enabled
+    const settingsLogsOn = !!(controller?.plugin?.settings?.basesPOCLogs);
+    let debugCfg = !!(data['tasknotes.debug']
       ?? data?.tasknotes?.debug
       ?? (fullCfg as any)['tasknotes.debug']
       ?? (fullCfg as any)?.tasknotes?.debug);
-    if (!debug) {
+    if (!debugCfg) {
       try {
-        debug = !!(query?.getViewConfig?.('tasknotes.debug')
+        debugCfg = !!(query?.getViewConfig?.('tasknotes.debug')
           ?? (query?.getViewConfig?.('tasknotes') as any)?.debug);
       } catch (_) { /* ignore */ }
     }
+    const debug = settingsLogsOn && debugCfg;
     if (debug) {
       console.debug('[TaskNotes][Bases] tasklist-rows config detected:', tn);
     }
@@ -151,17 +153,13 @@ export function getTaskNotesTasklistRows(basesContainer: any, pathToProps: Map<s
       }
     }
 
-    // Log parsed rows when logs are enabled in settings
+    // Log parsed rows when Logs are enabled in settings (only when debug config is also on)
     try {
-      const settingsLogsOn = !!(controller?.plugin?.settings?.basesPOCLogs);
-      if (settingsLogsOn) {
-        console.log('[TaskNotes][Bases] PARSED_ROWS_UNCONDITIONAL:', { row3Ids, row4Ids });
+      const settingsLogsOn2 = !!(controller?.plugin?.settings?.basesPOCLogs);
+      if (settingsLogsOn2 && debug) {
+        console.debug('[TaskNotes][Bases] Parsed rows:', { row3Ids, row4Ids });
       }
     } catch (_) { /* ignore */ }
-
-    if (debug) {
-      console.debug('[TaskNotes][Bases] Parsed rows:', { row3Ids, row4Ids });
-    }
 
     // Fallback: if no row3 configured, use Bases 'order'
     if (!row3Ids || row3Ids.length === 0) {

--- a/src/bases/tasklist-rows.ts
+++ b/src/bases/tasklist-rows.ts
@@ -1,0 +1,261 @@
+import type { TaskInfo } from '../types';
+
+// Extended property config passed to TaskCard for rendering
+export interface BasesSelectedProperty {
+  id: string;
+  displayName: string; // Bases/native display name for intelligibility in menus/filters
+  visible: boolean;
+  // TaskNotes extensions for UI rendering only (do not affect Bases internals)
+  tnLabel?: string | null; // null -> suppress label; string -> override label; undefined -> use displayName
+  tnSeparator?: string; // custom separator between label and value; default to ': '
+}
+export interface BasesRowConfig {
+  selected: BasesSelectedProperty[];
+  getValue: (taskPath: string, propId: string) => unknown;
+}
+
+export interface TasklistRows { row3?: BasesRowConfig; row4?: BasesRowConfig }
+
+function isNonEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function buildIdIndex(propsMap?: Record<string, any>): Map<string, string> {
+  const idIndex = new Map<string, string>();
+  if (!propsMap || typeof propsMap !== 'object') return idIndex;
+  for (const id of Object.keys(propsMap)) {
+    idIndex.set(id, id);
+    const last = id.includes('.') ? id.split('.').pop()! : id;
+    idIndex.set(last, id);
+    const dn = propsMap[id]?.getDisplayName?.();
+    if (typeof dn === 'string' && dn.trim()) idIndex.set(dn.toLowerCase(), id);
+  }
+  return idIndex;
+}
+
+function normalizeTokens(tokens: unknown, idIndex: Map<string, string>): string[] {
+  if (!tokens) return [];
+  const arr = Array.isArray(tokens) ? tokens : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const token of arr) {
+    let raw: string = '';
+    if (typeof token === 'string') {
+      raw = token;
+    } else if (token && typeof token === 'object') {
+      const keys = Object.keys(token as any);
+      if (keys.length === 1) raw = keys[0];
+      else raw = '';
+    } else {
+      raw = String(token || '');
+    }
+    const t = String(raw || '');
+    if (!t) continue;
+    const id = idIndex.get(t) || idIndex.get(t.toLowerCase()) || t;
+    if (!seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+function makeGetValue(pathToProps: Map<string, any>) {
+  return (taskPath: string, propId: string): unknown => {
+    const props = pathToProps.get(taskPath) || {};
+    const v = props[propId];
+    if (isNonEmpty(v)) return v;
+    const last = propId.includes('.') ? propId.split('.').pop()! : propId;
+    return props[last];
+  };
+}
+
+export function getTaskNotesTasklistRows(basesContainer: any, pathToProps: Map<string, any>): TasklistRows {
+  try {
+    const controller = (basesContainer?.controller ?? basesContainer) as any;
+    const query = (basesContainer?.query ?? controller?.query) as any;
+    if (!controller) return {};
+
+    const fullCfg = controller?.getViewConfig?.() ?? {};
+    const propsMap: Record<string, any> | undefined = query?.properties;
+    const idIndex = buildIdIndex(propsMap);
+    const getValue = makeGetValue(pathToProps);
+
+    // Diagnostic: log what Bases provides when logs are enabled in settings
+    try {
+      const settingsLogsOn = !!(controller?.plugin?.settings?.basesPOCLogs);
+      if (settingsLogsOn) {
+        console.debug('[TaskNotes][Bases] DIAGNOSTIC - fullCfg keys:', Object.keys(fullCfg));
+        console.debug('[TaskNotes][Bases] DIAGNOSTIC - fullCfg:', fullCfg);
+      }
+    } catch (_) { /* ignore */ }
+
+    // Prefer reading custom keys from fullCfg.data (as seen in your environment)
+    const data = (fullCfg as any)?.data ?? {};
+
+    // Read custom config under tasknotes.tasklist (or tasknote.tasklist)
+    // Bases may provide dotted keys under fullCfg.data
+    let tn = data['tasknotes.tasklist']
+      ?? data?.tasknotes?.tasklist
+      ?? (fullCfg as any)['tasknotes.tasklist']
+      ?? (fullCfg as any)?.tasknotes?.tasklist
+      ?? (fullCfg as any)['tasknote.tasklist']
+      ?? (fullCfg as any)?.tasknote?.tasklist;
+    if (!tn) {
+      try {
+        tn = query?.getViewConfig?.('tasknotes.tasklist')
+          ?? (query?.getViewConfig?.('tasknotes') as any)?.tasklist;
+      } catch (_) { /* ignore */ }
+    }
+
+    let row3Ids: string[] | undefined;
+    let row4Ids: string[] | undefined;
+
+    // Debug logging (support both full config and query lookups)
+    let debug = !!(data['tasknotes.debug']
+      ?? data?.tasknotes?.debug
+      ?? (fullCfg as any)['tasknotes.debug']
+      ?? (fullCfg as any)?.tasknotes?.debug);
+    if (!debug) {
+      try {
+        debug = !!(query?.getViewConfig?.('tasknotes.debug')
+          ?? (query?.getViewConfig?.('tasknotes') as any)?.debug);
+      } catch (_) { /* ignore */ }
+    }
+    if (debug) {
+      console.debug('[TaskNotes][Bases] tasklist-rows config detected:', tn);
+    }
+
+    if (tn) {
+      if (Array.isArray(tn)) {
+        // Array of objects e.g., [{ 'row.3': [...] }, { 'row.4': [...] }]
+        if (debug) console.debug('[TaskNotes][Bases] Processing array form:', tn);
+        for (const entry of tn) {
+          if (!entry || typeof entry !== 'object') continue;
+          if ((entry as any)['row.3']) row3Ids = normalizeTokens((entry as any)['row.3'], idIndex);
+          if ((entry as any)['row.4']) row4Ids = normalizeTokens((entry as any)['row.4'], idIndex);
+        }
+      } else if (typeof tn === 'object') {
+        // Object forms: { 'row.3': [...], 'row.4': [...] } or { rows: { '3': [...], '4': [...] } }
+        if (debug) console.debug('[TaskNotes][Bases] Processing object form:', tn);
+        if ((tn as any)['row.3'] || (tn as any)['row.4']) {
+          row3Ids = normalizeTokens((tn as any)['row.3'], idIndex);
+          row4Ids = normalizeTokens((tn as any)['row.4'], idIndex);
+        } else if ((tn as any).rows) {
+          row3Ids = normalizeTokens((tn as any).rows?.['3'], idIndex);
+          row4Ids = normalizeTokens((tn as any).rows?.['4'], idIndex);
+        }
+      }
+    }
+
+    // Log parsed rows when logs are enabled in settings
+    try {
+      const settingsLogsOn = !!(controller?.plugin?.settings?.basesPOCLogs);
+      if (settingsLogsOn) {
+        console.log('[TaskNotes][Bases] PARSED_ROWS_UNCONDITIONAL:', { row3Ids, row4Ids });
+      }
+    } catch (_) { /* ignore */ }
+
+    if (debug) {
+      console.debug('[TaskNotes][Bases] Parsed rows:', { row3Ids, row4Ids });
+    }
+
+    // Fallback: if no row3 configured, use Bases 'order'
+    if (!row3Ids || row3Ids.length === 0) {
+      let order: string[] | undefined;
+      try {
+        order = (query?.getViewConfig?.('order') as string[] | undefined)
+          ?? (fullCfg as any)?.order
+          ?? (fullCfg as any)?.columns?.order;
+      } catch (_) {
+        order = (fullCfg as any)?.order ?? (fullCfg as any)?.columns?.order;
+      }
+      if (Array.isArray(order)) {
+        row3Ids = normalizeTokens(order, idIndex);
+      }
+    }
+
+    const rows: TasklistRows = {};
+
+    // Helper: parse optional per-field overrides from config token
+    // Accept forms like: 'note.assignee' or { 'note.assignee': { overrideDisplayName: string|null|"", displayNameSuffix: string|null|"" } }
+    const parseToken = (token: any): { id: string; overrideDisplayName?: string | null; displayNameSuffix?: string | null } | null => {
+      if (typeof token === 'string') return { id: token };
+      if (token && typeof token === 'object') {
+        const keys = Object.keys(token);
+        if (keys.length === 1) {
+          const id = keys[0];
+          const cfg = (token as any)[id] || {};
+          return {
+            id,
+            overrideDisplayName: (cfg?.overrideDisplayName ?? undefined),
+            displayNameSuffix: (cfg?.displayNameSuffix ?? undefined)
+          };
+        }
+      }
+      return null;
+    };
+
+    // Re-parse tn to capture overrides per row
+    let row3Tokens: Array<{ id: string; overrideDisplayName?: string | null; displayNameSuffix?: string | null }> | undefined;
+    let row4Tokens: Array<{ id: string; overrideDisplayName?: string | null; displayNameSuffix?: string | null }> | undefined;
+    if (tn) {
+      const extractArray = (arrLike: any): any[] => (Array.isArray(arrLike) ? arrLike : []);
+      if (Array.isArray(tn)) {
+        for (const entry of tn) {
+          if (!entry || typeof entry !== 'object') continue;
+          if ((entry as any)['row.3']) row3Tokens = extractArray((entry as any)['row.3']).map(parseToken).filter(Boolean) as any[];
+          if ((entry as any)['row.4']) row4Tokens = extractArray((entry as any)['row.4']).map(parseToken).filter(Boolean) as any[];
+        }
+      } else if (typeof tn === 'object') {
+        if ((tn as any)['row.3'] || (tn as any)['row.4']) {
+          row3Tokens = extractArray((tn as any)['row.3']).map(parseToken).filter(Boolean) as any[];
+          row4Tokens = extractArray((tn as any)['row.4']).map(parseToken).filter(Boolean) as any[];
+        } else if ((tn as any).rows) {
+          row3Tokens = extractArray((tn as any).rows?.['3']).map(parseToken).filter(Boolean) as any[];
+          row4Tokens = extractArray((tn as any).rows?.['4']).map(parseToken).filter(Boolean) as any[];
+        }
+      }
+    }
+
+    const makeRow = (ids?: string[], tokens?: Array<{ id: string; overrideDisplayName?: string | null; displayNameSuffix?: string | null }>): BasesRowConfig | undefined => {
+      if (!ids || ids.length === 0) return undefined;
+      const tokenMap = new Map<string, { overrideDisplayName?: string | null; displayNameSuffix?: string | null }>();
+      (tokens || []).forEach(t => tokenMap.set(t.id, { overrideDisplayName: t.overrideDisplayName, displayNameSuffix: t.displayNameSuffix }));
+      const selected = ids.map(id => {
+        const baseDisplay = propsMap?.[id]?.getDisplayName?.() ?? id;
+        const overrides = tokenMap.get(id);
+        let tnLabel: string | null | undefined = undefined;
+        if (overrides && ('overrideDisplayName' in overrides)) {
+          const ov = overrides.overrideDisplayName;
+          tnLabel = (ov === '' ? null : ov);
+        }
+        let tnSeparator: string | undefined = undefined;
+        if (overrides && ('displayNameSuffix' in overrides)) {
+          const sep = overrides.displayNameSuffix;
+          tnSeparator = (sep === '' ? '' : typeof sep === 'string' ? sep : undefined);
+        }
+        return {
+          id,
+          displayName: baseDisplay,
+          visible: true,
+          tnLabel,
+          tnSeparator
+        } as BasesSelectedProperty;
+      });
+      return { selected, getValue };
+    };
+
+    rows.row3 = makeRow(row3Ids, row3Tokens);
+    rows.row4 = makeRow(row4Ids, row4Tokens);
+
+    return rows;
+  } catch (e) {
+    console.debug('[TaskNotes][Bases] getTaskNotesTasklistRows failed:', e);
+    return {};
+  }
+}
+

--- a/src/bases/view-factory.ts
+++ b/src/bases/view-factory.ts
@@ -1,7 +1,7 @@
 import TaskNotesPlugin from '../main';
 import { BasesDataItem, identifyTaskNotesFromBasesData, renderTaskNotesInBasesView } from './helpers';
 import { TaskNotesBasesTaskListComponent } from './component';
-import { setIcon, ButtonComponent, TextComponent, debounce, setTooltip } from 'obsidian';
+import { setIcon, ButtonComponent, TextComponent, debounce, setTooltip, TFile } from 'obsidian';
 import { renderTextWithLinks, appendInternalLink } from '../ui/renderers/linkRenderer';
 
 export interface BasesContainerLike {
@@ -53,6 +53,106 @@ export function buildTasknotesTaskListViewFactory(plugin: TaskNotesPlugin) {
     itemsContainer.className = 'tn-bases-items-container';
     itemsContainer.style.cssText = 'margin-top: 12px;';
     root.appendChild(itemsContainer);
+
+    /**
+     * Add "+New" button to the right side of the controls (after expand/collapse buttons)
+     */
+    const addNewTaskButton = () => {
+      // Remove any existing "+New" button first
+      controls.querySelectorAll('.filter-bar__new-task-button').forEach(el => el.remove());
+
+      const newTaskButton = new ButtonComponent(controls)
+        .setTooltip('Create new task')
+        .setClass('filter-bar__new-task-button')
+        .onClick(() => {
+          createNewTaskWithContext();
+        });
+      newTaskButton.buttonEl.addClass('clickable-icon');
+      newTaskButton.buttonEl.addClass('has-text-icon');
+
+      // Clear any existing content and build manually
+      newTaskButton.buttonEl.empty();
+
+      // Add icon
+      const iconEl = newTaskButton.buttonEl.createSpan({ cls: 'button-icon' });
+      setIcon(iconEl, 'plus');
+
+      // Add text
+      const textEl = newTaskButton.buttonEl.createSpan({ cls: 'button-text', text: 'New' });
+    };
+
+    /**
+     * Context-aware task creation based on workspace position
+     */
+    const createNewTaskWithContext = () => {
+      try {
+        // Detect workspace position and determine context
+        const context = detectWorkspaceContext();
+
+        if (context.isInSidebar) {
+          // Sidebar mode: Use active file as project context
+          const activeFile = plugin.app.workspace.getActiveFile();
+          if (activeFile) {
+            const projectReference = `[[${activeFile.basename}]]`;
+            plugin.openTaskCreationModal({
+              projects: [projectReference]
+            });
+          } else {
+            // No active file, create standalone task
+            plugin.openTaskCreationModal();
+          }
+        } else {
+          // Main content mode: Create standalone task
+          // TODO: In the future, we could use the base file itself as context
+          plugin.openTaskCreationModal();
+        }
+      } catch (error) {
+        console.error('[TaskNotes][Bases] Error creating new task:', error);
+        // Fallback to basic task creation
+        plugin.openTaskCreationModal();
+      }
+    };
+
+    /**
+     * Detect if the Bases view is in sidebar vs main content area
+     */
+    const detectWorkspaceContext = () => {
+      try {
+        // Try to find the workspace leaf containing this view
+        const workspace = plugin.app.workspace;
+        let currentLeaf = null;
+
+        // Search through all leaves to find the one containing our view
+        workspace.iterateAllLeaves((leaf) => {
+          if (leaf.view && leaf.view.containerEl &&
+              leaf.view.containerEl.contains(viewContainerEl)) {
+            currentLeaf = leaf;
+          }
+        });
+
+        if (!currentLeaf) {
+          // Fallback: assume main content if we can't determine
+          return { isInSidebar: false, leaf: null };
+        }
+
+        // Check if the leaf is in a sidebar by examining its parent structure
+        const leafEl = currentLeaf.containerEl;
+        const isInLeftSidebar = leafEl.closest('.workspace-split.mod-left-split') !== null;
+        const isInRightSidebar = leafEl.closest('.workspace-split.mod-right-split') !== null;
+        const isInSidebar = isInLeftSidebar || isInRightSidebar;
+
+        return {
+          isInSidebar,
+          isInLeftSidebar,
+          isInRightSidebar,
+          leaf: currentLeaf
+        };
+      } catch (error) {
+        console.error('[TaskNotes][Bases] Error detecting workspace context:', error);
+        // Safe fallback
+        return { isInSidebar: false, leaf: null };
+      }
+    };
 
     // Helper to extract items from Bases results
     const extractDataItems = (): BasesDataItem[] => {
@@ -316,6 +416,9 @@ export function buildTasknotesTaskListViewFactory(plugin: TaskNotesPlugin) {
                 }
                 GroupingUtils.collapseAllGroups(BASES_TASK_LIST_VIEW_TYPE, groupingKeyForButtons, names, plugin);
               });
+
+              // Add "+New" button after expand/collapse buttons
+              addNewTaskButton();
             } catch (_) { /* ignore */ }
           } else {
             // No groupBy configured -> flat list, but still apply Bases sort if present
@@ -323,6 +426,9 @@ export function buildTasknotesTaskListViewFactory(plugin: TaskNotesPlugin) {
             const cmp = getBasesSortComparator(basesContainer as any, pathToProps);
             const toRender = cmp ? [...searchedTasks].sort(cmp) : searchedTasks;
             await renderTaskNotesInBasesView(itemsContainer, toRender, plugin, { extraPropertiesRows: extraRows as any });
+
+            // Add "+New" button for flat list view
+            addNewTaskButton();
           }
         }
       } catch (error: any) {

--- a/src/bases/view-factory.ts
+++ b/src/bases/view-factory.ts
@@ -76,6 +76,15 @@ export function buildTasknotesTaskListViewFactory(plugin: TaskNotesPlugin) {
       if (!currentRoot) return;
       try {
         const dataItems = extractDataItems();
+        try {
+          if (plugin.settings?.basesAdvancedDataLogs) {
+            const raw = Array.from(((basesContainer as any)?.results as Map<any, any> | undefined)?.entries?.() || []);
+            console.log('[TaskNotes][Bases][ADVANCED-DUMP]', {
+              size: (basesContainer as any)?.results instanceof Map ? (basesContainer as any).results.size : undefined,
+              results: raw
+            });
+          }
+        } catch (_) { /* ignore */ }
         const taskNotes = await identifyTaskNotesFromBasesData(dataItems);
 
         // Clear previous expand/collapse buttons (keep search input)

--- a/src/bases/view-factory.ts
+++ b/src/bases/view-factory.ts
@@ -1,0 +1,348 @@
+import TaskNotesPlugin from '../main';
+import { BasesDataItem, identifyTaskNotesFromBasesData, renderTaskNotesInBasesView } from './helpers';
+import { TaskNotesBasesTaskListComponent } from './component';
+import { setIcon, ButtonComponent, TextComponent, debounce, setTooltip } from 'obsidian';
+import { renderTextWithLinks, appendInternalLink } from '../ui/renderers/linkRenderer';
+
+export interface BasesContainerLike {
+  results?: Map<any, any>;
+  query?: { on?: (event: string, cb: () => void) => void; off?: (event: string, cb: () => void) => void };
+  viewContainerEl?: HTMLElement;
+}
+
+export function buildTasknotesTaskListViewFactory(plugin: TaskNotesPlugin) {
+  return function tasknotesTaskListViewFactory(basesContainer: BasesContainerLike) {
+    let currentRoot: HTMLElement | null = null;
+
+    // Guard
+    const viewContainerEl = (basesContainer as any)?.viewContainerEl as HTMLElement | undefined;
+    if (!viewContainerEl) {
+      console.error('[TaskNotes][BasesPOC] No viewContainerEl found');
+      return { destroy: () => {} } as any;
+    }
+
+    // Ensure clean container
+    viewContainerEl.innerHTML = '';
+
+    // Root container for TaskNotes view
+    const root = document.createElement('div');
+    root.className = 'tn-bases-integration tasknotes-plugin tasknotes-container';
+    viewContainerEl.appendChild(root);
+    currentRoot = root;
+
+
+    // Controls container (top bar) - mimic FilterBar expand/collapse buttons
+    const controls = document.createElement('div');
+    controls.className = 'filter-bar__top-controls';
+    root.appendChild(controls);
+
+    // Add search input (ephemeral in-memory filtering)
+    let currentSearchTerm = '';
+    const searchInput = new TextComponent(controls)
+      .setPlaceholder('Search path | title | aliases');
+    searchInput.inputEl.addClass('filter-bar__search-input');
+    setTooltip(searchInput.inputEl, 'Quick search (ephemeral)', { placement: 'top' } as any);
+
+    const triggerSearch = debounce(() => {
+      currentSearchTerm = searchInput.getValue();
+      void render();
+    }, 800);
+    searchInput.onChange(() => triggerSearch());
+
+    const itemsContainer = document.createElement('div');
+    itemsContainer.className = 'tn-bases-items-container';
+    itemsContainer.style.cssText = 'margin-top: 12px;';
+    root.appendChild(itemsContainer);
+
+    // Helper to extract items from Bases results
+    const extractDataItems = (): BasesDataItem[] => {
+      const dataItems: BasesDataItem[] = [];
+      const results = (basesContainer as any)?.results as Map<any, any> | undefined;
+      if (results && results instanceof Map) {
+        for (const [key, value] of results.entries()) {
+          dataItems.push({
+            key,
+            data: value,
+            file: (value as any)?.file,
+            path: (value as any)?.file?.path || (value as any)?.path,
+            properties: (value as any)?.properties || (value as any)?.frontmatter
+          });
+        }
+      }
+      return dataItems;
+    };
+
+    const render = async () => {
+      if (!currentRoot) return;
+      try {
+        const dataItems = extractDataItems();
+        const taskNotes = await identifyTaskNotesFromBasesData(dataItems);
+
+        // Clear previous expand/collapse buttons (keep search input)
+        controls.querySelectorAll('.filter-bar__expand-groups, .filter-bar__collapse-groups').forEach(el => el.remove());
+
+        // Render body
+        itemsContainer.innerHTML = '';
+        if (taskNotes.length === 0) {
+          const emptyEl = document.createElement('div');
+          emptyEl.className = 'tn-bases-empty';
+          emptyEl.style.cssText = 'padding: 20px; text-align: center; color: #666;';
+
+          const emptyTitle = document.createElement('p');
+          emptyTitle.textContent = 'No TaskNotes tasks found for this Base.';
+          emptyTitle.style.cssText = 'margin: 0 0 10px 0; font-weight: 500;';
+          emptyEl.appendChild(emptyTitle);
+
+          const emptyDesc = document.createElement('p');
+          emptyDesc.textContent = 'TaskNotes are identified by files with task-related frontmatter properties.';
+          emptyDesc.style.cssText = 'margin: 0; font-size: 0.9em; opacity: 0.7;';
+          emptyEl.appendChild(emptyDesc);
+
+          itemsContainer.appendChild(emptyEl);
+        } else {
+          // Build a map from task path to its properties/frontmatter for property value resolution
+          const pathToProps = new Map<string, Record<string, any>>(
+            dataItems.filter(i => !!i.path).map(i => [i.path!, (i as any).properties || (i as any).frontmatter || {}])
+          );
+
+          // Compute TaskNotes Task Card property rows from Bases view config
+          const { getTaskNotesTasklistRows } = await import('./tasklist-rows');
+          const rows = getTaskNotesTasklistRows(basesContainer as any, pathToProps);
+          let extraRows = [rows.row3, rows.row4].filter(Boolean) as any[];
+          try {
+            const settingsLogsOn = !!((plugin as any)?.settings?.basesPOCLogs);
+            if (settingsLogsOn) {
+              console.log('[TaskNotes][Bases] EXTRA_ROWS_UNCONDITIONAL:', {
+                count: extraRows.length,
+                row3: rows.row3?.selected?.map(s => s.id),
+                row4: rows.row4?.selected?.map(s => s.id)
+              });
+            }
+          } catch (_) { /* ignore */ }
+          // Backward-compatible fallback: use 'order' as single row if custom config absent
+          if (extraRows.length === 0) {
+            const { getBasesPropertyRowConfig } = await import('./property-selection');
+            const fallback = getBasesPropertyRowConfig(basesContainer as any, pathToProps) || undefined;
+            if (fallback) extraRows = [fallback] as any[];
+          }
+
+          // In-memory search filter (ephemeral)
+          const { buildSearchIndex, filterTasksBySearch } = await import('./search');
+          const getAliases = (p: string): string[] => {
+            const props = pathToProps.get(p) || {};
+            const v = props['note.aliases'] ?? props['aliases'];
+            if (Array.isArray(v)) return v.filter((x: any) => !!x).map(String);
+            if (typeof v === 'string' && v.trim()) return [v];
+            return [];
+          };
+          const searchIndex = buildSearchIndex(taskNotes, { getAliases });
+          const searchedTasks = filterTasksBySearch(taskNotes, searchIndex, currentSearchTerm);
+
+          // Attempt to read Bases native groupBy configuration
+          const { getBasesGroupByConfig } = await import('./group-by');
+          const groupCfg = getBasesGroupByConfig(basesContainer as any, pathToProps);
+
+          if (groupCfg) {
+            // Sort tasks using Bases view sort settings if available
+            const { getBasesSortComparator } = await import('./sorting');
+            const cmp = getBasesSortComparator(basesContainer as any, pathToProps);
+            const tasksForGrouping = cmp ? [...searchedTasks].sort(cmp) : searchedTasks;
+
+            const groups = new Map<string, typeof taskNotes>();
+            for (const t of tasksForGrouping) {
+              const values = groupCfg.getGroupValues(t.path) || ['none'];
+              for (const v of values) {
+                const key = String(v ?? 'none');
+                if (!groups.has(key)) groups.set(key, []);
+                groups.get(key)!.push(t);
+              }
+            }
+
+            // Order group headings: if first sort key matches the same domain, use its direction; else alphabetical
+            let groupNames = Array.from(groups.keys());
+            if (cmp && (cmp as any).__basesSortEntries && (cmp as any).__basesSortEntries.length > 0) {
+              const first = (cmp as any).__basesSortEntries[0];
+              const { getGroupNameComparator } = await import('./group-ordering');
+              groupNames = groupNames.sort(getGroupNameComparator(first));
+            } else {
+              groupNames = groupNames.sort((a, b) => a.localeCompare(b));
+            }
+
+            // Utilities for count and collapsed state
+            const { GroupCountUtils } = await import('../utils/GroupCountUtils');
+            const { GroupingUtils } = await import('../utils/GroupingUtils');
+            const { BASES_TASK_LIST_VIEW_TYPE } = await import('../types');
+            const groupingKey = `bases:${groupCfg.normalizedId}`;
+
+            const groupSections: HTMLElement[] = [];
+            for (const groupName of groupNames) {
+              const tasks = groups.get(groupName)!;
+              if (!tasks.length) continue;
+
+              const section = document.createElement('section');
+              section.className = 'task-section task-group';
+              section.setAttribute('data-group', groupName);
+
+              // Header
+              const header = document.createElement('h3');
+              header.className = 'task-group-header task-list-view__group-header';
+
+              const toggleBtn = document.createElement('button');
+              toggleBtn.className = 'task-group-toggle';
+              toggleBtn.setAttribute('aria-label', 'Toggle group');
+              try {
+                setIcon(toggleBtn, 'chevron-right');
+                const svg = toggleBtn.querySelector('svg');
+                if (svg) { svg.classList.add('chevron'); svg.setAttribute('width', '16'); svg.setAttribute('height', '16'); }
+              } catch (_) {
+                toggleBtn.textContent = '▸';
+              }
+              header.appendChild(toggleBtn);
+
+              const labelSpan = document.createElement('span');
+              labelSpan.className = 'tn-bases-group-label';
+
+              // Render wikilinks/markdown links clickable in group names (Text/List props)
+              // If the rendered result has no anchors, fall back to plain text
+              renderTextWithLinks(labelSpan, groupName, { metadataCache: plugin.app.metadataCache, workspace: plugin.app.workspace });
+              if (labelSpan.querySelectorAll('a').length === 0) {
+                labelSpan.textContent = groupName;
+              }
+              header.appendChild(labelSpan);
+
+              // Count
+              const stats = GroupCountUtils.calculateGroupStats(tasks, plugin);
+              const countSpan = document.createElement('span');
+              countSpan.className = 'agenda-view__item-count';
+              countSpan.textContent = ` ${GroupCountUtils.formatGroupCount(stats.completed, stats.total).text}`;
+              header.appendChild(countSpan);
+
+              section.appendChild(header);
+
+              // List container
+              const list = document.createElement('div');
+              list.className = 'tasks-container task-cards';
+              section.appendChild(list);
+
+              // Collapsed state
+              const collapsedInitially = GroupingUtils.isGroupCollapsed(
+                BASES_TASK_LIST_VIEW_TYPE,
+                groupingKey,
+                groupName,
+                plugin
+              );
+              if (collapsedInitially) {
+                section.classList.add('is-collapsed');
+                list.style.display = 'none';
+              }
+              toggleBtn.setAttribute('aria-expanded', String(!collapsedInitially));
+
+              // Toggle behavior
+              const toggle = () => {
+                const willCollapse = !section.classList.contains('is-collapsed');
+                GroupingUtils.setGroupCollapsed(BASES_TASK_LIST_VIEW_TYPE, groupingKey, groupName, willCollapse, plugin);
+                section.classList.toggle('is-collapsed', willCollapse);
+                list.style.display = willCollapse ? 'none' : '';
+                toggleBtn.setAttribute('aria-expanded', String(!willCollapse));
+              };
+              header.addEventListener('click', (e) => {
+                const target = e.target as HTMLElement;
+                if (target.closest('a')) return; // ignore internal link clicks
+                toggle();
+              });
+              toggleBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                toggle();
+              });
+
+              // Render tasks for this group using existing helper
+              await renderTaskNotesInBasesView(list, tasks, plugin, { extraPropertiesRows: extraRows as any });
+
+              itemsContainer.appendChild(section);
+              groupSections.push(section);
+            }
+
+            // After creating all groups, add expand/collapse all buttons matching Task List behavior
+            try {
+              const { GroupingUtils } = await import('../utils/GroupingUtils');
+              const { BASES_TASK_LIST_VIEW_TYPE } = await import('../types');
+              const groupingKeyForButtons = `bases:${groupCfg.normalizedId}`;
+
+              // Expand All button
+              const expandAllBtn = new ButtonComponent(controls)
+                .setIcon('list-tree')
+                .setTooltip('Expand All Groups')
+                .setClass('filter-bar__expand-groups');
+              (expandAllBtn as any).buttonEl.classList.add('clickable-icon');
+              expandAllBtn.onClick(() => {
+                for (const section of groupSections) {
+                  section.classList.remove('is-collapsed');
+                  const list = section.querySelector('.task-cards') as HTMLElement | null;
+                  if (list) list.style.display = '';
+                  const name = section.getAttribute('data-group') || '';
+                  GroupingUtils.setGroupCollapsed(BASES_TASK_LIST_VIEW_TYPE, groupingKeyForButtons, name, false, plugin);
+                  const btn = section.querySelector('.task-group-toggle');
+                  btn?.setAttribute('aria-expanded', 'true');
+                }
+              });
+
+              // Collapse All button
+              const collapseAllBtn = new ButtonComponent(controls)
+                .setIcon('list-collapse')
+                .setTooltip('Collapse All Groups')
+                .setClass('filter-bar__collapse-groups');
+              (collapseAllBtn as any).buttonEl.classList.add('clickable-icon');
+              collapseAllBtn.onClick(() => {
+                const names = groupSections.map(s => s.getAttribute('data-group') || '');
+                for (const section of groupSections) {
+                  const list = section.querySelector('.task-cards') as HTMLElement | null;
+                  const hasTasks = !!list && list.children.length > 0;
+                  if (hasTasks) {
+                    section.classList.add('is-collapsed');
+                    if (list) list.style.display = 'none';
+                    const btn = section.querySelector('.task-group-toggle');
+                    btn?.setAttribute('aria-expanded', 'false');
+                  }
+                }
+                GroupingUtils.collapseAllGroups(BASES_TASK_LIST_VIEW_TYPE, groupingKeyForButtons, names, plugin);
+              });
+            } catch (_) { /* ignore */ }
+          } else {
+            // No groupBy configured -> flat list, but still apply Bases sort if present
+            const { getBasesSortComparator } = await import('./sorting');
+            const cmp = getBasesSortComparator(basesContainer as any, pathToProps);
+            const toRender = cmp ? [...searchedTasks].sort(cmp) : searchedTasks;
+            await renderTaskNotesInBasesView(itemsContainer, toRender, plugin, { extraPropertiesRows: extraRows as any });
+          }
+        }
+      } catch (error: any) {
+        console.error('[TaskNotes][BasesPOC] Error rendering Bases data:', error);
+        const errorEl = document.createElement('div');
+        errorEl.className = 'tn-bases-error';
+        errorEl.style.cssText = 'padding: 20px; color: #d73a49; background: #ffeaea; border-radius: 4px; margin: 10px 0;';
+        root.appendChild(errorEl);
+      }
+    };
+
+    // Build component with lifecycle hooks
+    const component = new TaskNotesBasesTaskListComponent({
+      getContainer: () => currentRoot,
+      setContainer: (el) => { currentRoot = el; },
+      refresh: render,
+      attachQueryListener: (handler) => (basesContainer as any)?.query?.on?.('change', handler),
+      detachQueryListener: (handler) => (basesContainer as any)?.query?.off?.('change', handler)
+    });
+
+    // Add Bases lifecycle shims
+    (component as any).load = component.onload.bind(component);
+    (component as any).unload = component.onunload.bind(component);
+    // Do not override onResize; use class method
+
+    // Kick off initial async render
+    void render();
+
+    return component as any;
+  };
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -273,8 +273,17 @@ export default class TaskNotesPlugin extends Plugin {
 		this.migrationPromise = this.performEarlyMigrationCheck();
 
 		// Defer expensive initialization until layout is ready
-		this.app.workspace.onLayoutReady(() => {
+		this.app.workspace.onLayoutReady(async () => {
 			this.initializeAfterLayoutReady();
+			// Experimental: register Bases integrations when feature flag enabled
+			try {
+				if (this.settings?.enableBasesPOC) {
+					const { registerBasesTaskList } = await import('./bases/registration');
+					await registerBasesTaskList(this);
+				}
+			} catch (e) {
+				console.warn('[TaskNotes][Bases] Registration failed:', e);
+			}
 		});
 
 		// At the very end of onload, resolve the promise to signal readiness

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -243,5 +243,8 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 		'tags'         // Tags
 	],
 	// Recurring task behavior defaults
-	maintainDueDateOffsetInRecurring: false
+	maintainDueDateOffsetInRecurring: false,
+	// Experimental Bases POC gating and logs (default off)
+	enableBasesPOC: false,
+	basesPOCLogs: false
 };

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -246,5 +246,6 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	maintainDueDateOffsetInRecurring: false,
 	// Experimental Bases POC gating and logs (default off)
 	enableBasesPOC: false,
-	basesPOCLogs: false
+	basesPOCLogs: false,
+	basesAdvancedDataLogs: false
 };

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1671,6 +1671,27 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 			cls: 'settings-help-note'
 		});
 
+		// Experimental / Bases POC
+		new Setting(container).setName('Experimental / Bases POC').setHeading();
+		new Setting(container)
+			.setName('Enable Bases integration (POC)')
+			.setDesc('Registers TaskNotes views with Obsidian Bases when the Bases plugin is available. Default off.')
+			.addToggle(toggle => toggle
+				.setValue(!!this.plugin.settings.enableBasesPOC)
+				.onChange(async (value) => {
+					this.plugin.settings.enableBasesPOC = value;
+					await this.plugin.saveSettings();
+				}));
+		new Setting(container)
+			.setName('Enable Bases POC logs')
+			.setDesc('Log extra diagnostics to console for Bases integration components')
+			.addToggle(toggle => toggle
+				.setValue(!!this.plugin.settings.basesPOCLogs)
+				.onChange(async (value) => {
+					this.plugin.settings.basesPOCLogs = value;
+					await this.plugin.saveSettings();
+				}));
+
 		// Status bar toggle
 		new Setting(container)
 			.setName('Show tracked tasks in status bar')

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1691,6 +1691,15 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 					this.plugin.settings.basesPOCLogs = value;
 					await this.plugin.saveSettings();
 				}));
+		new Setting(container)
+			.setName('Enable advanced Bases data logs')
+			.setDesc('Dump full Bases results (metadata, properties, formulas) to console for inspection. WARNING: verbose')
+			.addToggle(toggle => toggle
+				.setValue(!!this.plugin.settings.basesAdvancedDataLogs)
+				.onChange(async (value) => {
+					this.plugin.settings.basesAdvancedDataLogs = value;
+					await this.plugin.saveSettings();
+				}));
 
 		// Status bar toggle
 		new Setting(container)

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export const POMODORO_STATS_VIEW_TYPE = 'tasknotes-pomodoro-stats-view';
 export const STATS_VIEW_TYPE = 'tasknotes-stats-view';
 export const KANBAN_VIEW_TYPE = 'tasknotes-kanban-view';
 export const SUBTASK_WIDGET_VIEW_TYPE = 'tasknotes-subtask-widget-view';
+// Experimental Bases Task List view type (unofficial)
+export const BASES_TASK_LIST_VIEW_TYPE = 'tasknotes-bases-task-list-view';
 
 // Event types
 export const EVENT_DATE_SELECTED = 'date-selected';

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -105,6 +105,9 @@ export interface TaskNotesSettings {
 	defaultVisibleProperties?: string[];
 	// Recurring task behavior
 	maintainDueDateOffsetInRecurring: boolean;
+	// Experimental Bases POC (default false; optional in persisted data)
+	enableBasesPOC?: boolean;
+	basesPOCLogs?: boolean;
 }
 
 export interface DefaultReminder {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -108,6 +108,7 @@ export interface TaskNotesSettings {
 	// Experimental Bases POC (default false; optional in persisted data)
 	enableBasesPOC?: boolean;
 	basesPOCLogs?: boolean;
+	basesAdvancedDataLogs?: boolean;
 }
 
 export interface DefaultReminder {

--- a/src/ui/renderers/linkRenderer.ts
+++ b/src/ui/renderers/linkRenderer.ts
@@ -1,0 +1,136 @@
+// Link and tag rendering utilities for UI components
+
+import { App, TFile } from 'obsidian';
+
+/** Minimal services required to render internal links (DI-friendly) */
+export interface LinkServices {
+  metadataCache: App['metadataCache'];
+  workspace: App['workspace'];
+}
+
+const LINK_REGEX = /\[\[([^\[\]]+)\]\]|\[([^\]]+)\]\(([^)]+)\)/g;
+
+/** Append an Obsidian internal link element with hover and open behaviors */
+export function appendInternalLink(
+  container: HTMLElement,
+  filePath: string,
+  displayText: string,
+  deps: LinkServices
+): void {
+  const linkEl = container.createEl('a', {
+    cls: 'internal-link',
+    text: displayText,
+    attr: {
+      'data-href': filePath,
+      'role': 'link',
+      'tabindex': '0'
+    }
+  });
+
+  linkEl.addEventListener('click', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      const file = deps.metadataCache.getFirstLinkpathDest(filePath, '');
+      if (file instanceof TFile) {
+        await deps.workspace.getLeaf(false).openFile(file);
+      }
+    } catch (error) {
+      console.error('[TaskNotes] Error opening internal link:', { filePath, error });
+    }
+  });
+
+  linkEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      (linkEl as HTMLElement).click();
+    }
+  });
+
+  linkEl.addEventListener('mouseover', (event) => {
+    const file = deps.metadataCache.getFirstLinkpathDest(filePath, '');
+    if (file instanceof TFile) {
+      deps.workspace.trigger('hover-link', {
+        event,
+        source: 'tasknotes-property-link',
+        hoverParent: container,
+        targetEl: linkEl,
+        linktext: filePath,
+        sourcePath: file.path
+      } as any);
+    }
+  });
+}
+
+/** Render a text string, converting WikiLinks and Markdown links */
+export interface RenderLinksOptions {
+  renderPlain?: (container: HTMLElement, text: string, deps: LinkServices) => void;
+}
+
+export function renderTextWithLinks(
+  container: HTMLElement,
+  text: string,
+  deps: LinkServices,
+  options?: RenderLinksOptions
+): void {
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = LINK_REGEX.exec(text)) !== null) {
+    const [full, wikiInner, mdText, mdHref] = match as any;
+    const start = match.index;
+
+    if (start > lastIndex) {
+      container.appendChild(document.createTextNode(text.slice(lastIndex, start)));
+    }
+
+    if (wikiInner) {
+      const content = wikiInner;
+      let filePath = content;
+      let displayText = content;
+      if (content.includes('|')) {
+        const [fp, alias] = content.split('|');
+        filePath = fp;
+        displayText = alias;
+      }
+      appendInternalLink(container, filePath, displayText, deps);
+    } else if (mdText && mdHref) {
+      const href = String(mdHref).trim();
+      const disp = String(mdText).trim();
+      if (/^[a-z]+:\/\//i.test(href)) {
+        const a = container.createEl('a', { text: disp, attr: { href, target: '_blank', rel: 'noopener' } });
+        a.classList.add('external-link');
+      } else {
+        appendInternalLink(container, href, disp, deps);
+      }
+    }
+
+    lastIndex = start + full.length;
+  }
+
+  if (lastIndex < text.length) {
+    container.appendChild(document.createTextNode(text.slice(lastIndex)));
+  }
+}
+
+/** Render a value (string or string[]) with link support */
+export function renderValueWithLinks(
+  container: HTMLElement,
+  value: unknown,
+  deps: LinkServices
+): void {
+  if (typeof value === 'string') {
+    renderTextWithLinks(container, value, deps);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, idx) => {
+      if (idx > 0) container.appendChild(document.createTextNode(', '));
+      if (typeof item === 'string') renderTextWithLinks(container, item, deps);
+      else container.appendChild(document.createTextNode(String(item)));
+    });
+    return;
+  }
+  container.appendChild(document.createTextNode(String(value)));
+}
+

--- a/src/ui/renderers/tagRenderer.ts
+++ b/src/ui/renderers/tagRenderer.ts
@@ -1,0 +1,41 @@
+// Tag rendering utilities following TaskNotes coding standards
+
+/** Render a single tag string as an Obsidian-like tag element */
+export function renderTag(container: HTMLElement, tag: string): void {
+  if (!tag || typeof tag !== 'string') return;
+
+  const normalized = normalizeTag(tag);
+  if (!normalized) return;
+
+  const el = container.createEl('a', {
+    cls: 'tag',
+    text: normalized,
+    attr: { 'href': normalized }
+  });
+}
+
+/** Render a list or single tag value into a container */
+export function renderTagsValue(container: HTMLElement, value: unknown): void {
+  if (typeof value === 'string') {
+    renderTag(container, value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((t, idx) => {
+      if (idx > 0) container.appendChild(document.createTextNode(' '));
+      renderTag(container, String(t));
+    });
+    return;
+  }
+  // Fallback: not a recognizable tag value
+  if (value != null) container.appendChild(document.createTextNode(String(value)));
+}
+
+/** Normalize arbitrary tag strings into #tag form */
+export function normalizeTag(raw: string): string | null {
+  const s = raw.trim();
+  if (!s) return null;
+  if (s.startsWith('#')) return s;
+  return `#${s}`;
+}
+

--- a/src/views/BasesTaskListView.ts
+++ b/src/views/BasesTaskListView.ts
@@ -1,0 +1,41 @@
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import TaskNotesPlugin from '../main';
+import { BASES_TASK_LIST_VIEW_TYPE } from '../types';
+
+export class BasesTaskListView extends ItemView {
+  constructor(leaf: WorkspaceLeaf, private plugin: TaskNotesPlugin) {
+    super(leaf);
+  }
+
+  getViewType(): string {
+    return BASES_TASK_LIST_VIEW_TYPE;
+  }
+
+  getDisplayText(): string {
+    return 'TaskNotes Task List';
+  }
+
+  getIcon(): string {
+    return 'check-square';
+  }
+
+  async onOpen() {
+    const container = this.containerEl.children[1] as HTMLElement;
+    container.empty();
+    const root = container.createDiv({ cls: 'tn-bases-task-list' });
+
+    root.createEl('h4', { text: 'TaskNotes Task List' });
+    const ul = root.createEl('ul', { cls: 'tn-bases-task-list-items' });
+    ['Sample Task A', 'Sample Task B', 'Sample Task C'].forEach(t => {
+      const li = ul.createEl('li');
+      const cb = li.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
+      cb.disabled = true;
+      li.createSpan({ text: ' ' + t });
+    });
+  }
+
+  async onClose() {
+    // no-op
+  }
+}
+

--- a/tests/unit/bases/agenda-view.factory.test.ts
+++ b/tests/unit/bases/agenda-view.factory.test.ts
@@ -1,0 +1,152 @@
+import { buildTasknotesAgendaViewFactory } from '../../../src/bases/agenda-view';
+
+// Stub TaskCard to avoid complex dependencies in unit test
+jest.mock('../../../src/ui/TaskCard', () => ({
+  createTaskCard: (task: any) => {
+    const el = document.createElement('div');
+    el.className = 'task-card';
+    el.setAttribute('data-task-path', task.path);
+    el.textContent = task.title || '';
+    return el;
+  },
+  DEFAULT_TASK_CARD_OPTIONS: {}
+}));
+
+// Mock helpers to simplify data flow
+jest.mock('../../../src/bases/helpers', () => {
+  const actual = jest.requireActual('../../../src/bases/helpers');
+  return {
+    ...actual,
+    identifyTaskNotesFromBasesData: async (dataItems: any[]) => dataItems.map(i => ({
+      path: i.path,
+      title: i.properties?.title || 'Untitled',
+      status: i.properties?.status || 'open',
+      priority: i.properties?.priority || 'normal',
+      due: i.properties?.due,
+      scheduled: i.properties?.scheduled,
+      archived: false
+    })),
+    renderTaskNotesInBasesView: async (container: HTMLElement, taskNotes: any[]) => {
+      const list = document.createElement('div');
+      list.className = 'tn-bases-tasknotes-list';
+      taskNotes.forEach((t) => {
+        const el = document.createElement('div');
+        el.className = 'task-card';
+        el.setAttribute('data-task-path', t.path);
+        el.textContent = t.title || '';
+        list.appendChild(el);
+      });
+      container.appendChild(list);
+    }
+  };
+});
+
+function makePlugin() {
+  return {
+    app: { metadataCache: {}, workspace: {} },
+    settings: { basesPOCLogs: false },
+    // Selected date drives Agenda date range
+    selectedDate: '2025-01-01',
+    statusManager: {
+      getAllStatuses: () => [{ value: 'open' }, { value: 'done' }],
+      isCompletedStatus: (s: string) => s === 'done'
+    },
+    priorityManager: {
+      getAllPriorities: () => [{ value: 'low' }, { value: 'normal' }, { value: 'high' }]
+    },
+    viewStateManager: {
+      getViewPreferences: jest.fn(() => ({})),
+      setViewPreferences: jest.fn()
+    }
+  } as any;
+}
+
+function makeBasesContainer(items: any[], cfg: any = {}) {
+  const results = new Map<any, any>();
+  items.forEach((it, i) => results.set(i, it));
+  const query = { properties: cfg.properties || {}, getViewConfig: (k?: string) => (k ? cfg[k] : cfg) } as any;
+  return { results, query, viewContainerEl: document.createElement('div'), controller: { getViewConfig: () => cfg, query } } as any;
+}
+
+describe('buildTasknotesAgendaViewFactory (Bases)', () => {
+  it('renders day groups based on due/scheduled dates with counts', async () => {
+    const plugin = makePlugin();
+    const items = [
+      { file: { path: '/a.md' }, properties: { due: '2025-01-01', title: 'Alpha' } },
+      { file: { path: '/b.md' }, properties: { due: '2025-01-02', title: 'Bravo' } },
+      { file: { path: '/c.md' }, properties: { scheduled: '2025-01-01', title: 'Charlie' } }
+    ];
+    const bases = makeBasesContainer(items, {});
+
+    const factory = buildTasknotesAgendaViewFactory(plugin);
+    factory(bases);
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const container = (bases.viewContainerEl as HTMLElement);
+    const headers = Array.from(container.querySelectorAll('.task-group-header .tn-bases-group-label')).map(el => el.textContent || '');
+    expect(headers.sort()).toEqual(['2025-01-01', '2025-01-02']);
+
+    const counts = Array.from(container.querySelectorAll('.agenda-view__item-count')).map(el => el.textContent || '');
+    expect(counts.length).toBeGreaterThan(0);
+    expect(counts.join(' ')).toMatch(/\d+ \/ \d+/);
+  });
+
+  it('supports expand/collapse all groups controls', async () => {
+    const plugin = makePlugin();
+    const items = [
+      { file: { path: '/a.md' }, properties: { due: '2025-01-01', title: 'Alpha' } },
+      { file: { path: '/b.md' }, properties: { due: '2025-01-02', title: 'Bravo' } }
+    ];
+    const bases = makeBasesContainer(items, {});
+
+    const factory = buildTasknotesAgendaViewFactory(plugin);
+    factory(bases);
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const container = (bases.viewContainerEl as HTMLElement);
+    const collapseAll = container.querySelector('.filter-bar__collapse-groups') as HTMLElement;
+    expect(collapseAll).toBeTruthy();
+    collapseAll.dispatchEvent(new Event('click'));
+
+    await new Promise(r => setTimeout(r, 0));
+
+    const sections = Array.from(container.querySelectorAll('.task-section.task-group')) as HTMLElement[];
+    expect(sections.every(s => s.classList.contains('is-collapsed'))).toBe(true);
+
+    const expandAll = container.querySelector('.filter-bar__expand-groups') as HTMLElement;
+    expect(expandAll).toBeTruthy();
+    expandAll.dispatchEvent(new Event('click'));
+    await new Promise(r => setTimeout(r, 0));
+    expect(sections.every(s => !s.classList.contains('is-collapsed'))).toBe(true);
+  });
+
+  it('filters tasks by search term across day groups', async () => {
+    const plugin = makePlugin();
+    const items = [
+      { file: { path: '/a.md' }, properties: { due: '2025-01-01', title: 'Alpha' } },
+      { file: { path: '/b.md' }, properties: { due: '2025-01-01', title: 'Bravo' } },
+      { file: { path: '/c.md' }, properties: { due: '2025-01-02', title: 'Charlie' } }
+    ];
+    const bases = makeBasesContainer(items, {});
+
+    const factory = buildTasknotesAgendaViewFactory(plugin);
+    factory(bases);
+    await new Promise(r => setTimeout(r, 10));
+
+    const container = (bases.viewContainerEl as HTMLElement);
+    const input = container.querySelector('.filter-bar__search-input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    input.value = 'Alpha';
+    input.dispatchEvent(new Event('input'));
+    await new Promise(r => setTimeout(r, 900));
+
+    const tasks = Array.from(container.querySelectorAll('.task-card')) as HTMLElement[];
+    const titles = tasks.map(t => t.textContent || '');
+    expect(titles.join(' ')).toContain('Alpha');
+    expect(titles.join(' ')).not.toContain('Bravo');
+  });
+});
+

--- a/tests/unit/bases/group-by.test.ts
+++ b/tests/unit/bases/group-by.test.ts
@@ -1,0 +1,52 @@
+import { getBasesGroupByConfig } from '../../../src/bases/group-by';
+
+describe('getBasesGroupByConfig', () => {
+  const makeBases = (groupBy: any, props: Record<string, { getDisplayName?: () => string }>) => ({
+    controller: {
+      getViewConfig: () => ({ groupBy })
+    },
+    query: {
+      getViewConfig: (k: string) => (k === 'groupBy' ? groupBy : undefined),
+      properties: props
+    }
+  });
+
+  it('returns null when no groupBy', () => {
+    const cfg = getBasesGroupByConfig(makeBases(undefined, {}), new Map());
+    expect(cfg).toBeNull();
+  });
+
+  it('normalizes by id and reads scalar values', () => {
+    const props = { 'note.in': { getDisplayName: () => 'Project' } } as const;
+    const bases = makeBases('note.in', props as any);
+    const map = new Map<string, any>();
+    map.set('a.md', { 'note.in': 'Foo' });
+
+    const cfg = getBasesGroupByConfig(bases as any, map)!;
+    expect(cfg.normalizedId).toBe('note.in');
+    expect(cfg.displayName).toBe('Project');
+    expect(cfg.getGroupValues('a.md')).toEqual(['Foo']);
+  });
+
+  it('normalizes by last segment and reads array values', () => {
+    const props = { 'note.tags': { getDisplayName: () => 'Type' } } as const;
+    const bases = makeBases('tags', props as any);
+    const map = new Map<string, any>();
+    map.set('a.md', { 'note.tags': ['a', 'b'] });
+
+    const cfg = getBasesGroupByConfig(bases as any, map)!;
+    expect(cfg.normalizedId).toBe('note.tags');
+    expect(cfg.getGroupValues('a.md')).toEqual(['a', 'b']);
+  });
+
+  it('falls back to last segment when id key missing', () => {
+    const props = { 'note.in': { getDisplayName: () => 'Project' } } as const;
+    const bases = makeBases('note.in', props as any);
+    const map = new Map<string, any>();
+    map.set('a.md', { in: 'Foo' });
+
+    const cfg = getBasesGroupByConfig(bases as any, map)!;
+    expect(cfg.getGroupValues('a.md')).toEqual(['Foo']);
+  });
+});
+

--- a/tests/unit/bases/kanban-view.factory.test.ts
+++ b/tests/unit/bases/kanban-view.factory.test.ts
@@ -1,0 +1,114 @@
+import { buildTasknotesKanbanViewFactory } from '../../../src/bases/kanban-view';
+
+// Stub TaskCard to avoid complex dependencies in unit test
+jest.mock('../../../src/ui/TaskCard', () => ({
+  createTaskCard: (task: any) => {
+    const el = document.createElement('div');
+    el.className = 'task-card';
+    el.setAttribute('data-task-path', task.path);
+    return el;
+  },
+  DEFAULT_TASK_CARD_OPTIONS: {}
+}));
+
+// Mock helpers to simplify data flow
+jest.mock('../../../src/bases/helpers', () => {
+  const actual = jest.requireActual('../../../src/bases/helpers');
+  return {
+    ...actual,
+    identifyTaskNotesFromBasesData: async (dataItems: any[]) => dataItems.map(i => ({
+      path: i.path,
+      title: i.properties?.title || 'Untitled',
+      status: i.properties?.status || 'open',
+      priority: 'normal',
+      archived: false
+    })),
+    renderTaskNotesInBasesView: async (container: HTMLElement, taskNotes: any[]) => {
+      const list = document.createElement('div');
+      list.className = 'tn-bases-tasknotes-list';
+      taskNotes.forEach((t) => {
+        const el = document.createElement('div');
+        el.className = 'task-card';
+        el.setAttribute('data-task-path', t.path);
+        list.appendChild(el);
+      });
+      container.appendChild(list);
+    }
+  };
+});
+
+// Minimal mock helpers
+const makePlugin = () => ({
+  app: { metadataCache: {}, workspace: {} },
+  cacheManager: { getCachedTaskInfo: jest.fn(async (p: string) => ({ path: p })) },
+  updateTaskProperty: jest.fn(async () => {}),
+  settings: { basesPOCLogs: false }
+}) as any;
+
+function makeBasesContainer(items: any[], cfg: any = {}) {
+  const results = new Map<any, any>();
+  items.forEach((it, i) => results.set(i, it));
+  const query = { properties: cfg.properties || {}, getViewConfig: (k?: string) => (k ? cfg[k] : cfg) } as any;
+  return { results, query, viewContainerEl: document.createElement('div'), controller: { getViewConfig: () => cfg, query } } as any;
+}
+
+describe('buildTasknotesKanbanViewFactory', () => {
+  it('renders columns based on groupBy and uses TaskCard renderer', async () => {
+    const plugin = makePlugin();
+    // Two tasks with status values
+    const items = [
+      { file: { path: '/a.md' }, properties: { status: 'open', title: 'A' } },
+      { file: { path: '/b.md' }, properties: { status: 'done', title: 'B' } }
+    ];
+    const cfg = { groupBy: 'status', order: ['status', 'title'], properties: { status: { getDisplayName: () => 'Status' } } };
+    const bases = makeBasesContainer(items, cfg);
+
+    const factory = buildTasknotesKanbanViewFactory(plugin);
+    factory(bases);
+
+    // Wait for initial async render
+    await new Promise(r => setTimeout(r, 10));
+
+    // Verify columns exist and have counts
+    const container = (bases.viewContainerEl as HTMLElement);
+    const titles = Array.from(container.querySelectorAll('.kanban-view__column-title')).map(el => el.textContent || '');
+    const uniqueTitles = Array.from(new Set(titles));
+    expect(uniqueTitles.sort()).toEqual(['done', 'open']);
+
+    const counts = Array.from(container.querySelectorAll('.kanban-view__column-count')).map(el => el.textContent || '');
+    expect(counts.join(' ')).toContain('1 tasks');
+  });
+
+  it('supports dropping a task to another column triggers update', async () => {
+    const plugin = makePlugin();
+    const items = [
+      { file: { path: '/a.md' }, properties: { status: 'open', title: 'A' } },
+      { file: { path: '/b.md' }, properties: { status: 'done', title: 'B' } }
+    ];
+    const cfg = { groupBy: 'status', order: ['status', 'title'], properties: { status: { getDisplayName: () => 'Status' } } };
+    const bases = makeBasesContainer(items, cfg);
+
+    const factory = buildTasknotesKanbanViewFactory(plugin);
+    const component = factory(bases);
+    await Promise.resolve();
+    await (component as any).refresh?.();
+    await new Promise(r => setTimeout(r, 0));
+
+    const container = (bases.viewContainerEl as HTMLElement);
+    const doneCol = container.querySelector('.kanban-view__column[data-column-id="done"]') as HTMLElement;
+    expect(doneCol).toBeTruthy();
+
+    // Simulate drop of '/a.md' into 'done'
+    const evt = new Event('drop', { bubbles: true }) as any;
+    evt.preventDefault = () => {};
+    evt.stopPropagation = () => {};
+    evt.dataTransfer = { getData: () => '/a.md' };
+    doneCol.dispatchEvent(evt);
+
+    // Allow async handler
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(plugin.updateTaskProperty).toHaveBeenCalled();
+  });
+});
+

--- a/tests/unit/bases/new-button.test.ts
+++ b/tests/unit/bases/new-button.test.ts
@@ -1,0 +1,159 @@
+// Mock Obsidian components first
+jest.mock('obsidian', () => ({
+  Component: class MockComponent {
+    onload() {}
+    onunload() {}
+  },
+  setIcon: jest.fn(),
+  ButtonComponent: jest.fn().mockImplementation(() => ({
+    setTooltip: jest.fn().mockReturnThis(),
+    setClass: jest.fn().mockReturnThis(),
+    onClick: jest.fn().mockReturnThis(),
+    buttonEl: {
+      addClass: jest.fn(),
+      empty: jest.fn(),
+      createSpan: jest.fn(() => ({ className: '' }))
+    }
+  })),
+  TextComponent: jest.fn().mockImplementation(() => ({
+    setPlaceholder: jest.fn().mockReturnThis(),
+    getValue: jest.fn(() => ''),
+    onChange: jest.fn().mockReturnThis(),
+    inputEl: {
+      addClass: jest.fn(),
+      addEventListener: jest.fn()
+    }
+  })),
+  debounce: jest.fn((fn) => fn),
+  setTooltip: jest.fn(),
+  TFile: jest.fn()
+}));
+
+import { buildTasknotesTaskListViewFactory } from '../../../src/bases/view-factory';
+import { buildTasknotesKanbanViewFactory } from '../../../src/bases/kanban-view';
+import { buildTasknotesAgendaViewFactory } from '../../../src/bases/agenda-view';
+
+// Mock DOM environment
+const mockElement = {
+  className: '',
+  style: { cssText: '' },
+  appendChild: jest.fn(),
+  createSpan: jest.fn(() => ({ className: '', textContent: '' })),
+  empty: jest.fn(),
+  closest: jest.fn(),
+  contains: jest.fn(() => true),
+  addEventListener: jest.fn(),
+  remove: jest.fn()
+} as any;
+
+// Mock document
+(global as any).document = {
+  createElement: jest.fn(() => mockElement)
+};
+
+// Mock plugin with workspace detection
+const createMockPlugin = (isInSidebar = false, activeFile = null) => ({
+  app: {
+    workspace: {
+      getActiveFile: jest.fn(() => activeFile),
+      iterateAllLeaves: jest.fn((callback: (leaf: any) => void) => {
+        // Mock leaf that contains our view
+        const mockLeaf = {
+          view: {
+            containerEl: mockElement
+          },
+          containerEl: {
+            closest: jest.fn((selector: string) => {
+              if (isInSidebar && (selector.includes('mod-left-split') || selector.includes('mod-right-split'))) {
+                return {}; // Return truthy value to indicate sidebar
+              }
+              return null;
+            })
+          }
+        };
+        callback(mockLeaf);
+      })
+    }
+  },
+  openTaskCreationModal: jest.fn(),
+  settings: { basesPOCLogs: false }
+});
+
+// Mock Bases container
+const createMockBasesContainer = () => ({
+  results: new Map(),
+  query: { on: jest.fn(), off: jest.fn() },
+  viewContainerEl: mockElement
+});
+
+describe('Bases "+New" Button', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Task List View', () => {
+    it('should create component with "+New" button functionality', () => {
+      const plugin = createMockPlugin();
+      const basesContainer = createMockBasesContainer();
+      const factory = buildTasknotesTaskListViewFactory(plugin as any);
+
+      const component = factory(basesContainer as any);
+
+      // Verify component was created
+      expect(component).toBeDefined();
+      expect(typeof component.onload).toBe('function');
+      expect(typeof component.onunload).toBe('function');
+    });
+
+    it('should handle different workspace contexts', () => {
+      const plugin = createMockPlugin(false); // Not in sidebar
+      const basesContainer = createMockBasesContainer();
+      const factory = buildTasknotesTaskListViewFactory(plugin as any);
+
+      const component = factory(basesContainer as any);
+
+      expect(component).toBeDefined();
+    });
+  });
+
+  describe('Kanban View', () => {
+    it('should create component with "+New" button functionality', () => {
+      const plugin = createMockPlugin();
+      const basesContainer = createMockBasesContainer();
+      const factory = buildTasknotesKanbanViewFactory(plugin as any);
+
+      const component = factory(basesContainer as any);
+
+      expect(component).toBeDefined();
+      expect(typeof component.onload).toBe('function');
+      expect(typeof component.onunload).toBe('function');
+    });
+  });
+
+  describe('Agenda View', () => {
+    it('should create component with "+New" button functionality', () => {
+      const plugin = createMockPlugin();
+      const basesContainer = createMockBasesContainer();
+      const factory = buildTasknotesAgendaViewFactory(plugin as any);
+
+      const component = factory(basesContainer as any);
+
+      expect(component).toBeDefined();
+      expect(typeof component.onload).toBe('function');
+      expect(typeof component.onunload).toBe('function');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle missing viewContainerEl gracefully', () => {
+      const plugin = createMockPlugin();
+      const basesContainer = { results: new Map() }; // Missing viewContainerEl
+      const factory = buildTasknotesTaskListViewFactory(plugin as any);
+
+      const component = factory(basesContainer as any);
+
+      expect(component).toBeDefined();
+      expect(typeof component.destroy).toBe('function');
+    });
+  });
+});

--- a/tests/unit/bases/search.test.ts
+++ b/tests/unit/bases/search.test.ts
@@ -1,0 +1,62 @@
+import { buildSearchIndex, filterTasksBySearch } from '../../../src/bases/search';
+import type { TaskInfo } from '../../../src/types';
+
+describe('Bases in-memory search', () => {
+  const makeTask = (path: string, title: string): TaskInfo => ({
+    path, title, status: 'open', priority: 'normal', archived: false
+  } as any);
+
+  const deps = (aliasesMap: Record<string, string | string[]>) => ({
+    getAliases: (p: string) => {
+      const v = aliasesMap[p];
+      if (!v) return [];
+      if (Array.isArray(v)) return v;
+      return [v];
+    }
+  });
+
+  it('returns all when query empty', () => {
+    const tasks = [makeTask('a.md', 'Alpha'), makeTask('b.md', 'Beta')];
+    const idx = buildSearchIndex(tasks, deps({}));
+    const res = filterTasksBySearch(tasks, idx, '');
+    expect(res.length).toBe(2);
+  });
+
+  it('matches by title', () => {
+    const tasks = [makeTask('a.md', 'Alpha'), makeTask('b.md', 'Beta')];
+    const idx = buildSearchIndex(tasks, deps({}));
+    const res = filterTasksBySearch(tasks, idx, 'alp');
+    expect(res.map(t=>t.title)).toEqual(['Alpha']);
+  });
+
+  it('matches by path', () => {
+    const tasks = [makeTask('Projects/A.md', 'Task'), makeTask('Notes/B.md', 'Task')];
+    const idx = buildSearchIndex(tasks, deps({}));
+    const res = filterTasksBySearch(tasks, idx, 'projects/');
+    expect(res.map(t=>t.path)).toEqual(['Projects/A.md']);
+  });
+
+  it('matches by aliases (string and array)', () => {
+    const tasks = [makeTask('a.md', 'Task A'), makeTask('b.md', 'Task B')];
+    const idx = buildSearchIndex(tasks, deps({ 'a.md': 'Foo', 'b.md': ['Bar', 'Baz'] }));
+    const r1 = filterTasksBySearch(tasks, idx, 'foo');
+    expect(r1.map(t=>t.path)).toEqual(['a.md']);
+    const r2 = filterTasksBySearch(tasks, idx, 'baz');
+    expect(r2.map(t=>t.path)).toEqual(['b.md']);
+  });
+
+  it('AND semantics across tokens', () => {
+    const tasks = [makeTask('x.md', 'Alpha Beta'), makeTask('y.md', 'Alpha Gamma')];
+    const idx = buildSearchIndex(tasks, deps({}));
+    const r = filterTasksBySearch(tasks, idx, 'alpha gamma');
+    expect(r.map(t=>t.path)).toEqual(['y.md']);
+  });
+
+  it('case-insensitive', () => {
+    const tasks = [makeTask('x.md', 'MiXeD CaSe')];
+    const idx = buildSearchIndex(tasks, deps({ 'x.md': ['AliAs'] }));
+    const r = filterTasksBySearch(tasks, idx, 'mixed alias');
+    expect(r.map(t=>t.path)).toEqual(['x.md']);
+  });
+});
+

--- a/tests/unit/bases/sorting.test.ts
+++ b/tests/unit/bases/sorting.test.ts
@@ -1,0 +1,46 @@
+import { getBasesSortComparator } from '../../../src/bases/sorting';
+import type { TaskInfo } from '../../../src/types';
+
+describe('Bases sorting comparator', () => {
+  const makeTask = (path: string, title: string, due?: string): TaskInfo => ({
+    path, title, status: 'open', priority: 'normal', archived: false, tags: [],
+    due, scheduled: undefined, contexts: [], projects: []
+  } as any);
+
+  const pathToProps = new Map<string, any>();
+  const basesContainer = (sort: any, props: Record<string, any>) => ({
+    controller: { getViewConfig: () => ({ sort }) },
+    query: { getViewConfig: (k: string) => (k === 'sort' ? sort : undefined), properties: props }
+  });
+
+  it('sorts by file.basename DESC then title ASC as tiebreaker', () => {
+    const tasks = [
+      makeTask('b/Two.md', 'Two'),
+      makeTask('a/One.md', 'One'),
+      makeTask('a/Alpha.md', 'Alpha')
+    ];
+    const cmp = getBasesSortComparator(basesContainer([
+      { property: 'file.basename', direction: 'DESC' },
+      { property: 'title', direction: 'ASC' }
+    ], {}) as any, pathToProps)!;
+
+    const sorted = [...tasks].sort(cmp);
+    expect(sorted.map(t => t.title)).toEqual(['Two', 'One', 'Alpha']);
+  });
+
+  it('sorts by note.in ASC using properties map', () => {
+    const tasks = [
+      makeTask('x/1.md', 'T1'),
+      makeTask('x/2.md', 'T2'),
+      makeTask('x/3.md', 'T3')
+    ];
+    const p2 = new Map([['x/1.md', { 'note.in': 'B' }], ['x/2.md', { 'note.in': 'A' }], ['x/3.md', { 'note.in': 'B' }]]);
+    const cmp = getBasesSortComparator(basesContainer([
+      { property: 'note.in', direction: 'ASC' }
+    ], { 'note.in': { getDisplayName: () => 'Project' } }) as any, p2 as any)!;
+
+    const sorted = [...tasks].sort(cmp);
+    expect(sorted.map(t => t.path)).toEqual(['x/2.md', 'x/1.md', 'x/3.md']);
+  });
+});
+

--- a/tests/unit/bases/tasklist-rows.overrides.test.ts
+++ b/tests/unit/bases/tasklist-rows.overrides.test.ts
@@ -1,0 +1,83 @@
+import { getTaskNotesTasklistRows } from '../../../src/bases/tasklist-rows';
+
+describe('getTaskNotesTasklistRows - overrides', () => {
+  const makeBases = (cfg: any, props: Record<string, any> = {}) => ({
+    controller: { getViewConfig: () => cfg },
+    query: {
+      getViewConfig: (k: string) => (k === 'order' ? cfg.order : undefined),
+      properties: props
+    }
+  });
+
+  const props = {
+    'note.in': { getDisplayName: () => 'In' },
+    'note.assignee': { getDisplayName: () => 'Assignee' },
+    'note.tags': { getDisplayName: () => 'Tags' },
+    'due': { getDisplayName: () => 'Due' },
+  } as const;
+
+  it('parses per-field overrides in object tokens for row.3 and row.4', () => {
+    const cfg = {
+      data: {
+        ['tasknotes.tasklist']: {
+          'row.3': [
+            { 'note.in': { overrideDisplayName: '👤', displayNameSuffix: '' } },
+            { 'note.assignee': { overrideDisplayName: '↳', displayNameSuffix: '' } }
+          ],
+          'row.4': [
+            { 'note.tags': { displayNameSuffix: '' } },
+            { 'due': { overrideDisplayName: '📅', displayNameSuffix: '|' } }
+          ]
+        }
+      }
+    } as any;
+
+    const rows = getTaskNotesTasklistRows(makeBases(cfg, props), new Map());
+    expect(rows.row3).toBeTruthy();
+    expect(rows.row4).toBeTruthy();
+
+    const row3 = rows.row3!.selected;
+    const row4 = rows.row4!.selected;
+
+    // IDs preserved
+    expect(row3.map(s => s.id)).toEqual(['note.in', 'note.assignee']);
+    expect(row4.map(s => s.id)).toEqual(['note.tags', 'due']);
+
+    // Base displayName preserved from Bases props
+    expect(row3[0].displayName).toBe('In');
+    expect(row3[1].displayName).toBe('Assignee');
+
+    // Overrides applied for TaskNotes UI
+    expect(row3[0].tnLabel).toBe('👤');
+    expect(row3[0].tnSeparator).toBe('');
+    expect(row3[1].tnLabel).toBe('↳');
+    expect(row3[1].tnSeparator).toBe('');
+
+    // Only suffix override for tags
+    expect(row4[0].tnLabel).toBeUndefined();
+    expect(row4[0].tnSeparator).toBe('');
+
+    // Both overrides for due
+    expect(row4[1].tnLabel).toBe('📅');
+    expect(row4[1].tnSeparator).toBe('|');
+  });
+
+  it('treats empty overrideDisplayName as suppress label (tnLabel=null)', () => {
+    const cfg = {
+      data: {
+        ['tasknotes.tasklist']: {
+          'row.3': [ { 'note.in': { overrideDisplayName: '', displayNameSuffix: '' } } ]
+        }
+      }
+    } as any;
+
+    const rows = getTaskNotesTasklistRows(makeBases(cfg, props), new Map());
+    const s = rows.row3!.selected[0];
+    expect(s.id).toBe('note.in');
+    expect(s.tnLabel).toBeNull();
+    expect(s.tnSeparator).toBe('');
+    // Bases displayName still intact for internal usage
+    expect(s.displayName).toBe('In');
+  });
+});
+

--- a/tests/unit/bases/tasklist-rows.test.ts
+++ b/tests/unit/bases/tasklist-rows.test.ts
@@ -1,0 +1,59 @@
+import { getTaskNotesTasklistRows } from '../../../src/bases/tasklist-rows';
+
+describe('getTaskNotesTasklistRows', () => {
+  const makeBases = (cfg: any, props: Record<string, any> = {}) => ({
+    controller: { getViewConfig: () => cfg },
+    query: {
+      getViewConfig: (k: string) => (k === 'order' ? cfg.order : undefined),
+      properties: props
+    }
+  });
+
+  const props = {
+    'note.in': { getDisplayName: () => 'Project' },
+    'note.assignee': { getDisplayName: () => 'Allocated To' },
+    'note.tags': { getDisplayName: () => 'Type' },
+    'due': { getDisplayName: () => 'Due' },
+  };
+
+  it('parses nested tasknotes.tasklist rows', () => {
+    const cfg = {
+      order: ['in','assignee','tags','due'],
+      tasknotes: { tasklist: { 'row.3': ['note.in','note.assignee'], 'row.4': ['note.tags'] } }
+    };
+    const rows = getTaskNotesTasklistRows(makeBases(cfg, props), new Map());
+    expect(rows.row3?.selected.map(s=>s.id)).toEqual(['note.in','note.assignee']);
+    expect(rows.row4?.selected.map(s=>s.id)).toEqual(['note.tags']);
+  });
+
+  it('parses dotted key variant', () => {
+    const cfg = {
+      order: ['in','assignee','tags','due'],
+      ['tasknotes.tasklist']: { 'row.3': ['note.in'], 'row.4': ['note.tags'] }
+    } as any;
+    const rows = getTaskNotesTasklistRows(makeBases(cfg, props), new Map());
+    expect(rows.row3?.selected.map(s=>s.id)).toEqual(['note.in']);
+    expect(rows.row4?.selected.map(s=>s.id)).toEqual(['note.tags']);
+  });
+
+  it('parses data container dotted keys', () => {
+    const cfg = {
+      order: ['in','assignee','tags','due'],
+      data: {
+        ['tasknotes.tasklist']: { 'row.3': ['note.in','note.assignee'], 'row.4': ['note.tags'] },
+        ['tasknotes.debug']: true
+      }
+    } as any;
+    const rows = getTaskNotesTasklistRows(makeBases(cfg, props), new Map());
+    expect(rows.row3?.selected.map(s=>s.id)).toEqual(['note.in','note.assignee']);
+    expect(rows.row4?.selected.map(s=>s.id)).toEqual(['note.tags']);
+  });
+
+  it('falls back to order when no custom rows provided', () => {
+    const cfg = { order: ['in','assignee','due'] };
+    const rows = getTaskNotesTasklistRows(makeBases(cfg, props), new Map());
+    expect(rows.row3?.selected.map(s=>s.id)).toEqual(['note.in','note.assignee','due']);
+    expect(rows.row4).toBeUndefined();
+  });
+});
+

--- a/tests/unit/bases/view-factory.group-links.test.ts
+++ b/tests/unit/bases/view-factory.group-links.test.ts
@@ -1,0 +1,35 @@
+import { renderTextWithLinks } from '../../../src/ui/renderers/linkRenderer';
+
+// Smoke test for link rendering in group headers: ensure wikilinks/markdown are converted to anchors
+// We don't unit-test view-factory's whole DOM flow here; we test the renderer used by it.
+
+describe('Bases Task List group header link rendering', () => {
+  const deps = {
+    metadataCache: { getFirstLinkpathDest: jest.fn(() => ({ path: 'X.md' })) } as any,
+    workspace: { getLeaf: jest.fn(() => ({ openFile: jest.fn() })), trigger: jest.fn() } as any
+  };
+
+  it('renders wikilink as internal link', () => {
+    const el = document.createElement('div');
+    renderTextWithLinks(el, '[[Sample Project A]]', deps);
+    const a = el.querySelector('a.internal-link') as HTMLAnchorElement;
+    expect(a).toBeTruthy();
+    expect(a.textContent).toBe('Sample Project A');
+    expect(a.getAttribute('data-href')).toBe('Sample Project A');
+  });
+
+  it('renders markdown link as internal or external accordingly', () => {
+    const el = document.createElement('div');
+    renderTextWithLinks(el, '[Docs](docs/README)', deps);
+    const internal = el.querySelector('a.internal-link') as HTMLAnchorElement;
+    expect(internal).toBeTruthy();
+    expect(internal.textContent).toBe('Docs');
+
+    const el2 = document.createElement('div');
+    renderTextWithLinks(el2, '[External](https://example.com)', deps);
+    const external = el2.querySelector('a.external-link') as HTMLAnchorElement;
+    expect(external).toBeTruthy();
+    expect(external.textContent).toBe('External');
+  });
+});
+

--- a/tests/unit/services/filterService.groupByStatus.test.ts
+++ b/tests/unit/services/filterService.groupByStatus.test.ts
@@ -1,0 +1,64 @@
+import { FilterService } from '../../../src/services/FilterService';
+import { MinimalNativeCache } from '../../../src/utils/MinimalNativeCache';
+import { StatusManager } from '../../../src/services/StatusManager';
+import { PriorityManager } from '../../../src/services/PriorityManager';
+import { MockObsidian, App } from '../../__mocks__/obsidian';
+import { DEFAULT_SETTINGS, DEFAULT_FIELD_MAPPING } from '../../../src/settings/defaults';
+import { FieldMapper } from '../../../src/services/FieldMapper';
+
+function makeApp(): App {
+  return MockObsidian.createMockApp();
+}
+
+function makeCache(app: App, settingsOverride: Partial<typeof DEFAULT_SETTINGS> = {}) {
+  const mapper = new FieldMapper(DEFAULT_FIELD_MAPPING);
+  const settings = { ...DEFAULT_SETTINGS, ...settingsOverride } as any;
+  const cache = new MinimalNativeCache(app as any, settings, mapper);
+  cache.initialize();
+  return cache;
+}
+
+function makeFilterService(cache: MinimalNativeCache, plugin: any) {
+  const status = new StatusManager(plugin.settings.customStatuses);
+  const priority = new PriorityManager(plugin.settings.customPriorities);
+  return new FilterService(cache, status, priority, plugin);
+}
+
+function createTaskFile(app: App, path: string, fm: Record<string, any>) {
+  const yamlLines = Object.entries(fm)
+    .map(([k, v]) => `${k}: ${Array.isArray(v) ? `[${v.join(', ')}]` : v}`);
+  const content = `---\n${yamlLines.join('\n')}\n---\n`;
+  return (app.vault as any).create(path, content);
+}
+
+describe('FilterService - group by status', () => {
+  beforeEach(() => MockObsidian.reset());
+
+  test('groups tasks by status values and sorts by status order', async () => {
+    const app = makeApp();
+    const cache = makeCache(app, { taskIdentificationMethod: 'property', taskPropertyName: 'isTask', taskPropertyValue: 'true' } as any);
+    const plugin = { settings: DEFAULT_SETTINGS } as any;
+    const fs = makeFilterService(cache, plugin);
+
+    await createTaskFile(app, 'Tasks/a.md', { isTask: true, title: 'A', status: 'open' });
+    await createTaskFile(app, 'Tasks/b.md', { isTask: true, title: 'B', status: 'in-progress' });
+    await createTaskFile(app, 'Tasks/c.md', { isTask: true, title: 'C', status: 'done' });
+
+    // Ensure metadata present (explicit set avoids timing issues)
+    app.metadataCache.setCache('Tasks/a.md', { frontmatter: { isTask: true, title: 'A', status: 'open' } });
+    app.metadataCache.setCache('Tasks/b.md', { frontmatter: { isTask: true, title: 'B', status: 'in-progress' } });
+    app.metadataCache.setCache('Tasks/c.md', { frontmatter: { isTask: true, title: 'C', status: 'done' } });
+
+    const query = fs.createDefaultQuery();
+    (query as any).groupKey = 'status';
+
+    const grouped = await fs.getGroupedTasks(query);
+    const keys = Array.from(grouped.keys());
+
+    expect(keys).toEqual(['open', 'in-progress', 'done']);
+    expect(grouped.get('open')!.map(t => t.path)).toEqual(expect.arrayContaining(['Tasks/a.md']));
+    expect(grouped.get('in-progress')!.map(t => t.path)).toEqual(expect.arrayContaining(['Tasks/b.md']));
+    expect(grouped.get('done')!.map(t => t.path)).toEqual(expect.arrayContaining(['Tasks/c.md']))
+  });
+});
+


### PR DESCRIPTION
Hi @callumalpass 

As I mentioned in my last comment:

- Rebased onto the latest main
- Has no console errors
- Has advanced data login (a data dump that gives you the ability to see all data provided by bases - you need to enable another toggle in settings in addition to the POC logs)
- Dependency update: Obsidian-Typings updated to the latest version (release a couple of days ago).

I encourage you to try the advanced log below
<img width="1372" height="681" alt="image" src="https://github.com/user-attachments/assets/1eb8181e-6288-40be-807d-06bc9fa6ae15" />

<img width="1616" height="760" alt="image" src="https://github.com/user-attachments/assets/b996617c-e196-4650-9136-8a4e756d5546" />

⚠️ There are multiple test unrelated to Bases that are still failing after lots of changes were introduced by the latest plugin releases. As I mentioned before, I'll address them separately on a dedicated PR to main. 

It might be easier to just replace this entire branch with my branch.

Later... because tomorrow the weather looks great and I'll finally go to the mountain ⛷️
