### PR TITLE
Fix startup crash with empty reminders property

### DIFF
--- a/src/services/FieldMapper.ts
+++ b/src/services/FieldMapper.ts
@@ -127,8 +127,15 @@ export class FieldMapper {
 
         if (frontmatter[this.mapping.reminders] !== undefined) {
             const reminders = frontmatter[this.mapping.reminders];
-            // Ensure reminders is always an array
-            mapped.reminders = Array.isArray(reminders) ? reminders : [reminders];
+            // Ensure reminders is always an array and filter out null/undefined values
+            if (Array.isArray(reminders)) {
+                const filteredReminders = reminders.filter(r => r != null);
+                if (filteredReminders.length > 0) {
+                    mapped.reminders = filteredReminders;
+                }
+            } else if (reminders != null) {
+                mapped.reminders = [reminders];
+            }
         }
 
         // Handle tags array (includes archive tag)

--- a/tests/unit/services/FieldMapper.boolean-status.test.ts
+++ b/tests/unit/services/FieldMapper.boolean-status.test.ts
@@ -197,4 +197,65 @@ describe('FieldMapper - boolean status handling', () => {
             expect(convertedTaskData.status).toBe('true');
         });
     });
+
+    describe('null reminders handling', () => {
+        it('should filter out null reminders from array', () => {
+            const frontmatter = {
+                title: 'Test Task',
+                reminders: [null, { id: 'valid-reminder', type: 'relative' }, null]
+            };
+
+            const taskInfo = fieldMapper.mapFromFrontmatter(frontmatter, 'test-task.md');
+
+            expect(Array.isArray(taskInfo.reminders)).toBe(true);
+            expect(taskInfo.reminders).toHaveLength(1);
+            expect(taskInfo.reminders[0]).toEqual({ id: 'valid-reminder', type: 'relative' });
+        });
+
+        it('should handle null reminders value by not setting reminders property', () => {
+            const frontmatter = {
+                title: 'Test Task',
+                reminders: null
+            };
+
+            const taskInfo = fieldMapper.mapFromFrontmatter(frontmatter, 'test-task.md');
+
+            expect(taskInfo.reminders).toBeUndefined();
+        });
+
+        it('should handle undefined reminders value by not setting reminders property', () => {
+            const frontmatter = {
+                title: 'Test Task',
+                reminders: undefined
+            };
+
+            const taskInfo = fieldMapper.mapFromFrontmatter(frontmatter, 'test-task.md');
+
+            expect(taskInfo.reminders).toBeUndefined();
+        });
+
+        it('should handle array of all null reminders by not setting reminders property', () => {
+            const frontmatter = {
+                title: 'Test Task',
+                reminders: [null, null, undefined]
+            };
+
+            const taskInfo = fieldMapper.mapFromFrontmatter(frontmatter, 'test-task.md');
+
+            expect(taskInfo.reminders).toBeUndefined();
+        });
+
+        it('should handle valid single reminder properly', () => {
+            const frontmatter = {
+                title: 'Test Task',
+                reminders: { id: 'valid-reminder', type: 'absolute' }
+            };
+
+            const taskInfo = fieldMapper.mapFromFrontmatter(frontmatter, 'test-task.md');
+
+            expect(Array.isArray(taskInfo.reminders)).toBe(true);
+            expect(taskInfo.reminders).toHaveLength(1);
+            expect(taskInfo.reminders[0]).toEqual({ id: 'valid-reminder', type: 'absolute' });
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Fixes startup crash when templates contain empty `reminders:` property (#583)
- FieldMapper now filters out null/undefined reminders before array creation
- Added comprehensive test coverage for null reminders handling

## Test plan
- [x] All existing tests pass
- [x] New test cases verify null reminders are handled correctly
- [x] Manual verification with reproduction scenario
- [x] Build succeeds without issues