### PR TITLE
Fix completion date timezone handling (Issues #571, #574)

### DIFF
--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -3,7 +3,7 @@ import { FilenameContext, generateTaskFilename, generateUniqueFilename } from '.
 import { Notice, TFile, normalizePath, stringifyYaml } from 'obsidian';
 import { TemplateData, mergeTemplateFrontmatter, processTemplate } from '../utils/templateProcessor';
 import { addDTSTARTToRecurrenceRule, ensureFolderExists, updateToNextScheduledOccurrence } from '../utils/helpers';
-import { formatDateForStorage, getCurrentDateString, getCurrentTimestamp } from '../utils/dateUtils';
+import { formatDateForStorage, getCurrentDateString, getCurrentTimestamp, getTodayLocal, createUTCDateFromLocalCalendarDate } from '../utils/dateUtils';
 import { format } from 'date-fns';
 
 import TaskNotesPlugin from '../main';
@@ -1201,8 +1201,12 @@ export class TaskService {
             throw new Error('Task is not recurring');
         }
 
-        // Use the provided date or fall back to the currently selected date
-        const targetDate = date || this.plugin.selectedDate;
+        // Default to local today instead of selectedDate for recurring task completion
+        // This ensures completion is recorded for user's actual calendar day unless explicitly overridden
+        const targetDate = date || (() => {
+            const todayLocal = getTodayLocal();
+            return createUTCDateFromLocalCalendarDate(todayLocal);
+        })();
         const dateStr = formatDateForStorage(targetDate);
         
         // Check current completion status for this date using fresh data

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -653,7 +653,13 @@ export function getCurrentTimestamp(): string {
  * Get current date in YYYY-MM-DD format for completion dates
  */
 export function getCurrentDateString(): string {
-    return formatDateForStorage(new Date());
+    // For user actions (task completion), use local date extraction
+    // This ensures completion is recorded as user's local calendar day
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes timezone-related issues with task completion dates that caused tasks to be recorded on incorrect days.

## Issues Fixed

- **#571**: Non-recurring tasks completed late at night were recorded as tomorrow's date
- **#574**: Recurring task completion dates were affected by calendar navigation

## Changes

### Non-recurring task completion
- Modified `getCurrentDateString()` to use local date extraction instead of UTC
- Ensures completion is recorded on user's actual calendar day

### Recurring task completion  
- Changed fallback from `selectedDate` to local today for completion recording
- Prevents calendar selection from affecting when tasks are marked complete
- Fixed notification formatting to display correct local dates

### Implementation Details
- Follows UTC anchor principle: read dates with UTC anchoring, write dates with local extraction
- Maintains timezone consistency across different user locations
- Preserves ability to explicitly specify completion dates when needed

## Test Plan

- [x] Test task completion at various times of day across timezones
- [x] Verify recurring task completion ignores calendar selection
- [x] Confirm notifications display correct local dates