### PR TITLE
Fix custom property duplication and total tracked time visibility

### DIFF
--- a/src/settings/tabs/appearanceTab.ts
+++ b/src/settings/tabs/appearanceTab.ts
@@ -54,7 +54,7 @@ export function renderAppearanceTab(container: HTMLElement, plugin: TaskNotesPlu
         plugin.settings.userFields.forEach(field => {
             if (field.displayName && field.key) {
                 propertyGroups.user.push({
-                    key: field.key,
+                    key: `user:${field.id}`,
                     label: field.displayName
                 });
             }

--- a/src/ui/TaskCard.ts
+++ b/src/ui/TaskCard.ts
@@ -303,7 +303,7 @@ const PROPERTY_RENDERERS: Record<string, PropertyRenderer> = {
         }
     },
     'totalTrackedTime': (element, value, _, plugin) => {
-        if (typeof value === 'number') {
+        if (typeof value === 'number' && value > 0) {
             element.textContent = `${plugin.formatTime(value)} tracked`;
         }
     },
@@ -1108,24 +1108,6 @@ export function createTaskCard(task: TaskInfo, plugin: TaskNotesPlugin, visibleP
         }
     }
     
-    // Legacy: Add time spent information if timeEstimate or totalTrackedTime properties are not explicitly configured
-    const timeSpent = calculateTotalTimeSpent(task.timeEntries || []);
-    const hasTimeEstimate = propertiesToShow.includes('timeEstimate');
-    const hasTotalTrackedTime = propertiesToShow.includes('totalTrackedTime');
-    if (!hasTimeEstimate && !hasTotalTrackedTime && (task.timeEstimate || timeSpent > 0)) {
-        const timeInfo: string[] = [];
-        if (timeSpent > 0) {
-            timeInfo.push(`${plugin.formatTime(timeSpent)} spent`);
-        }
-        if (task.timeEstimate) {
-            timeInfo.push(`${plugin.formatTime(task.timeEstimate)} estimated`);
-        }
-        const timeSpan = metadataLine.createEl('span', {
-            cls: 'task-card__metadata-property task-card__metadata-property--time'
-        });
-        timeSpan.textContent = timeInfo.join(', ');
-        metadataElements.push(timeSpan);
-    }
     
     // Add separators between metadata elements
     addMetadataSeparators(metadataLine, metadataElements);
@@ -1620,24 +1602,6 @@ export function updateTaskCard(element: HTMLElement, task: TaskInfo, plugin: Tas
             }
         }
         
-        // Legacy: Add time spent information if timeEstimate or totalTrackedTime properties are not explicitly configured
-        const timeSpent = calculateTotalTimeSpent(task.timeEntries || []);
-        const hasTimeEstimate = propertiesToShow.includes('timeEstimate');
-        const hasTotalTrackedTime = propertiesToShow.includes('totalTrackedTime');
-        if (!hasTimeEstimate && !hasTotalTrackedTime && (task.timeEstimate || timeSpent > 0)) {
-            const timeInfo: string[] = [];
-            if (timeSpent > 0) {
-                timeInfo.push(`${plugin.formatTime(timeSpent)} spent`);
-            }
-            if (task.timeEstimate) {
-                timeInfo.push(`${plugin.formatTime(task.timeEstimate)} estimated`);
-            }
-            const timeSpan = metadataLine.createEl('span', {
-                cls: 'task-card__metadata-property task-card__metadata-property--time'
-            });
-            timeSpan.textContent = timeInfo.join(', ');
-            metadataElements.push(timeSpan);
-        }
         
         // Add separators between metadata elements
         addMetadataSeparators(metadataLine, metadataElements);

--- a/tests/unit/ui/TaskCard.test.ts
+++ b/tests/unit/ui/TaskCard.test.ts
@@ -332,8 +332,38 @@ describe('TaskCard Component', () => {
       expect(metadataLine?.textContent).toContain('Due:');
       expect(metadataLine?.textContent).toContain('Scheduled:');
       expect(metadataLine?.textContent).toContain('@work, @urgent');
-      expect(metadataLine?.textContent).toContain('30m spent');
+      // Time tracking info should only show when explicitly configured as visible properties
+      expect(metadataLine?.textContent).not.toContain('30m spent');
+      expect(metadataLine?.textContent).not.toContain('60m estimated');
+    });
+
+    it('should show time tracking properties when explicitly enabled', () => {
+      const task = TaskFactory.createTask({
+        timeEstimate: 60,
+        timeEntries: [{ startTime: '2025-01-15T10:00:00Z', endTime: '2025-01-15T10:30:00Z' }],
+        totalTrackedTime: 30
+      });
+
+      // Test with timeEstimate and totalTrackedTime properties explicitly enabled
+      const visibleProperties = ['timeEstimate', 'totalTrackedTime'];
+      const card = createTaskCard(task, mockPlugin, visibleProperties);
+      const metadataLine = card.querySelector('.task-card__metadata');
+
       expect(metadataLine?.textContent).toContain('60m estimated');
+      expect(metadataLine?.textContent).toContain('30m tracked');
+    });
+
+    it('should not show totalTrackedTime when value is 0', () => {
+      const task = TaskFactory.createTask({
+        totalTrackedTime: 0
+      });
+
+      // Enable totalTrackedTime property but value is 0
+      const visibleProperties = ['totalTrackedTime'];
+      const card = createTaskCard(task, mockPlugin, visibleProperties);
+      const metadataLine = card.querySelector('.task-card__metadata');
+
+      expect(metadataLine?.textContent).not.toContain('tracked');
     });
 
     it('should create clickable project links for wikilink projects', () => {


### PR DESCRIPTION
## Summary

Fixes two issues with task card property display:

1. **Custom property duplication**: Custom properties appeared twice when configured in both settings and filter bar
2. **Unwanted total tracked time display**: Total tracked time showed even when not enabled and displayed zero values

## Changes

- Standardize custom property identifiers to use consistent `user:` prefix format
- Remove legacy time tracking fallback that bypassed property visibility settings  
- Add condition to only show total tracked time when value > 0 minutes
- Update tests to reflect corrected behavior

## Testing

- All existing tests pass
- Added new tests for proper time tracking property behavior
- Verified custom properties no longer duplicate

## Result

Users now have proper control over task card property visibility without duplicate or unwanted information.