### PR TITLE
Add performance warning for large Bases queries

### DIFF
--- a/src/bases/base-view-factory.ts
+++ b/src/bases/base-view-factory.ts
@@ -11,6 +11,8 @@
  */
 import TaskNotesPlugin from '../main';
 import { BasesDataItem, identifyTaskNotesFromBasesData, renderTaskNotesInBasesView } from './helpers';
+import { TaskInfo } from '../types';
+import { updateTaskCard } from '../ui/TaskCard';
 
 export interface BasesContainerLike {
   results?: Map<any, any>;
@@ -23,9 +25,290 @@ export interface ViewConfig {
   errorPrefix: string;
 }
 
+/**
+ * Simple task change detection
+ */
+function hasTaskChanged(oldTask: TaskInfo, newTask: TaskInfo): boolean {
+  return (
+    oldTask.title !== newTask.title ||
+    oldTask.status !== newTask.status ||
+    oldTask.priority !== newTask.priority ||
+    oldTask.due !== newTask.due ||
+    oldTask.scheduled !== newTask.scheduled ||
+    oldTask.dateModified !== newTask.dateModified ||
+    JSON.stringify(oldTask.projects) !== JSON.stringify(newTask.projects) ||
+    JSON.stringify(oldTask.contexts) !== JSON.stringify(newTask.contexts) ||
+    JSON.stringify(oldTask.tags) !== JSON.stringify(newTask.tags)
+  );
+}
+
+/**
+ * Simplified DOM reconciliation with targeted updates
+ */
+async function reconcileTaskList(
+  container: HTMLElement,
+  newTasks: TaskInfo[],
+  plugin: TaskNotesPlugin,
+  basesContainer: any,
+  lastRenderedTasks: Map<string, TaskInfo>,
+  progressiveState: any
+): Promise<void> {
+  // Handle empty state
+  if (newTasks.length === 0) {
+    container.innerHTML = '';
+    const emptyEl = document.createElement('div');
+    emptyEl.className = 'tn-bases-empty';
+    emptyEl.style.cssText = 'padding: 20px; text-align: center; color: #666;';
+    emptyEl.textContent = 'No TaskNotes tasks found for this Base.';
+    container.appendChild(emptyEl);
+    lastRenderedTasks.clear();
+    return;
+  }
+
+  // Remove empty state if present
+  const emptyEl = container.querySelector('.tn-bases-empty');
+  if (emptyEl) {
+    emptyEl.remove();
+  }
+
+  // Apply sorting 
+  const dataItems = Array.from((basesContainer as any)?.results?.values() || [])
+    .map((value: any) => ({
+      key: value?.file?.path || value?.path,
+      data: value,
+      file: value?.file,
+      path: value?.file?.path || value?.path,
+      properties: value?.properties || value?.frontmatter,
+      basesData: value
+    }));
+
+  const pathToProps = new Map<string, Record<string, any>>(
+    dataItems.filter(i => !!i.path).map(i => [i.path || '', (i as any).properties || (i as any).frontmatter || {}])
+  );
+
+  const { getBasesSortComparator } = await import('./sorting');
+  const sortComparator = getBasesSortComparator(basesContainer, pathToProps);
+  if (sortComparator) {
+    newTasks.sort(sortComparator);
+  }
+
+  // Check if this is the first render
+  if (lastRenderedTasks.size === 0) {
+    // First render - use async batch rendering
+    await renderTaskNotesInBasesView(container, newTasks, plugin, basesContainer);
+    return;
+  }
+
+  // Use targeted DOM reconciliation for updates
+  await reconcileTaskCards(container, newTasks, plugin, basesContainer, lastRenderedTasks);
+}
+
+/**
+ * Perform targeted DOM updates without full re-render
+ */
+async function reconcileTaskCards(
+  container: HTMLElement,
+  newTasks: TaskInfo[],
+  plugin: TaskNotesPlugin,
+  basesContainer: any,
+  lastRenderedTasks: Map<string, TaskInfo>
+): Promise<void> {
+  const { createTaskCard } = await import('../ui/TaskCard');
+  
+  // Find the task list container
+  let taskListContainer = container.querySelector('.tn-bases-tasknotes-list') as HTMLElement;
+  if (!taskListContainer) {
+    // If no task list exists, create one and render all tasks
+    await renderTaskNotesInBasesView(container, newTasks, plugin, basesContainer);
+    return;
+  }
+
+  // Get current task elements
+  const currentTaskElements = new Map<string, HTMLElement>();
+  const taskCards = taskListContainer.querySelectorAll('.task-card[data-task-path]');
+  taskCards.forEach(card => {
+    const path = (card as HTMLElement).dataset.taskPath;
+    if (path) {
+      currentTaskElements.set(path, card as HTMLElement);
+    }
+  });
+
+  // Build maps for efficient lookups
+  const newTasksMap = new Map<string, TaskInfo>();
+  newTasks.forEach(task => newTasksMap.set(task.path, task));
+
+  // 1. Remove tasks that no longer exist
+  for (const [path, element] of currentTaskElements) {
+    if (!newTasksMap.has(path)) {
+      element.remove();
+    }
+  }
+
+  // 2. Update existing tasks that have changed
+  for (const [path, newTask] of newTasksMap) {
+    const existingElement = currentTaskElements.get(path);
+    const lastRenderedTask = lastRenderedTasks.get(path);
+    
+    if (existingElement && lastRenderedTask) {
+      // Check if task has actually changed
+      if (hasTaskChanged(lastRenderedTask, newTask)) {
+        try {
+          updateTaskCard(existingElement, newTask, plugin);
+        } catch (error) {
+          console.warn('[TaskNotes][Reconcile] Error updating task card:', error);
+          // Fallback: recreate the card
+          try {
+            const newCard = createTaskCard(newTask, plugin);
+            existingElement.replaceWith(newCard);
+          } catch (createError) {
+            console.error('[TaskNotes][Reconcile] Error creating replacement card:', createError);
+          }
+        }
+      }
+    }
+  }
+
+  // 3. Add new tasks using async batch rendering
+  const existingTaskPaths = new Set(currentTaskElements.keys());
+  const tasksToAdd = newTasks.filter(task => !existingTaskPaths.has(task.path));
+  
+  if (tasksToAdd.length > 0) {
+    await addNewTasksAsync(taskListContainer, tasksToAdd, plugin, basesContainer);
+  }
+
+  // 4. Handle reordering if needed (simple approach: if order changed significantly, re-render)
+  const currentOrder = Array.from(currentTaskElements.keys());
+  const newOrder = newTasks.map(t => t.path);
+  const orderChanged = currentOrder.length === newOrder.length && 
+    currentOrder.some((path, index) => path !== newOrder[index]);
+
+  if (orderChanged && tasksToAdd.length === 0) {
+    // Only reorder if no new tasks were added (to avoid double rendering)
+    reorderTaskCards(taskListContainer, newTasks, currentTaskElements);
+  }
+}
+
+/**
+ * Add new tasks using async batch rendering
+ */
+async function addNewTasksAsync(
+  container: HTMLElement,
+  tasksToAdd: TaskInfo[],
+  plugin: TaskNotesPlugin,
+  basesContainer: any
+): Promise<void> {
+  const { createTaskCard } = await import('../ui/TaskCard');
+  const { getBasesVisibleProperties } = await import('./helpers');
+
+  // Get visible properties from Bases
+  let visibleProperties: string[] | undefined;
+  let cardOptions = {
+    showCheckbox: false,
+    showArchiveButton: false,
+    showTimeTracking: false,
+    showRecurringControls: true,
+    groupByDate: false
+  };
+
+  if (basesContainer) {
+    const basesVisibleProperties = getBasesVisibleProperties(basesContainer);
+    
+    if (basesVisibleProperties.length > 0) {
+      visibleProperties = basesVisibleProperties.map(p => p.id).map(propId => {
+        let mappedId = propId;
+        
+        // Apply field mappings (same logic as in helpers.ts)
+        const internalFieldName = plugin.fieldMapper?.fromUserField(propId);
+        if (internalFieldName) {
+          mappedId = internalFieldName;
+        }
+        else if (propId.startsWith('task.')) {
+          mappedId = propId.substring(5);
+        }
+        else if (propId.startsWith('note.')) {
+          const stripped = propId.substring(5);
+          const strippedInternalFieldName = plugin.fieldMapper?.fromUserField(stripped);
+          if (strippedInternalFieldName) {
+            mappedId = strippedInternalFieldName;
+          }
+          else if (stripped === 'dateCreated') mappedId = 'dateCreated';
+          else if (stripped === 'dateModified') mappedId = 'dateModified';
+          else if (stripped === 'completedDate') mappedId = 'completedDate';
+          else mappedId = stripped;
+        }
+        else if (propId === 'file.ctime') mappedId = 'dateCreated';
+        else if (propId === 'file.mtime') mappedId = 'dateModified';
+        else if (propId === 'file.name') mappedId = 'title';
+        else if (propId.startsWith('formula.')) {
+          mappedId = propId;
+        }
+        
+        return mappedId;
+      });
+    }
+  }
+
+  // Use plugin default properties if no Bases properties available
+  if (!visibleProperties || visibleProperties.length === 0) {
+    visibleProperties = plugin.settings.defaultVisibleProperties || [
+      'due', 'scheduled', 'projects', 'contexts', 'tags'
+    ];
+  }
+
+  // Render new tasks in batches
+  const batchSize = 25;
+  for (let i = 0; i < tasksToAdd.length; i += batchSize) {
+    const batch = tasksToAdd.slice(i, i + batchSize);
+    const fragment = document.createDocumentFragment();
+    
+    for (const taskInfo of batch) {
+      try {
+        const taskCard = createTaskCard(taskInfo, plugin, visibleProperties, cardOptions);
+        fragment.appendChild(taskCard);
+      } catch (error) {
+        console.warn('[TaskNotes][AddNew] Error creating task card:', error);
+      }
+    }
+    
+    // Add the entire batch at once
+    container.appendChild(fragment);
+    
+    // Yield control using requestAnimationFrame for smooth rendering
+    if (i + batchSize < tasksToAdd.length) {
+      await new Promise(resolve => requestAnimationFrame(resolve));
+    }
+  }
+}
+
+/**
+ * Reorder existing task cards to match new order
+ */
+function reorderTaskCards(
+  container: HTMLElement,
+  newTasks: TaskInfo[],
+  currentTaskElements: Map<string, HTMLElement>
+): void {
+  const fragment = document.createDocumentFragment();
+  
+  // Add elements in the new order
+  for (const task of newTasks) {
+    const element = currentTaskElements.get(task.path);
+    if (element) {
+      fragment.appendChild(element);
+    }
+  }
+  
+  // Replace container contents with reordered elements
+  container.appendChild(fragment);
+}
+
+
+
+
 export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: ViewConfig) {
   return function tasknotesBaseViewFactory(basesContainer: BasesContainerLike) {
     let currentRoot: HTMLElement | null = null;
+    let lastRenderedTasks: Map<string, TaskInfo> = new Map(); // Track rendered tasks by path
 
     const viewContainerEl = (basesContainer as any)?.viewContainerEl as HTMLElement | undefined;
     if (!viewContainerEl) {
@@ -72,47 +355,74 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 
     const render = async () => {
       if (!currentRoot) return;
+      const startTime = performance.now();
+      
       try {
+        // Show loading indicator for large datasets
         const dataItems = extractDataItems();
+        const isLargeDataset = dataItems.length > 100;
         
-        // Compute Bases formulas for TaskNotes items
+        let loadingIndicator: HTMLElement | null = null;
+        if (isLargeDataset) {
+          loadingIndicator = itemsContainer.createEl('div', {
+            cls: 'tn-bases-loading',
+            text: `Loading ${dataItems.length} tasks...`
+          });
+          loadingIndicator.style.cssText = 'padding: 20px; text-align: center; color: var(--text-muted);';
+        }
+        
+        // Performance monitoring for large datasets
+        if (dataItems.length > 500) {
+          console.log(`[TaskNotes][Bases] Rendering ${dataItems.length} tasks - this may take a moment`);
+        }
+        
+        // Compute Bases formulas for TaskNotes items with batch processing
         // This ensures formulas have access to TaskNote-specific properties
         const ctxFormulas = (basesContainer as any)?.ctx?.formulas;
         if (ctxFormulas && dataItems.length > 0) {
-          for (let i = 0; i < dataItems.length; i++) {
-            const item = dataItems[i];
-            const itemFormulaResults = item.basesData?.formulaResults;
-            if (!itemFormulaResults?.cachedFormulaOutputs) continue;
+          const formulaBatchSize = 25;
+          for (let i = 0; i < dataItems.length; i += formulaBatchSize) {
+            const batch = dataItems.slice(i, i + formulaBatchSize);
             
-            for (const formulaName of Object.keys(ctxFormulas)) {
-              const formula = ctxFormulas[formulaName];
-              if (formula && typeof formula.getValue === 'function') {
-                try {
-                  const baseData = item.basesData;
-                  const taskProperties = item.properties || {};
-                  
-                  let result;
-                  
-                  // Temporarily merge TaskNote properties into frontmatter for formula access
-                  // This preserves Bases' internal object structure while providing item-specific data
-                  if (baseData.frontmatter && Object.keys(taskProperties).length > 0) {
-                    const originalFrontmatter = baseData.frontmatter;
-                    baseData.frontmatter = { ...originalFrontmatter, ...taskProperties };
-                    result = formula.getValue(baseData);
-                    baseData.frontmatter = originalFrontmatter; // Restore original state
-                  } else {
-                    result = formula.getValue(baseData);
+            for (const item of batch) {
+              const itemFormulaResults = item.basesData?.formulaResults;
+              if (!itemFormulaResults?.cachedFormulaOutputs) continue;
+              
+              for (const formulaName of Object.keys(ctxFormulas)) {
+                const formula = ctxFormulas[formulaName];
+                if (formula && typeof formula.getValue === 'function') {
+                  try {
+                    const baseData = item.basesData;
+                    const taskProperties = item.properties || {};
+                    
+                    let result;
+                    
+                    // Temporarily merge TaskNote properties into frontmatter for formula access
+                    // This preserves Bases' internal object structure while providing item-specific data
+                    if (baseData.frontmatter && Object.keys(taskProperties).length > 0) {
+                      const originalFrontmatter = baseData.frontmatter;
+                      baseData.frontmatter = { ...originalFrontmatter, ...taskProperties };
+                      result = formula.getValue(baseData);
+                      baseData.frontmatter = originalFrontmatter; // Restore original state
+                    } else {
+                      result = formula.getValue(baseData);
+                    }
+                    
+                    // Store computed result for TaskCard rendering
+                    if (result !== undefined) {
+                      itemFormulaResults.cachedFormulaOutputs[formulaName] = result;
+                    }
+                  } catch (e) {
+                    // Formulas may fail for various reasons (missing data, syntax errors, etc.)
+                    // This is expected behavior and doesn't require action
                   }
-                  
-                  // Store computed result for TaskCard rendering
-                  if (result !== undefined) {
-                    itemFormulaResults.cachedFormulaOutputs[formulaName] = result;
-                  }
-                } catch (e) {
-                  // Formulas may fail for various reasons (missing data, syntax errors, etc.)
-                  // This is expected behavior and doesn't require action
                 }
               }
+            }
+            
+            // Yield control between batches to prevent UI freezing using requestAnimationFrame
+            if (i + formulaBatchSize < dataItems.length) {
+              await new Promise(resolve => requestAnimationFrame(resolve));
             }
           }
         }
@@ -121,31 +431,24 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
         const taskNotes = await identifyTaskNotesFromBasesData(dataItems, plugin);
         
 
-        // Render body
-        itemsContainer.innerHTML = '';
-        if (taskNotes.length === 0) {
-          const emptyEl = document.createElement('div');
-          emptyEl.className = 'tn-bases-empty';
-          emptyEl.style.cssText = 'padding: 20px; text-align: center; color: #666;';
-          emptyEl.textContent = 'No TaskNotes tasks found for this Base.';
-          itemsContainer.appendChild(emptyEl);
-        } else {
-          // Build a map from task path to its properties/frontmatter
-          const pathToProps = new Map<string, Record<string, any>>(
-            dataItems.filter(i => !!i.path).map(i => [i.path || '', (i as any).properties || (i as any).frontmatter || {}])
-          );
-
-
-          // Apply Bases sorting if configured
-          const { getBasesSortComparator } = await import('./sorting');
-          const sortComparator = getBasesSortComparator(basesContainer, pathToProps);
-          if (sortComparator) {
-            taskNotes.sort(sortComparator);
-          }
-
-          // Render tasks using existing helper
-          await renderTaskNotesInBasesView(itemsContainer, taskNotes, plugin, basesContainer);
+        // Remove loading indicator
+        if (loadingIndicator) {
+          loadingIndicator.remove();
         }
+        
+        // Use DOM reconciliation for efficient updates
+        await reconcileTaskList(itemsContainer, taskNotes, plugin, basesContainer, lastRenderedTasks, null);
+        
+        // Update cache
+        lastRenderedTasks.clear();
+        taskNotes.forEach(task => lastRenderedTasks.set(task.path, task));
+        
+        // Performance logging for monitoring
+        const elapsed = performance.now() - startTime;
+        if (dataItems.length > 100 || elapsed > 1000) {
+          console.log(`[TaskNotes][Bases] Rendered ${taskNotes.length} tasks in ${elapsed.toFixed(0)}ms`);
+        }
+        
       } catch (error: any) {
         console.error(`[TaskNotes][BasesPOC] Error rendering Bases ${config.errorPrefix}:`, error);
         const errorEl = document.createElement('div');

--- a/src/bases/base-view-factory.ts
+++ b/src/bases/base-view-factory.ts
@@ -3,16 +3,11 @@
  * 
  * This module provides a factory function that creates TaskNotes views within the Bases plugin.
  * It handles formula computation, data transformation, and rendering of TaskNotes items in Bases views.
- * 
- * Key features:
- * - Formula computation with access to TaskNote properties
- * - Proper handling of missing/empty formula values
- * - Integration with Bases' view lifecycle management
  */
 import TaskNotesPlugin from '../main';
-import { BasesDataItem, identifyTaskNotesFromBasesData, renderTaskNotesInBasesView } from './helpers';
+import { BasesDataItem, identifyTaskNotesFromBasesData, getBasesVisibleProperties } from './helpers';
 import { TaskInfo } from '../types';
-import { updateTaskCard } from '../ui/TaskCard';
+import { createTaskCard, updateTaskCard } from '../ui/TaskCard';
 
 export interface BasesContainerLike {
   results?: Map<any, any>;
@@ -25,294 +20,14 @@ export interface ViewConfig {
   errorPrefix: string;
 }
 
-/**
- * Simple task change detection
- */
-function hasTaskChanged(oldTask: TaskInfo, newTask: TaskInfo): boolean {
-  return (
-    oldTask.title !== newTask.title ||
-    oldTask.status !== newTask.status ||
-    oldTask.priority !== newTask.priority ||
-    oldTask.due !== newTask.due ||
-    oldTask.scheduled !== newTask.scheduled ||
-    oldTask.dateModified !== newTask.dateModified ||
-    JSON.stringify(oldTask.projects) !== JSON.stringify(newTask.projects) ||
-    JSON.stringify(oldTask.contexts) !== JSON.stringify(newTask.contexts) ||
-    JSON.stringify(oldTask.tags) !== JSON.stringify(newTask.tags)
-  );
-}
-
-/**
- * Simplified DOM reconciliation with targeted updates
- */
-async function reconcileTaskList(
-  container: HTMLElement,
-  newTasks: TaskInfo[],
-  plugin: TaskNotesPlugin,
-  basesContainer: any,
-  lastRenderedTasks: Map<string, TaskInfo>,
-  progressiveState: any
-): Promise<void> {
-  // Handle empty state
-  if (newTasks.length === 0) {
-    container.innerHTML = '';
-    const emptyEl = document.createElement('div');
-    emptyEl.className = 'tn-bases-empty';
-    emptyEl.style.cssText = 'padding: 20px; text-align: center; color: #666;';
-    emptyEl.textContent = 'No TaskNotes tasks found for this Base.';
-    container.appendChild(emptyEl);
-    lastRenderedTasks.clear();
-    return;
-  }
-
-  // Remove empty state if present
-  const emptyEl = container.querySelector('.tn-bases-empty');
-  if (emptyEl) {
-    emptyEl.remove();
-  }
-
-  // Apply sorting 
-  const dataItems = Array.from((basesContainer as any)?.results?.values() || [])
-    .map((value: any) => ({
-      key: value?.file?.path || value?.path,
-      data: value,
-      file: value?.file,
-      path: value?.file?.path || value?.path,
-      properties: value?.properties || value?.frontmatter,
-      basesData: value
-    }));
-
-  const pathToProps = new Map<string, Record<string, any>>(
-    dataItems.filter(i => !!i.path).map(i => [i.path || '', (i as any).properties || (i as any).frontmatter || {}])
-  );
-
-  const { getBasesSortComparator } = await import('./sorting');
-  const sortComparator = getBasesSortComparator(basesContainer, pathToProps);
-  if (sortComparator) {
-    newTasks.sort(sortComparator);
-  }
-
-  // Check if this is the first render
-  if (lastRenderedTasks.size === 0) {
-    // First render - use async batch rendering
-    await renderTaskNotesInBasesView(container, newTasks, plugin, basesContainer);
-    return;
-  }
-
-  // Use targeted DOM reconciliation for updates
-  await reconcileTaskCards(container, newTasks, plugin, basesContainer, lastRenderedTasks);
-}
-
-/**
- * Perform targeted DOM updates without full re-render
- */
-async function reconcileTaskCards(
-  container: HTMLElement,
-  newTasks: TaskInfo[],
-  plugin: TaskNotesPlugin,
-  basesContainer: any,
-  lastRenderedTasks: Map<string, TaskInfo>
-): Promise<void> {
-  const { createTaskCard } = await import('../ui/TaskCard');
-  
-  // Find the task list container
-  let taskListContainer = container.querySelector('.tn-bases-tasknotes-list') as HTMLElement;
-  if (!taskListContainer) {
-    // If no task list exists, create one and render all tasks
-    await renderTaskNotesInBasesView(container, newTasks, plugin, basesContainer);
-    return;
-  }
-
-  // Get current task elements
-  const currentTaskElements = new Map<string, HTMLElement>();
-  const taskCards = taskListContainer.querySelectorAll('.task-card[data-task-path]');
-  taskCards.forEach(card => {
-    const path = (card as HTMLElement).dataset.taskPath;
-    if (path) {
-      currentTaskElements.set(path, card as HTMLElement);
-    }
-  });
-
-  // Build maps for efficient lookups
-  const newTasksMap = new Map<string, TaskInfo>();
-  newTasks.forEach(task => newTasksMap.set(task.path, task));
-
-  // 1. Remove tasks that no longer exist
-  for (const [path, element] of currentTaskElements) {
-    if (!newTasksMap.has(path)) {
-      element.remove();
-    }
-  }
-
-  // 2. Update existing tasks that have changed
-  for (const [path, newTask] of newTasksMap) {
-    const existingElement = currentTaskElements.get(path);
-    const lastRenderedTask = lastRenderedTasks.get(path);
-    
-    if (existingElement && lastRenderedTask) {
-      // Check if task has actually changed
-      if (hasTaskChanged(lastRenderedTask, newTask)) {
-        try {
-          updateTaskCard(existingElement, newTask, plugin);
-        } catch (error) {
-          console.warn('[TaskNotes][Reconcile] Error updating task card:', error);
-          // Fallback: recreate the card
-          try {
-            const newCard = createTaskCard(newTask, plugin);
-            existingElement.replaceWith(newCard);
-          } catch (createError) {
-            console.error('[TaskNotes][Reconcile] Error creating replacement card:', createError);
-          }
-        }
-      }
-    }
-  }
-
-  // 3. Add new tasks using async batch rendering
-  const existingTaskPaths = new Set(currentTaskElements.keys());
-  const tasksToAdd = newTasks.filter(task => !existingTaskPaths.has(task.path));
-  
-  if (tasksToAdd.length > 0) {
-    await addNewTasksAsync(taskListContainer, tasksToAdd, plugin, basesContainer);
-  }
-
-  // 4. Handle reordering if needed (simple approach: if order changed significantly, re-render)
-  const currentOrder = Array.from(currentTaskElements.keys());
-  const newOrder = newTasks.map(t => t.path);
-  const orderChanged = currentOrder.length === newOrder.length && 
-    currentOrder.some((path, index) => path !== newOrder[index]);
-
-  if (orderChanged && tasksToAdd.length === 0) {
-    // Only reorder if no new tasks were added (to avoid double rendering)
-    reorderTaskCards(taskListContainer, newTasks, currentTaskElements);
-  }
-}
-
-/**
- * Add new tasks using async batch rendering
- */
-async function addNewTasksAsync(
-  container: HTMLElement,
-  tasksToAdd: TaskInfo[],
-  plugin: TaskNotesPlugin,
-  basesContainer: any
-): Promise<void> {
-  const { createTaskCard } = await import('../ui/TaskCard');
-  const { getBasesVisibleProperties } = await import('./helpers');
-
-  // Get visible properties from Bases
-  let visibleProperties: string[] | undefined;
-  let cardOptions = {
-    showCheckbox: false,
-    showArchiveButton: false,
-    showTimeTracking: false,
-    showRecurringControls: true,
-    groupByDate: false
-  };
-
-  if (basesContainer) {
-    const basesVisibleProperties = getBasesVisibleProperties(basesContainer);
-    
-    if (basesVisibleProperties.length > 0) {
-      visibleProperties = basesVisibleProperties.map(p => p.id).map(propId => {
-        let mappedId = propId;
-        
-        // Apply field mappings (same logic as in helpers.ts)
-        const internalFieldName = plugin.fieldMapper?.fromUserField(propId);
-        if (internalFieldName) {
-          mappedId = internalFieldName;
-        }
-        else if (propId.startsWith('task.')) {
-          mappedId = propId.substring(5);
-        }
-        else if (propId.startsWith('note.')) {
-          const stripped = propId.substring(5);
-          const strippedInternalFieldName = plugin.fieldMapper?.fromUserField(stripped);
-          if (strippedInternalFieldName) {
-            mappedId = strippedInternalFieldName;
-          }
-          else if (stripped === 'dateCreated') mappedId = 'dateCreated';
-          else if (stripped === 'dateModified') mappedId = 'dateModified';
-          else if (stripped === 'completedDate') mappedId = 'completedDate';
-          else mappedId = stripped;
-        }
-        else if (propId === 'file.ctime') mappedId = 'dateCreated';
-        else if (propId === 'file.mtime') mappedId = 'dateModified';
-        else if (propId === 'file.name') mappedId = 'title';
-        else if (propId.startsWith('formula.')) {
-          mappedId = propId;
-        }
-        
-        return mappedId;
-      });
-    }
-  }
-
-  // Use plugin default properties if no Bases properties available
-  if (!visibleProperties || visibleProperties.length === 0) {
-    visibleProperties = plugin.settings.defaultVisibleProperties || [
-      'due', 'scheduled', 'projects', 'contexts', 'tags'
-    ];
-  }
-
-  // Render new tasks in batches
-  const batchSize = 25;
-  for (let i = 0; i < tasksToAdd.length; i += batchSize) {
-    const batch = tasksToAdd.slice(i, i + batchSize);
-    const fragment = document.createDocumentFragment();
-    
-    for (const taskInfo of batch) {
-      try {
-        const taskCard = createTaskCard(taskInfo, plugin, visibleProperties, cardOptions);
-        fragment.appendChild(taskCard);
-      } catch (error) {
-        console.warn('[TaskNotes][AddNew] Error creating task card:', error);
-      }
-    }
-    
-    // Add the entire batch at once
-    container.appendChild(fragment);
-    
-    // Yield control using requestAnimationFrame for smooth rendering
-    if (i + batchSize < tasksToAdd.length) {
-      await new Promise(resolve => requestAnimationFrame(resolve));
-    }
-  }
-}
-
-/**
- * Reorder existing task cards to match new order
- */
-function reorderTaskCards(
-  container: HTMLElement,
-  newTasks: TaskInfo[],
-  currentTaskElements: Map<string, HTMLElement>
-): void {
-  const fragment = document.createDocumentFragment();
-  
-  // Add elements in the new order
-  for (const task of newTasks) {
-    const element = currentTaskElements.get(task.path);
-    if (element) {
-      fragment.appendChild(element);
-    }
-  }
-  
-  // Replace container contents with reordered elements
-  container.appendChild(fragment);
-}
-
-
-
-
 export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: ViewConfig) {
   return function tasknotesBaseViewFactory(basesContainer: BasesContainerLike) {
     let currentRoot: HTMLElement | null = null;
-    let lastRenderedTasks: Map<string, TaskInfo> = new Map(); // Track rendered tasks by path
+    let currentRenderCancellation: { cancelled: boolean } | null = null;
 
     const viewContainerEl = (basesContainer as any)?.viewContainerEl as HTMLElement | undefined;
     if (!viewContainerEl) {
-      console.error('[TaskNotes][BasesPOC] No viewContainerEl found');
+      console.error('[TaskNotes][Bases] No viewContainerEl found');
       return { destroy: () => {} } as any;
     }
 
@@ -323,7 +38,6 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
     root.className = 'tn-bases-integration tasknotes-plugin tasknotes-container';
     viewContainerEl.appendChild(root);
     currentRoot = root;
-
 
     const itemsContainer = document.createElement('div');
     itemsContainer.className = 'tn-bases-items-container';
@@ -345,112 +59,147 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
             properties: (value as any)?.properties || (value as any)?.frontmatter,
             basesData: value
           };
-          
           dataItems.push(item);
         }
       }
-      
       return dataItems;
     };
 
     const render = async () => {
       if (!currentRoot) return;
+      
+      if (currentRenderCancellation) {
+        currentRenderCancellation.cancelled = true;
+      }
+      
+      const renderCancellation = { cancelled: false };
+      currentRenderCancellation = renderCancellation;
+      
       const startTime = performance.now();
       
       try {
-        // Show loading indicator for large datasets
         const dataItems = extractDataItems();
-        const isLargeDataset = dataItems.length > 100;
         
-        let loadingIndicator: HTMLElement | null = null;
-        if (isLargeDataset) {
-          loadingIndicator = itemsContainer.createEl('div', {
-            cls: 'tn-bases-loading',
-            text: `Loading ${dataItems.length} tasks...`
-          });
-          loadingIndicator.style.cssText = 'padding: 20px; text-align: center; color: var(--text-muted);';
-        }
-        
-        // Performance monitoring for large datasets
-        if (dataItems.length > 500) {
-          console.log(`[TaskNotes][Bases] Rendering ${dataItems.length} tasks - this may take a moment`);
-        }
-        
-        // Compute Bases formulas for TaskNotes items with batch processing
-        // This ensures formulas have access to TaskNote-specific properties
+        // --- Formula Computation (leaving as is) ---
         const ctxFormulas = (basesContainer as any)?.ctx?.formulas;
         if (ctxFormulas && dataItems.length > 0) {
-          const formulaBatchSize = 25;
-          for (let i = 0; i < dataItems.length; i += formulaBatchSize) {
-            const batch = dataItems.slice(i, i + formulaBatchSize);
-            
-            for (const item of batch) {
-              const itemFormulaResults = item.basesData?.formulaResults;
-              if (!itemFormulaResults?.cachedFormulaOutputs) continue;
-              
-              for (const formulaName of Object.keys(ctxFormulas)) {
-                const formula = ctxFormulas[formulaName];
-                if (formula && typeof formula.getValue === 'function') {
-                  try {
-                    const baseData = item.basesData;
-                    const taskProperties = item.properties || {};
-                    
-                    let result;
-                    
-                    // Temporarily merge TaskNote properties into frontmatter for formula access
-                    // This preserves Bases' internal object structure while providing item-specific data
-                    if (baseData.frontmatter && Object.keys(taskProperties).length > 0) {
-                      const originalFrontmatter = baseData.frontmatter;
-                      baseData.frontmatter = { ...originalFrontmatter, ...taskProperties };
-                      result = formula.getValue(baseData);
-                      baseData.frontmatter = originalFrontmatter; // Restore original state
-                    } else {
-                      result = formula.getValue(baseData);
+            const formulaBatchSize = 25;
+            for (let i = 0; i < dataItems.length; i += formulaBatchSize) {
+                if (renderCancellation.cancelled) return;
+                const batch = dataItems.slice(i, i + formulaBatchSize);
+                for (const item of batch) {
+                    const itemFormulaResults = item.basesData?.formulaResults;
+                    if (!itemFormulaResults?.cachedFormulaOutputs) continue;
+                    for (const formulaName of Object.keys(ctxFormulas)) {
+                        const formula = ctxFormulas[formulaName];
+                        if (formula && typeof formula.getValue === 'function') {
+                            try {
+                                const baseData = item.basesData;
+                                const taskProperties = item.properties || {};
+                                let result;
+                                if (baseData.frontmatter && Object.keys(taskProperties).length > 0) {
+                                    const originalFrontmatter = baseData.frontmatter;
+                                    baseData.frontmatter = { ...originalFrontmatter, ...taskProperties };
+                                    result = formula.getValue(baseData);
+                                    baseData.frontmatter = originalFrontmatter;
+                                } else {
+                                    result = formula.getValue(baseData);
+                                }
+                                if (result !== undefined) {
+                                    itemFormulaResults.cachedFormulaOutputs[formulaName] = result;
+                                }
+                            } catch (e) { /* Formula errors are expected */ }
+                        }
                     }
-                    
-                    // Store computed result for TaskCard rendering
-                    if (result !== undefined) {
-                      itemFormulaResults.cachedFormulaOutputs[formulaName] = result;
-                    }
-                  } catch (e) {
-                    // Formulas may fail for various reasons (missing data, syntax errors, etc.)
-                    // This is expected behavior and doesn't require action
-                  }
                 }
-              }
+                if (i + formulaBatchSize < dataItems.length) {
+                    await new Promise(resolve => requestAnimationFrame(resolve));
+                }
             }
-            
-            // Yield control between batches to prevent UI freezing using requestAnimationFrame
-            if (i + formulaBatchSize < dataItems.length) {
-              await new Promise(resolve => requestAnimationFrame(resolve));
-            }
-          }
         }
-        
-        
-        const taskNotes = await identifyTaskNotesFromBasesData(dataItems, plugin);
-        
 
-        // Remove loading indicator
-        if (loadingIndicator) {
-          loadingIndicator.remove();
+        const taskNotes = await identifyTaskNotesFromBasesData(dataItems, plugin, undefined, renderCancellation);
+        
+        if (renderCancellation.cancelled) return;
+
+        if (taskNotes.length === 0) {
+            itemsContainer.innerHTML = '';
+            const emptyEl = document.createElement('div');
+            emptyEl.className = 'tn-bases-empty';
+            emptyEl.style.cssText = 'padding: 20px; text-align: center; color: var(--text-muted);';
+            emptyEl.textContent = 'No TaskNotes tasks found for this Base.';
+            itemsContainer.appendChild(emptyEl);
+            return;
         }
+
+        // --- Start of new rendering logic ---
+
+        // 1. Get card options and visible properties
+        let visibleProperties: string[] | undefined;
+        const cardOptions = {
+            showCheckbox: false,
+            showArchiveButton: false,
+            showTimeTracking: false,
+            showRecurringControls: true,
+            groupByDate: false
+        };
+
+        if (basesContainer) {
+            const basesVisibleProperties = getBasesVisibleProperties(basesContainer);
+            if (basesVisibleProperties.length > 0) {
+                visibleProperties = basesVisibleProperties.map(p => p.id).map(propId => {
+                    let mappedId = propId;
+                    const internalFieldName = plugin.fieldMapper?.fromUserField(propId);
+                    if (internalFieldName) mappedId = internalFieldName;
+                    else if (propId.startsWith('task.')) mappedId = propId.substring(5);
+                    else if (propId.startsWith('note.')) {
+                        const stripped = propId.substring(5);
+                        const strippedInternalFieldName = plugin.fieldMapper?.fromUserField(stripped);
+                        if (strippedInternalFieldName) mappedId = strippedInternalFieldName;
+                        else if (stripped === 'dateCreated') mappedId = 'dateCreated';
+                        else if (stripped === 'dateModified') mappedId = 'dateModified';
+                        else if (stripped === 'completedDate') mappedId = 'completedDate';
+                        else mappedId = stripped;
+                    }
+                    else if (propId === 'file.ctime') mappedId = 'dateCreated';
+                    else if (propId === 'file.mtime') mappedId = 'dateModified';
+                    else if (propId === 'file.name') mappedId = 'title';
+                    else if (propId.startsWith('formula.')) mappedId = propId;
+                    return mappedId;
+                });
+            }
+        }
+
+        if (!visibleProperties || visibleProperties.length === 0) {
+            visibleProperties = plugin.settings.defaultVisibleProperties || ['due', 'scheduled', 'projects', 'contexts', 'tags'];
+        }
+
+        // 2. Apply sorting
+        const pathToProps = new Map<string, Record<string, any>>(
+            dataItems.filter(i => !!i.path).map(i => [i.path || '', (i as any).properties || (i as any).frontmatter || {}])
+        );
+        const { getBasesSortComparator } = await import('./sorting');
+        const sortComparator = getBasesSortComparator(basesContainer, pathToProps);
+        if (sortComparator) {
+            taskNotes.sort(sortComparator);
+        }
+
+        // 3. Use the shared DOMReconciler
+        plugin.domReconciler.updateList<TaskInfo>(
+            itemsContainer,
+            taskNotes,
+            (task) => task.path, // getKey
+            (task) => createTaskCard(task, plugin, visibleProperties, cardOptions), // renderItem
+            (element, task) => updateTaskCard(element, task, plugin, visibleProperties, cardOptions) // updateItem
+        );
         
-        // Use DOM reconciliation for efficient updates
-        await reconcileTaskList(itemsContainer, taskNotes, plugin, basesContainer, lastRenderedTasks, null);
-        
-        // Update cache
-        lastRenderedTasks.clear();
-        taskNotes.forEach(task => lastRenderedTasks.set(task.path, task));
-        
-        // Performance logging for monitoring
         const elapsed = performance.now() - startTime;
         if (dataItems.length > 100 || elapsed > 1000) {
           console.log(`[TaskNotes][Bases] Rendered ${taskNotes.length} tasks in ${elapsed.toFixed(0)}ms`);
         }
         
       } catch (error: any) {
-        console.error(`[TaskNotes][BasesPOC] Error rendering Bases ${config.errorPrefix}:`, error);
+        console.error(`[TaskNotes][Bases] Error rendering Bases ${config.errorPrefix}:`, error);
         const errorEl = document.createElement('div');
         errorEl.className = 'tn-bases-error';
         errorEl.style.cssText = 'padding: 20px; color: #d73a49; background: #ffeaea; border-radius: 4px; margin: 10px 0;';
@@ -459,23 +208,15 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
       }
     };
 
-    // Kick off initial async render
     void render();
 
-    // Create view object with proper listener management
     let queryListener: (() => void) | null = null;
     
     const viewObject = {
       refresh: render,
-      onResize: () => {
-        // Handle resize - no-op for now
-      },
-      onDataUpdated: () => {
-        void render();
-      },
-      getEphemeralState: () => {
-        return { scrollTop: currentRoot?.scrollTop || 0 };
-      },
+      onResize: () => {},
+      onDataUpdated: () => { void render(); },
+      getEphemeralState: () => ({ scrollTop: currentRoot?.scrollTop || 0 }),
       setEphemeralState: (state: any) => {
         if (state?.scrollTop && currentRoot) {
           currentRoot.scrollTop = state.scrollTop;
@@ -483,11 +224,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
       },
       destroy: () => {
         if (queryListener && (basesContainer as any)?.query?.off) {
-          try {
-            (basesContainer as any).query.off('change', queryListener);
-          } catch (e) {
-            // Query listener removal may fail if already disposed
-          }
+          try { (basesContainer as any).query.off('change', queryListener); } catch (e) {}
         }
         if (currentRoot) {
           currentRoot.remove();
@@ -498,30 +235,18 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
       load: () => {
         if ((basesContainer as any)?.query?.on && !queryListener) {
           queryListener = () => void render();
-          try {
-            (basesContainer as any).query.on('change', queryListener);
-          } catch (e) {
-            // Query listener registration may fail for various reasons
-          }
+          try { (basesContainer as any).query.on('change', queryListener); } catch (e) {}
         }
-        
-        // Trigger initial formula computation on load
         const controller = (basesContainer as any)?.controller;
         if (controller?.runQuery) {
-          controller.runQuery().then(() => {
-            void render(); // Re-render with computed formulas
-          }).catch((e: any) => {
+          controller.runQuery().then(() => { void render(); }).catch((e: any) => {
             console.warn('[TaskNotes][Bases] Initial formula computation failed:', e);
           });
         }
       },
       unload: () => {
         if (queryListener && (basesContainer as any)?.query?.off) {
-          try {
-            (basesContainer as any).query.off('change', queryListener);
-          } catch (e) {
-            // Query listener removal may fail if already disposed
-          }
+          try { (basesContainer as any).query.off('change', queryListener); } catch (e) {}
         }
         if (currentRoot) {
           currentRoot.remove();

--- a/src/bases/kanban-view.ts
+++ b/src/bases/kanban-view.ts
@@ -4,7 +4,7 @@ import { TaskInfo } from '../types';
 import { getBasesGroupByConfig, BasesGroupByConfig } from './group-by';
 import { getGroupNameComparator } from './group-ordering';
 import { getBasesSortComparator } from './sorting';
-import { createTaskCard } from '../ui/TaskCard';
+import { createTaskCard, updateTaskCard } from '../ui/TaskCard';
 // Removed unused imports - using local BasesContainerLike interface for compatibility
 
 // Use the same interface as base-view-factory for compatibility
@@ -89,15 +89,100 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
 
     const render = async () => {
       if (!currentRoot) return;
+
+      const createColumnElement = (columnId: string, tasks: TaskInfo[], groupByConfig: BasesGroupByConfig | null): HTMLElement => {
+        const columnEl = document.createElement('div');
+        columnEl.className = 'kanban-view__column';
+        columnEl.dataset.columnId = columnId;
+  
+        const headerEl = columnEl.createDiv({ cls: 'kanban-view__column-header' });
+        
+        let title: string;
+        if (groupByConfig) {
+          const propertyId = groupByConfig.normalizedId.toLowerCase();
+          if (propertyId === 'status' || propertyId === 'note.status') {
+            const statusConfig = plugin.statusManager.getStatusConfig(columnId);
+            title = statusConfig?.label || columnId;
+          } else if (propertyId === 'priority' || propertyId === 'note.priority') {
+            const priorityConfig = plugin.priorityManager.getPriorityConfig(columnId);
+            title = priorityConfig?.label || columnId;
+          } else if (propertyId === 'projects' || propertyId === 'project' || propertyId === 'note.projects' || propertyId === 'note.project') {
+            title = columnId === 'none' ? 'No Project' : columnId;
+          } else if (propertyId === 'contexts' || propertyId === 'context' || propertyId === 'note.contexts' || propertyId === 'note.context') {
+            title = columnId === 'none' ? 'Uncategorized' : `@${columnId}`;
+          } else if (propertyId.includes('tag')) {
+            title = columnId === 'none' ? 'Untagged' : `#${columnId}`;
+          } else {
+            title = columnId === 'none' ? 'None' : columnId;
+          }
+        } else {
+          const statusConfig = plugin.statusManager.getStatusConfig(columnId);
+          title = statusConfig?.label || columnId;
+        }
+        headerEl.createEl('div', { cls: 'kanban-view__column-title', text: title });
+        headerEl.createEl('div', { 
+          text: `${tasks.length} tasks`, 
+          cls: 'kanban-view__column-count' 
+        });
+  
+        const bodyEl = columnEl.createDiv({ cls: 'kanban-view__column-body' });
+        bodyEl.createDiv({ cls: 'kanban-view__tasks-container' });
+  
+        addColumnDropHandlers(columnEl, async (taskPath: string, targetColumnId: string) => {
+          try {
+            const task = await plugin.cacheManager.getCachedTaskInfo(taskPath);
+            if (task && groupByConfig) {
+              const originalPropertyId = groupByConfig.normalizedId;
+              const propertyId = originalPropertyId.toLowerCase();
+              let valueToSet: any = targetColumnId;
+              if (targetColumnId === 'none' || targetColumnId === 'uncategorized') {
+                valueToSet = null;
+              }
+  
+              if (propertyId === 'status' || propertyId === 'note.status') {
+                await plugin.updateTaskProperty(task, 'status', valueToSet, { silent: true });
+              } else if (propertyId === 'priority' || propertyId === 'note.priority') {
+                await plugin.updateTaskProperty(task, 'priority', valueToSet, { silent: true });
+              } else if (propertyId === 'projects' || propertyId === 'project' || propertyId === 'note.projects' || propertyId === 'note.project') {
+                const projectValue = valueToSet ? (Array.isArray(valueToSet) ? valueToSet : [valueToSet]) : [];
+                await plugin.updateTaskProperty(task, 'projects', projectValue, { silent: true });
+              } else if (propertyId === 'contexts' || propertyId === 'context' || propertyId === 'note.contexts' || propertyId === 'note.context') {
+                const contextValue = valueToSet ? (Array.isArray(valueToSet) ? valueToSet : [valueToSet]) : [];
+                await plugin.updateTaskProperty(task, 'contexts', contextValue, { silent: true });
+              } else {
+                try {
+                  const file = plugin.app.vault.getAbstractFileByPath(task.path);
+                  if (file && 'stat' in file) {
+                    await plugin.app.fileManager.processFrontMatter(file as any, (frontmatter: any) => {
+                      const propertyName = originalPropertyId.includes('.') 
+                        ? originalPropertyId.split('.').pop()! 
+                        : originalPropertyId;
+                      frontmatter[propertyName] = valueToSet;
+                    });
+                  }
+                } catch (frontmatterError) {
+                  console.warn('[TaskNotes][Bases] Frontmatter update failed for custom property:', frontmatterError);
+                }
+              }
+              await render();
+            } else if (task && !groupByConfig) {
+              await plugin.updateTaskProperty(task, 'status', targetColumnId, { silent: true });
+              await render();
+            }
+          } catch (e) {
+            console.error('[TaskNotes][Bases] Move failed:', e);
+          }
+        });
+  
+        return columnEl;
+      };
       
       try {
         const dataItems = extractDataItems();
         const taskNotes = await identifyTaskNotesFromBasesData(dataItems, plugin);
 
-        // Clear board
-        board.innerHTML = '';
-
         if (taskNotes.length === 0) {
+          board.innerHTML = '';
           const empty = document.createElement('div');
           empty.className = 'tn-bases-empty';
           empty.style.cssText = 'padding: 20px; text-align: center; color: var(--text-muted);';
@@ -106,23 +191,16 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
           return;
         }
 
-        // Build path -> props map for dynamic property access
         const pathToProps = new Map<string, Record<string, any>>(
           dataItems.filter(i => !!i.path).map(i => [i.path || '', i.properties || {}])
         );
 
-        // Get advanced groupBy configuration
         const groupByConfig = getBasesGroupByConfig(basesContainer, pathToProps);
-        
-        // Group tasks using the advanced system
         const groups = new Map<string, TaskInfo[]>();
         
         if (groupByConfig) {
-          // Use dynamic groupBy from Bases configuration
           for (const task of taskNotes) {
             const groupValues = groupByConfig.getGroupValues(task.path);
-            
-            // Tasks can belong to multiple groups (e.g., multiple tags)
             for (const groupValue of groupValues) {
               if (!groups.has(groupValue)) {
                 groups.set(groupValue, []);
@@ -131,7 +209,6 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
             }
           }
         } else {
-          // Fallback to status grouping when no groupBy is configured
           for (const task of taskNotes) {
             const groupValue = task.status || 'open';
             if (!groups.has(groupValue)) {
@@ -139,8 +216,6 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
             }
             groups.get(groupValue)!.push(task);
           }
-          
-          // Add empty status columns
           plugin.statusManager.getAllStatuses().forEach(status => {
             if (!groups.has(status.value)) {
               groups.set(status.value, []);
@@ -148,158 +223,80 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
           });
         }
 
-        // Get sorting configuration for group names
         const sortComparator = getBasesSortComparator(basesContainer, pathToProps);
         const firstSortEntry = sortComparator ? { id: groupByConfig?.normalizedId || 'status', direction: 'ASC' as const } : null;
         const groupNameComparator = getGroupNameComparator(firstSortEntry);
-
-        // Create columns with proper ordering
         const columnIds = Array.from(groups.keys()).sort(groupNameComparator);
-        
-        for (const columnId of columnIds) {
-          const tasks = groups.get(columnId) || [];
-          const columnEl = createColumnElement(columnId, tasks, groupByConfig);
-          board.appendChild(columnEl);
-        }
+
+        plugin.domReconciler.updateList<string>(
+            board,
+            columnIds,
+            (columnId) => columnId,
+            (columnId) => {
+                const tasks = groups.get(columnId) || [];
+                const columnEl = createColumnElement(columnId, tasks, groupByConfig);
+                const tasksContainer = columnEl.querySelector('.kanban-view__tasks-container') as HTMLElement;
+                if (tasksContainer) {
+                    const visibleProperties = plugin.settings.defaultVisibleProperties;
+                    const cardOptions = { showDueDate: true, showCheckbox: false, showTimeTracking: true };
+                    plugin.domReconciler.updateList<TaskInfo>(
+                        tasksContainer,
+                        tasks,
+                        (task) => task.path,
+                        (task) => {
+                            const taskCard = createTaskCard(task, plugin, visibleProperties, cardOptions);
+                            taskCard.draggable = true;
+                            taskCard.addEventListener('dragstart', (e: DragEvent) => {
+                                if (e.dataTransfer) {
+                                    e.dataTransfer.setData('text/plain', task.path);
+                                    e.dataTransfer.effectAllowed = 'move';
+                                }
+                            });
+                            return taskCard;
+                        },
+                        (element, task) => {
+                            updateTaskCard(element, task, plugin, visibleProperties, cardOptions);
+                        }
+                    );
+                }
+                return columnEl;
+            },
+            (columnEl, columnId) => {
+                const tasks = groups.get(columnId) || [];
+                const tasksContainer = columnEl.querySelector('.kanban-view__tasks-container') as HTMLElement;
+                if (tasksContainer) {
+                    const visibleProperties = plugin.settings.defaultVisibleProperties;
+                    const cardOptions = { showDueDate: true, showCheckbox: false, showTimeTracking: true };
+                    plugin.domReconciler.updateList<TaskInfo>(
+                        tasksContainer,
+                        tasks,
+                        (task) => task.path,
+                        (task) => {
+                            const taskCard = createTaskCard(task, plugin, visibleProperties, cardOptions);
+                            taskCard.draggable = true;
+                            taskCard.addEventListener('dragstart', (e: DragEvent) => {
+                                if (e.dataTransfer) {
+                                    e.dataTransfer.setData('text/plain', task.path);
+                                    e.dataTransfer.effectAllowed = 'move';
+                                }
+                            });
+                            return taskCard;
+                        },
+                        (element, task) => {
+                            updateTaskCard(element, task, plugin, visibleProperties, cardOptions);
+                        }
+                    );
+                }
+                const countEl = columnEl.querySelector('.kanban-view__column-count') as HTMLElement;
+                if(countEl) {
+                    countEl.textContent = `${tasks.length} tasks`;
+                }
+            }
+        );
 
       } catch (error) {
         console.error('[TaskNotes][Bases] Error rendering Kanban:', error);
       }
-    };
-
-    // Reuse existing kanban column creation logic
-    const createColumnElement = (columnId: string, tasks: TaskInfo[], groupByConfig: BasesGroupByConfig | null): HTMLElement => {
-      const columnEl = document.createElement('div');
-      columnEl.className = 'kanban-view__column';
-      columnEl.dataset.columnId = columnId;
-
-      // Column header
-      const headerEl = columnEl.createDiv({ cls: 'kanban-view__column-header' });
-      
-      // Title - format based on property type and use TaskNotes display values
-      let title: string;
-      
-      if (groupByConfig) {
-        const propertyId = groupByConfig.normalizedId.toLowerCase();
-        
-        // Map Bases property IDs to TaskNotes native properties and use display values
-        if (propertyId === 'status' || propertyId === 'note.status') {
-          const statusConfig = plugin.statusManager.getStatusConfig(columnId);
-          title = statusConfig?.label || columnId;
-        } else if (propertyId === 'priority' || propertyId === 'note.priority') {
-          const priorityConfig = plugin.priorityManager.getPriorityConfig(columnId);
-          title = priorityConfig?.label || columnId;
-        } else if (propertyId === 'projects' || propertyId === 'project' || propertyId === 'note.projects' || propertyId === 'note.project') {
-          title = columnId === 'none' ? 'No Project' : columnId;
-        } else if (propertyId === 'contexts' || propertyId === 'context' || propertyId === 'note.contexts' || propertyId === 'note.context') {
-          title = columnId === 'none' ? 'Uncategorized' : `@${columnId}`;
-        } else if (propertyId.includes('tag')) {
-          // Handle tags properties
-          title = columnId === 'none' ? 'Untagged' : `#${columnId}`;
-        } else {
-          // For custom properties, show the value directly (not prefixed)
-          title = columnId === 'none' ? 'None' : columnId;
-        }
-      } else {
-        // Fallback for status grouping
-        const statusConfig = plugin.statusManager.getStatusConfig(columnId);
-        title = statusConfig?.label || columnId;
-      }
-      headerEl.createEl('div', { cls: 'kanban-view__column-title', text: title });
-      
-      // Count
-      headerEl.createEl('div', { 
-        text: `${tasks.length} tasks`, 
-        cls: 'kanban-view__column-count' 
-      });
-
-      // Column body
-      const bodyEl = columnEl.createDiv({ cls: 'kanban-view__column-body' });
-      const tasksContainer = bodyEl.createDiv({ cls: 'kanban-view__tasks-container' });
-
-      // Render tasks using existing TaskCard system
-      tasks.forEach(task => {
-        const visibleProperties = plugin.settings.defaultVisibleProperties;
-        const taskCard = createTaskCard(task, plugin, visibleProperties, {
-          showDueDate: true,
-          showCheckbox: false,
-          showTimeTracking: true
-        });
-        
-        // Make draggable
-        taskCard.draggable = true;
-        taskCard.addEventListener('dragstart', (e: DragEvent) => {
-          if (e.dataTransfer) {
-            e.dataTransfer.setData('text/plain', task.path);
-            e.dataTransfer.effectAllowed = 'move';
-          }
-        });
-        
-        tasksContainer.appendChild(taskCard);
-      });
-
-      // Add drop handlers - enhanced for dynamic groupBy
-      addColumnDropHandlers(columnEl, async (taskPath: string, targetColumnId: string) => {
-        try {
-          const task = await plugin.cacheManager.getCachedTaskInfo(taskPath);
-          if (task && groupByConfig) {
-            // Map Bases property IDs to TaskNotes native properties for updates
-            const originalPropertyId = groupByConfig.normalizedId;
-            const propertyId = originalPropertyId.toLowerCase();
-            
-            // Handle different property types
-            let valueToSet: any;
-            if (targetColumnId === 'none' || targetColumnId === 'uncategorized') {
-              valueToSet = null; // Clear the property
-            } else {
-              // For most properties, set the single value
-              // For array properties, determine if we should use array or single value
-              valueToSet = targetColumnId;
-            }
-            
-            // For native TaskNotes properties, use TaskNotes update methods directly
-            if (propertyId === 'status' || propertyId === 'note.status') {
-              await plugin.updateTaskProperty(task, 'status', valueToSet, { silent: true });
-            } else if (propertyId === 'priority' || propertyId === 'note.priority') {
-              await plugin.updateTaskProperty(task, 'priority', valueToSet, { silent: true });
-            } else if (propertyId === 'projects' || propertyId === 'project' || propertyId === 'note.projects' || propertyId === 'note.project') {
-              const projectValue = valueToSet ? (Array.isArray(valueToSet) ? valueToSet : [valueToSet]) : [];
-              await plugin.updateTaskProperty(task, 'projects', projectValue, { silent: true });
-            } else if (propertyId === 'contexts' || propertyId === 'context' || propertyId === 'note.contexts' || propertyId === 'note.context') {
-              const contextValue = valueToSet ? (Array.isArray(valueToSet) ? valueToSet : [valueToSet]) : [];
-              await plugin.updateTaskProperty(task, 'contexts', contextValue, { silent: true });
-            } else {
-              // For custom properties, update frontmatter directly
-              try {
-                const file = plugin.app.vault.getAbstractFileByPath(task.path);
-                if (file && 'stat' in file) { // Check if it's a TFile
-                  await plugin.app.fileManager.processFrontMatter(file as any, (frontmatter: any) => {
-                    // Extract the actual property name from Bases property ID
-                    // e.g., "note.note.projects" -> "projects"
-                    const propertyName = originalPropertyId.includes('.') 
-                      ? originalPropertyId.split('.').pop()! 
-                      : originalPropertyId;
-                    frontmatter[propertyName] = valueToSet;
-                  });
-                }
-              } catch (frontmatterError) {
-                console.warn('[TaskNotes][Bases] Frontmatter update failed for custom property:', frontmatterError);
-              }
-            }
-            
-            // Refresh the view
-            await render();
-          } else if (task && !groupByConfig) {
-            // Fallback to status update when no groupBy config
-            await plugin.updateTaskProperty(task, 'status', targetColumnId, { silent: true });
-            await render();
-          }
-        } catch (e) {
-          console.error('[TaskNotes][Bases] Move failed:', e);
-        }
-      });
-
-      return columnEl;
     };
 
     // Column title formatting now handled in createColumnElement with groupBy config


### PR DESCRIPTION
## Summary
- Add warning dialog when Bases queries return >1000 tasks
- Users can choose to cancel or continue loading
- Applied to both list and kanban views

## Context
Addresses part of #613 where large datasets can cause UI freezing. This doesn't solve all performance issues but gives users an informed choice before loading very large result sets.

## Changes
- Modal warning with task count and performance impact description
- Cancel option shows helpful message suggesting query refinement
- Continue option proceeds with existing optimized rendering
- Uses Lucide icons and proper DOM construction

## Test Plan
- [ ] Test with query returning >1000 tasks - warning should appear
- [ ] Test with query returning <1000 tasks - no warning
- [ ] Verify cancel shows appropriate message
- [ ] Verify continue loads all tasks normally