### PR TITLE
fix: add field mapping support for Bases views

### DIFF
--- a/src/bases/base-view-factory.ts
+++ b/src/bases/base-view-factory.ts
@@ -118,7 +118,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
         }
         
         
-        const taskNotes = await identifyTaskNotesFromBasesData(dataItems);
+        const taskNotes = await identifyTaskNotesFromBasesData(dataItems, plugin);
         
 
         // Render body

--- a/src/bases/kanban-view.ts
+++ b/src/bases/kanban-view.ts
@@ -92,7 +92,7 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
       
       try {
         const dataItems = extractDataItems();
-        const taskNotes = await identifyTaskNotesFromBasesData(dataItems);
+        const taskNotes = await identifyTaskNotesFromBasesData(dataItems, plugin);
 
         // Clear board
         board.innerHTML = '';

--- a/src/services/FieldMapper.ts
+++ b/src/services/FieldMapper.ts
@@ -273,6 +273,19 @@ export class FieldMapper {
     }
 
     /**
+     * Convert user's property name back to internal field name
+     * This is the reverse of toUserField()
+     */
+    fromUserField(userPropertyName: string): keyof FieldMapping | null {
+        for (const [internalName, userName] of Object.entries(this.mapping)) {
+            if (userName === userPropertyName) {
+                return internalName as keyof FieldMapping;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Validate that a mapping has no empty field names
      */
     static validateMapping(mapping: FieldMapping): { valid: boolean; errors: string[] } {


### PR DESCRIPTION
## Summary
- Fixes Bases views not recognizing user's custom field mappings (issue #607)
- Adds reverse field mapping to translate user property names back to internal TaskNotes properties
- Enables proper rendering of status dots, priority colors, and date formatting with custom field names

## Changes
- Add `fromUserField()` method to FieldMapper service for reverse mapping
- Use field mappings in Bases data processing and property visibility logic  
- Refactor `createTaskInfoFromBasesData` to eliminate code duplication
- Update all Bases view factories to pass plugin context for field mapping

## Test Plan
- [x] Build and type check passes
- [x] Manual testing in Obsidian with custom field names (e.g., Cyrillic property names)
- [x] Verify status dots and priority indicators appear correctly in Bases views

Closes #607