### PR TITLE
Remove cursor above subtasks when subtasks are set to show at top of project note

### DIFF
--- a/styles/project-note-subtasks.css
+++ b/styles/project-note-subtasks.css
@@ -36,6 +36,11 @@
     outline: none;
 }
 
+/* Hide CodeMirror widgetBuffer img when it's adjacent to our widget and our widget is on top of note (not last-child) */
+.cm-content > .cm-line:not(:last-child):has(.project-note-subtasks) img.cm-widgetBuffer {
+    display: none !important;
+}
+
 /* Hide CodeMirror cursor when it's adjacent to our widget */
 .cm-line:has(.project-note-subtasks) .cm-cursor,
 .cm-line:has(.project-note-subtasks) + .cm-line .cm-cursor {


### PR DESCRIPTION
I like to have my subtasks at the top of my project notes, but I noticed that there is a cursor shown above the subtasks but jumps to below the subtasks when you start typing.  This leaves a line gap and looks confusing.

This css fixes the issue by setting the CodeMirror widgetBuffer img tag to display: none; if the project-note-subtasks are at the top (or specifically, not at the bottom).

I tested this with both top and bottom display of subtasks and it worked well in my tests.  Oddly enough, if I set it to display: none while at the bottom, the opposite problem occurs (a cursor appears below the subtasks), that is why I look for not last-child.