### PR TITLE
docs: fix documentation inaccuracies and broken navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,25 @@
 # <img src="tasknotes-gradient.svg" width="32" height="32" style="vertical-align: middle;"> TaskNotes for Obsidian
 
-A task management plugin where each task is stored as an individual note using YAML frontmatter with calendar, kanban and pomodoro integration.
+Task management plugin where each task lives as a separate note with YAML frontmatter. Features calendar integration, Kanban boards, time tracking, and Pomodoro timer.
 
 ![Downloads](https://img.shields.io/github/downloads/callumalpass/tasknotes/main.js)
-![Screenshot of biblib Obsidian plugin](https://github.com/callumalpass/tasknotes/blob/main/media/175266750_comp.gif)
+![Screenshot of TaskNotes plugin](https://github.com/callumalpass/tasknotes/blob/main/media/175266750_comp.gif)
 
-**[ Documentation](https://callumalpass.github.io/tasknotes/)**
-
-### Quick Links
-
-- **[Getting Started](./docs/index.md)** - Core concepts and setup
-- **[Features Overview](./docs/features.md)** - Complete feature list
-- **[Views Guide](./docs/views.md)** - All available view types
-- **[Settings](./docs/settings.md)** - Configuration options
-- **[HTTP API](./docs/HTTP_API.md)** - External integrations
-- **[Troubleshooting](./docs/troubleshooting.md)** - Common issues
+**[📖 Documentation](https://callumalpass.github.io/tasknotes/)**
 
 ## Overview
 
-TaskNotes treats each task as an individual Markdown file with YAML frontmatter containing the task's metadata (due date, status, priority, etc.) and the note body for additional context, descriptions, or progress notes. This creates a flexible system where tasks can be as simple or detailed as needed.
+Each task is a full Markdown note with structured metadata in YAML frontmatter. This means your tasks have all the benefits of regular notes - linking, tagging, graph view, and unlimited content - while still working as structured data for filtering and organization.
 
-The plugin includes several views: calendar, kanban boards, filtered task lists, and a daily agenda. Tasks can link to projects using Obsidian's note linking. Recurring tasks track completion per instance.
+The plugin supports time tracking, recurring tasks, calendar integration with external ICS feeds, and integration with the Obsidian Bases plugin.
 
-You can track time on tasks with start/stop buttons and view session history. There's also a pomodoro timer that connects to tasks, with configurable work/break periods and stats.
+## Why YAML Frontmatter?
 
-## Rationale
+YAML is a standard data format that works with many tools, so you can easily extract and transform your task data into other formats. This keeps your data portable and aligns with Obsidian's file-over-app philosophy.
 
-Using YAML frontmatter for task storage has multiple benefits. YAML is a standard data format that works with many tools, so you can easily extract and transform your task data into other formats. This keeps your data portable and aligns with Obsidian's file-over-app philosophy.
+The frontmatter is extensible—add custom fields like "assigned-to" or "attachments" and use tools like Obsidian Bases to work with that data. This flexibility makes features like time-tracking natural, since there's an obvious place to store timing information.
 
-The frontmatter is also extensible—you can add custom fields like "assigned-to" or "attachments" and use other tools like Obsidian Bases to work with that data. This flexibility made it easy to add features like time-tracking, which is tricky in other task formats where there's no obvious place to store timing information.
-
-Since each task is a full note, you can write detailed descriptions, jot down thoughts as you work, and connect tasks to other notes through Obsidian's linking and graph features. The frontmatter compatibility with Bases also means you can use that plugin for different views and bulk operations if you want.
+Each task being a full note means you can write descriptions, jot down thoughts as you work, and connect tasks to other notes through Obsidian's linking and graph features. Bases integration provides custom views on your task data.
 
 ## Core Features
 
@@ -100,6 +89,7 @@ Since each task is a full note, you can write detailed descriptions, jot down th
 ## YAML Structure
 
 ### Task Example
+
 ```yaml
 title: "Complete documentation"
 status: "in-progress"

--- a/docs/TIMEZONE_HANDLING_GUIDE.md
+++ b/docs/TIMEZONE_HANDLING_GUIDE.md
@@ -1,8 +1,8 @@
-# ChronoSync Timezone Handling Guide
+# TaskNotes Timezone Handling Guide
 
 ## Overview
 
-ChronoSync uses a **UTC Midnight Convention** to ensure consistent date handling across all timezones. This guide explains how to handle dates correctly to avoid timezone-related bugs.
+TaskNotes uses a **UTC Midnight Convention** to ensure consistent date handling across all timezones. This guide explains how to handle dates correctly to avoid timezone-related bugs.
 
 ## Core Principle: Local Dates for Users, UTC for RRule
 
@@ -126,7 +126,7 @@ const calendarDate = formatDateForStorage(date); // This now returns local anywa
 
 ### What About `formatDateForStorage()`?
 
-This function now just calls `formatDateForStorage()` internally. It exists for backward compatibility but always returns local dates. You can use either, but prefer `formatDateForStorage()` for clarity.
+This function converts Date objects to YYYY-MM-DD format using local timezone components. It ensures consistent date formatting for storage and display purposes.
 
 ## Testing Your Code
 

--- a/docs/TIMEZONE_HANDLING_UTC.md
+++ b/docs/TIMEZONE_HANDLING_UTC.md
@@ -1,14 +1,14 @@
-# UTC-Based Timezone Handling in ChronoSync
+# UTC-Based Timezone Handling in TaskNotes
 
 ## Overview
 
-ChronoSync implements a UTC-based timezone approach to ensure consistent date handling across all timezones while maintaining intuitive user behavior. This document explains the technical implementation, design decisions, and best practices for developers working with the codebase.
+TaskNotes implements a UTC-based timezone approach to ensure consistent date handling across all timezones while maintaining intuitive user behavior. This document explains the technical implementation, design decisions, and best practices for developers working with the codebase.
 
 ## Core Architecture
 
 ### The UTC Midnight Convention
 
-ChronoSync follows a **UTC Midnight Convention** that operates on two key principles:
+TaskNotes follows a **UTC Midnight Convention** that operates on two key principles:
 
 1. **User-facing operations** use local dates for intuitive behavior
 2. **Internal calculations** use UTC to prevent timezone-dependent bugs
@@ -263,7 +263,7 @@ const rruleDate = createUTCDateForRRule(dateStr); // Interpreted as UTC - CONSIS
 
 ### Timezone-Aware Test Cases
 
-ChronoSync includes comprehensive tests for timezone handling:
+TaskNotes includes comprehensive tests for timezone handling:
 
 1. **Basic Date Functions**: Test date creation, parsing, and formatting across timezones
 2. **Recurring Task Logic**: Verify RRule calculations work correctly regardless of user timezone
@@ -355,6 +355,6 @@ The UTC-based approach maintains backward compatibility:
 
 ## Conclusion
 
-The UTC-based timezone approach provides ChronoSync with robust, consistent date handling that prevents timezone-related bugs while maintaining intuitive user behavior. By following the guidelines in this document, developers can ensure their code works correctly for users in all timezones.
+The UTC-based timezone approach provides TaskNotes with robust, consistent date handling that prevents timezone-related bugs while maintaining intuitive user behavior. By following the guidelines in this document, developers can ensure their code works correctly for users in all timezones.
 
 For quick reference, see the [Timezone Quick Reference Guide](TIMEZONE_QUICK_REFERENCE.md) for common patterns and functions.

--- a/docs/TIMEZONE_QUICK_REFERENCE.md
+++ b/docs/TIMEZONE_QUICK_REFERENCE.md
@@ -1,4 +1,4 @@
-# ChronoSync Timezone Quick Reference
+# TaskNotes Timezone Quick Reference
 
 ## 🚀 Quick Cheat Sheet
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,34 +1,23 @@
 # Core Concepts
 
-TaskNotes is a task and note management plugin for Obsidian that is built on the principle of "one note per task." This means that each task is a Markdown note, and all task-related information is stored in the note's YAML frontmatter.
+TaskNotes follows the "one note per task" principle, where each task lives as a separate Markdown note with structured metadata in YAML frontmatter.
 
 ## The Note-Per-Task Approach
 
-TaskNotes uses individual Markdown notes for each task, rather than a centralized database or a proprietary format. This approach has several implications:
+Individual Markdown notes replace centralized databases or proprietary formats. Each task file can be read, edited, and backed up with any text editor or automation tool.
 
-**Data Ownership and Portability**: Each task is a standard Markdown file that you can read, edit, and back up with any text editor or automation tool.
+The note body holds additional context like research findings, meeting notes, or links to related documents. Since tasks are proper notes, they work with Obsidian's backlinking, graph visualization, and tag management.
 
-**Rich Context and Flexibility**: You can include additional content in the body of each task note, such as research findings, meeting notes, or links to related documents.
-
-**Obsidian Integration**: By treating tasks as notes, TaskNotes can use Obsidian's core features, such as backlinking, graph visualization, and tag management.
-
-Storing each task as a separate file can lead to a large number of small files, which may not be ideal for all organizational preferences.
+This approach does create many small files, which may not suit every organizational preference.
 
 ## YAML Frontmatter for Structured Data
 
-TaskNotes uses YAML frontmatter to store structured task metadata, such as due dates, priority levels, and status. This human-readable format has several implications:
+Task metadata like due dates, priorities, and status live in YAML frontmatter. This widely adopted standard has broad tool support, letting you integrate task data with external systems and extend the data model with custom fields.
 
-**Standardization and Extensibility**: YAML is a widely adopted standard with broad tool support, which allows you to integrate your task data with external systems. You can also extend the data model by adding custom fields to the frontmatter.
+TaskNotes uses Obsidian's native metadata cache for performance, even with large task counts. The YAML format works with other Obsidian plugins like Bases, and plain text files integrate naturally with version control systems like Git.
 
-**Performance and Compatibility**: By using Obsidian's native metadata cache, TaskNotes can maintain good performance, even with a large number of tasks. The use of YAML frontmatter also allows for compatibility with other Obsidian plugins, such as Bases.
+## Methodology-Agnostic Design
 
-**Version Control and Collaboration**: Since tasks are stored as plain text files, they can be used with version control systems like Git.
+TaskNotes doesn't enforce any specific productivity methodology. The tools adapt to various approaches:
 
-## A Methodology-Agnostic Approach
-
-TaskNotes does not enforce a specific task management methodology. It provides a set of tools that can be adapted to a variety of productivity systems, including:
-
-- **Getting Things Done (GTD)**: Contexts, status workflows, and calendar integration can be used to support GTD principles.
-- **Timeboxing and Time-blocking**: Calendar integration and time tracking features can be used for time-based planning.
-- **Project-based Organization**: The projects feature, along with tags, contexts, and linking capabilities, can be used for project-centric workflows.
-- **Kanban and Agile**: The Kanban view and customizable status systems can be used to support agile development processes and other visual workflows.
+Getting Things Done benefits from contexts, status workflows, and calendar integration. Time-based planning uses calendar integration and time tracking features. Project-centric workflows leverage the projects feature with tags, contexts, and linking. Kanban and Agile methodologies work with the Kanban view and customizable status systems.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,4 +1,3 @@
-
 # Features
 
 TaskNotes is a task and note management plugin for Obsidian. It includes features for task management, inline task integration, time management, and calendar integration.
@@ -15,6 +14,7 @@ TaskNotes provides a system for managing tasks. You can create, edit, and organi
 - **Planning**: Time estimates and recurring patterns.
 - **Tracking**: Automatic creation and modification dates.
 - **Reminders**: Custom notifications for tasks using relative or absolute timing.
+- **Auto-archive**: Automatically archive tasks based on their status.
 
 For more detailed information, see the [Task Management](features/task-management.md) documentation.
 
@@ -25,7 +25,7 @@ TaskNotes provides comprehensive filtering capabilities through a hierarchical q
 - **Quick Search**: Instant text-based filtering
 - **Query Builder**: Complex hierarchical filter conditions with AND/OR logic
 - **Saved Views**: Named filter configurations for quick access
-- **Sorting and Grouping**: Multiple options for organizing task display
+- **Sorting and Grouping**: Multiple options for organizing task display, including by tags and custom user fields.
 
 For more detailed information, see the [Filtering and Views](features/filtering-and-views.md) documentation.
 
@@ -35,8 +35,9 @@ TaskNotes integrates with the Obsidian editor, which allows you to manage your t
 
 - **Task Link Overlays**: Interactive widgets that display task information and allow for quick edits.
 - **Instant Task Conversion**: A feature to convert checkbox tasks into TaskNotes.
+- **`create inline task` command**: A command to create a new task from within the editor.
 - **Project Subtasks Widget**: A collapsible widget that displays tasks linked to the current project note.
-- **Natural Language Processing**: A feature to create tasks from conversational language, with automatic parsing of dates, priorities, and other details.
+- **Natural Language Processing**: A feature to create tasks from conversational language, with automatic parsing of dates, priorities, and other details. Supports 12 languages.
 
 For more detailed information, see the [Inline Task Integration](features/inline-tasks.md) documentation.
 
@@ -55,20 +56,35 @@ For more detailed information, see the [Time Management](features/time-managemen
 TaskNotes includes calendar integration features, such as:
 
 - **ICS Calendar Subscriptions**: A feature to subscribe to external calendar feeds from Google Calendar, Outlook, and other services.
+- **ICS Export**: Export your task list as an ICS file, with automatic updates.
 - **Advanced Calendar View**: A calendar with multiple view modes (month, week, day, year, and configurable custom days), drag-and-drop scheduling, and time-blocking capabilities.
 - **Time-blocking**: A feature to create focused work periods and link them to your tasks.
 
 For more detailed information, see the [Calendar Integration](features/calendar-integration.md) documentation.
 
-## Workflows
+## User Fields
 
-TaskNotes can be configured to support various workflows and use cases. Common workflows include:
+TaskNotes allows you to define your own custom fields for tasks. This feature allows you to:
 
-- **Habit Tracking**: Using recurring tasks with completion tracking via the calendar interface
-- **Project Management**: Organizing tasks with project links and filtering
-- **Time Management**: Combining time tracking, Pomodoro sessions, and scheduling
+- **Add custom data**: Add any data you want to your tasks.
+- **Filter and sort**: Filter and sort your tasks based on your custom fields.
+- **Use in templates**: Use your custom fields in templates.
 
-For detailed workflow examples, see the [Workflows](workflows.md) documentation.
+For more detailed information, see the [User Fields](features/user-fields.md) documentation.
+
+## Integrations
+
+TaskNotes integrates with other Obsidian plugins, such as:
+
+- **Bases**: A deep integration with the Bases plugin, allowing you to use TaskNotes tasks in your Bases databases.
+
+For more detailed information, see the [Integrations](features/integrations.md) documentation.
+
+## REST API
+
+TaskNotes provides a REST API that allows you to interact with the plugin from other applications.
+
+For more detailed information, see the [HTTP API](HTTP_API.md) documentation.
 
 ## View Types
 
@@ -76,7 +92,7 @@ TaskNotes provides multiple view types for different perspectives on your tasks:
 
 - **[Task List View](views/task-list.md)** - Filtering, sorting, and grouping capabilities
 - **[Agenda View](views/agenda-view.md)** - Daily and weekly planning view
-- **[Kanban View](views/kanban-view.md)** - Card-based task organization  
+- **[Kanban View](views/kanban-view.md)** - Card-based task organization
 - **[Calendar Views](views/calendar-views.md)** - Visual scheduling and time-blocking
 - **[Notes View](views/notes-view.md)** - Date-based note browsing
 - **[Pomodoro View](views/pomodoro-view.md)** - Focus timer with task integration
@@ -90,5 +106,3 @@ Configure TaskNotes to match your workflow:
 - **[Calendar Settings](settings/calendar-settings.md)** - Calendar appearance and behavior
 - **[Advanced Settings](settings/advanced-settings.md)** - Field mapping and customization
 - **[Misc Settings](settings/misc-settings.md)** - Additional plugin features
-
-

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,108 +1,73 @@
 # Features
 
-TaskNotes is a task and note management plugin for Obsidian. It includes features for task management, inline task integration, time management, and calendar integration.
-
-[← Back to Documentation](index.md)
+TaskNotes covers the full spectrum of task management, from basic organization to advanced workflows with time tracking and calendar integration.
 
 ## Task Management
 
-TaskNotes provides a system for managing tasks. You can create, edit, and organize tasks with a variety of properties, including:
+Tasks support configurable status and priority levels, along with due dates, scheduled dates, contexts, and tags. Time estimates and recurring patterns help with planning, while automatic creation and modification timestamps keep everything tracked.
 
-- **Status and Priority**: Configurable status and priority levels.
-- **Scheduling**: Due dates and scheduled dates.
-- **Organization**: Contexts and tags.
-- **Planning**: Time estimates and recurring patterns.
-- **Tracking**: Automatic creation and modification dates.
-- **Reminders**: Custom notifications for tasks using relative or absolute timing.
-- **Auto-archive**: Automatically archive tasks based on their status.
+Custom reminders use either relative timing ("3 days before due") or absolute dates. Tasks can auto-archive based on their completion status, keeping your active lists clean.
 
-For more detailed information, see the [Task Management](features/task-management.md) documentation.
+See [Task Management](features/task-management.md) for details.
 
 ## Filtering and Views
 
-TaskNotes provides comprehensive filtering capabilities through a hierarchical query builder. The FilterBar is available in multiple views and supports:
+The FilterBar appears across multiple views, offering instant text search plus a hierarchical query builder for complex conditions using AND/OR logic. Saved views let you store frequently-used filter combinations, while sorting and grouping options organize tasks by tags, custom fields, or other properties.
 
-- **Quick Search**: Instant text-based filtering
-- **Query Builder**: Complex hierarchical filter conditions with AND/OR logic
-- **Saved Views**: Named filter configurations for quick access
-- **Sorting and Grouping**: Multiple options for organizing task display, including by tags and custom user fields.
-
-For more detailed information, see the [Filtering and Views](features/filtering-and-views.md) documentation.
+See [Filtering and Views](features/filtering-and-views.md) for details.
 
 ## Inline Task Integration
 
-TaskNotes integrates with the Obsidian editor, which allows you to manage your tasks from within your notes. Key features include:
+Task management happens directly within your notes through interactive widgets that overlay task links, showing information and allowing quick edits without leaving the editor. Convert existing checkbox tasks instantly, or create new tasks with the `create inline task` command.
 
-- **Task Link Overlays**: Interactive widgets that display task information and allow for quick edits.
-- **Instant Task Conversion**: A feature to convert checkbox tasks into TaskNotes.
-- **`create inline task` command**: A command to create a new task from within the editor.
-- **Project Subtasks Widget**: A collapsible widget that displays tasks linked to the current project note.
-- **Natural Language Processing**: A feature to create tasks from conversational language, with automatic parsing of dates, priorities, and other details. Supports 12 languages.
+Project notes can display collapsible widgets showing all linked subtasks. Natural language processing turns conversational text into structured tasks, automatically parsing dates, priorities, and other details across 12 languages.
 
-For more detailed information, see the [Inline Task Integration](features/inline-tasks.md) documentation.
+See [Inline Task Integration](features/inline-tasks.md) for details.
 
 ## Time Management
 
-TaskNotes includes time management tools, such as:
+Built-in time tracking records work sessions for individual tasks, while the integrated Pomodoro timer helps maintain focus during work periods. Analytics and statistics show patterns in your productivity over time.
 
-- **Time Tracking**: A time tracker to record the time you spend on each task.
-- **Pomodoro Timer**: A Pomodoro timer to work in focused intervals.
-- **Productivity Analytics**: Statistics and visualizations to show your work habits.
-
-For more detailed information, see the [Time Management](features/time-management.md) documentation.
+See [Time Management](features/time-management.md) for details.
 
 ## Calendar Integration
 
-TaskNotes includes calendar integration features, such as:
+External ICS feeds from Google Calendar, Outlook, and similar services sync into TaskNotes, while ICS export lets other systems access your task data with automatic updates.
 
-- **ICS Calendar Subscriptions**: A feature to subscribe to external calendar feeds from Google Calendar, Outlook, and other services.
-- **ICS Export**: Export your task list as an ICS file, with automatic updates.
-- **Advanced Calendar View**: A calendar with multiple view modes (month, week, day, year, and configurable custom days), drag-and-drop scheduling, and time-blocking capabilities.
-- **Time-blocking**: A feature to create focused work periods and link them to your tasks.
+The advanced calendar view supports multiple formats (month, week, day, year, plus configurable custom day ranges) with drag-and-drop task scheduling. Time-blocking creates focused work periods that link directly to specific tasks.
 
-For more detailed information, see the [Calendar Integration](features/calendar-integration.md) documentation.
+See [Calendar Integration](features/calendar-integration.md) for details.
 
 ## User Fields
 
-TaskNotes allows you to define your own custom fields for tasks. This feature allows you to:
+Custom fields extend task structure with any data you need. These fields work in filtering, sorting, and templates, letting you adapt TaskNotes to specialized workflows without losing functionality.
 
-- **Add custom data**: Add any data you want to your tasks.
-- **Filter and sort**: Filter and sort your tasks based on your custom fields.
-- **Use in templates**: Use your custom fields in templates.
-
-For more detailed information, see the [User Fields](features/user-fields.md) documentation.
+See [User Fields](features/user-fields.md) for details.
 
 ## Integrations
 
-TaskNotes integrates with other Obsidian plugins, such as:
+Deep integration with the Bases plugin lets TaskNotes tasks function as data sources within Bases databases, combining structured task management with Bases' analysis capabilities.
 
-- **Bases**: A deep integration with the Bases plugin, allowing you to use TaskNotes tasks in your Bases databases.
-
-For more detailed information, see the [Integrations](features/integrations.md) documentation.
+See [Integrations](features/integrations.md) for details.
 
 ## REST API
 
-TaskNotes provides a REST API that allows you to interact with the plugin from other applications.
+External applications can interact with TaskNotes through its REST API, enabling automation, reporting, and integration with other tools in your workflow.
 
-For more detailed information, see the [HTTP API](HTTP_API.md) documentation.
+See [HTTP API](HTTP_API.md) for details.
 
 ## View Types
 
-TaskNotes provides multiple view types for different perspectives on your tasks:
+Different views suit different work styles:
 
-- **[Task List View](views/task-list.md)** - Filtering, sorting, and grouping capabilities
-- **[Agenda View](views/agenda-view.md)** - Daily and weekly planning view
-- **[Kanban View](views/kanban-view.md)** - Card-based task organization
-- **[Calendar Views](views/calendar-views.md)** - Visual scheduling and time-blocking
-- **[Notes View](views/notes-view.md)** - Date-based note browsing
-- **[Pomodoro View](views/pomodoro-view.md)** - Focus timer with task integration
+[Task List View](views/task-list.md) handles filtering, sorting, and grouping. [Agenda View](views/agenda-view.md) focuses on daily and weekly planning. [Kanban View](views/kanban-view.md) organizes tasks as cards across status columns.
+
+[Calendar Views](views/calendar-views.md) provide visual scheduling with time-blocking. [Notes View](views/notes-view.md) browses content by date. [Pomodoro View](views/pomodoro-view.md) integrates focus timing with task tracking.
 
 ## Settings
 
-Configure TaskNotes to match your workflow:
+Configuration adapts TaskNotes to your workflow:
 
-- **[Task Defaults](settings/task-defaults.md)** - Default properties and templates
-- **[Inline Task Settings](settings/inline-task-settings.md)** - Editor integration options
-- **[Calendar Settings](settings/calendar-settings.md)** - Calendar appearance and behavior
-- **[Advanced Settings](settings/advanced-settings.md)** - Field mapping and customization
-- **[Misc Settings](settings/misc-settings.md)** - Additional plugin features
+[Task Defaults](settings/task-defaults.md) sets default properties and templates. [Inline Task Settings](settings/inline-task-settings.md) controls editor integration. [Calendar Settings](settings/calendar-settings.md) handles appearance and behavior.
+
+[Advanced Settings](settings/advanced-settings.md) covers field mapping and customization. [Misc Settings](settings/misc-settings.md) contains additional plugin features.

--- a/docs/features/calendar-integration.md
+++ b/docs/features/calendar-integration.md
@@ -51,4 +51,4 @@ Related notes and tasks are automatically identified by their ICS event ID field
 
 ## Time-blocking
 
-The Advanced Calendar supports time-blocking, which is a time management method that involves scheduling out parts of your day. You can create time blocks directly in the calendar, and you can link them to specific tasks. Time blocks are stored in the frontmatter of your daily notes.
+The Advanced Calendar supports time-blocking, which is a time management method that involves scheduling out parts of your day. You can create time blocks by holding the Shift key while selecting a time range in the calendar. Time blocks are stored in the frontmatter of your daily notes and can be linked to specific tasks.

--- a/docs/features/ics-integration.md
+++ b/docs/features/ics-integration.md
@@ -5,6 +5,7 @@ TaskNotes provides integration with ICS calendar events, allowing you to create 
 ## Overview
 
 The ICS integration allows you to:
+
 - View detailed information about calendar events
 - Create notes from calendar events with customizable templates
 - Generate tasks from events with proper scheduling and context
@@ -26,6 +27,7 @@ When you interact with a calendar event in TaskNotes, an information modal displ
 ### Related Content
 
 The modal shows a list of existing notes and tasks that are linked to the calendar event. Content is automatically categorized as:
+
 - **Task** - Files containing the configured task tag
 - **Note** - Files without the task tag
 
@@ -54,6 +56,7 @@ The note creation process allows customization of the generated content:
 ### Template Usage
 
 When a template is specified:
+
 - The template file is processed with ICS-specific variables
 - Standard TaskNotes template variables are also available
 - Template content replaces the default event description format
@@ -62,6 +65,7 @@ When a template is specified:
 ### Default Content
 
 Without a template, notes include:
+
 - Event title as the main heading
 - Formatted start and end times
 - Location information
@@ -95,12 +99,14 @@ Task content includes formatted event details similar to note creation, providin
 You can establish connections between existing vault content and calendar events:
 
 ### Link Process
+
 1. Select an existing markdown file from your vault
 2. The file's frontmatter is updated to include the event ID
 3. The modification date is updated to reflect the change
 4. The connection appears in the related content list
 
 ### Bidirectional References
+
 - Calendar events can display all linked content
 - Content files maintain references to their associated events
 - Multiple pieces of content can be linked to a single event
@@ -151,21 +157,27 @@ All standard TaskNotes template variables remain available:
 ICS integration settings are located in the Advanced Settings section:
 
 ### Default Templates
+
 Configure template files for consistent content creation from events. Templates are optional and the system provides sensible defaults when not specified.
 
 ### Default Folders
+
 Set destination folders for content created from events. This helps organize ICS-generated content separately from other vault content if desired.
 
 ### Filename Formats
+
 The system uses the standard TaskNotes filename generation with event-specific context, ensuring unique and descriptive filenames for created content.
 
 ## Technical Implementation
 
 ### Event Identification
+
 Calendar events are identified by their unique ICS event ID, which is maintained in the frontmatter of created content. This allows the system to track relationships even if event details change.
 
 ### Content Type Detection
+
 The system distinguishes between tasks and notes by checking for the presence of the configured task tag in the content's frontmatter tags array, rather than relying on file structure or naming conventions.
 
 ### Error Handling
+
 The integration includes error boundaries for network issues, file operations, and template processing. Failed operations provide user feedback without interrupting the overall workflow.

--- a/docs/features/inline-tasks.md
+++ b/docs/features/inline-tasks.md
@@ -34,6 +34,12 @@ Task link overlays work in both Live Preview and Reading modes:
 
 The overlays support drag-and-drop to calendar views and provide keyboard shortcuts for quick navigation (Ctrl/Cmd+Click to open the source file).
 
+## Create Inline Task Command
+
+The `Create inline task` command allows you to create a new task from the current line in the editor. This command is available in the command palette.
+
+When you run the command, the current line is used as the title of the new task. The line is then replaced with a link to the new task file.
+
 ## Instant Task Conversion
 
 The **Instant Task Conversion** feature transforms lines in your notes into TaskNotes files. This works with both checkbox tasks and regular lines of text. When available, a "convert" button appears next to the content in edit mode. Clicking this button creates a new task note using the line's text as the title and replaces the original line with a link to the new task file.
@@ -161,7 +167,9 @@ The Project Subtasks widget shows the saved view name and completion counts just
 
 ## Natural Language Processing
 
-TaskNotes includes a **Natural Language Processor (NLP)** that parses task descriptions written in English to extract structured data. This allows for task creation from conversational language, such as "Prepare quarterly report due Friday #work high priority," which would automatically set the due date, tag, and priority.
+TaskNotes includes a **Natural Language Processor (NLP)** that parses task descriptions to extract structured data. This allows for task creation from conversational language, such as "Prepare quarterly report due Friday #work high priority," which would automatically set the due date, tag, and priority.
+
+The NLP engine supports multiple languages, including English, Japanese, German, Russian, and Chinese.
 
 The NLP engine supports syntax for:
 

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -3,7 +3,7 @@
 
 TaskNotes integrates with other Obsidian plugins.
 
-[← Back to Features](features.md)
+[← Back to Features](../features.md)
 
 ## Bases
 

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -1,0 +1,25 @@
+
+# Integrations
+
+TaskNotes integrates with other Obsidian plugins.
+
+[← Back to Features](features.md)
+
+## Bases
+
+TaskNotes integrates with the [Bases plugin](https://github.com/obsidian-community/obsidian-bases). This allows you to use your tasks as a data source in your Bases databases.
+
+### Features
+
+- **Task Views**: TaskNotes provides two views for Bases: "Task List" and "Kanban".
+- **Task Properties**: Task properties are displayed on the task cards in the Bases views.
+- **Formula Computation**: Use Bases formulas to perform calculations on your task data.
+
+### Getting Started
+
+To use the Bases integration, you need to have both the TaskNotes and Bases plugins installed and enabled.
+
+1.  **Enable the Integration**: Go to the TaskNotes settings and enable the "Bases Integration" option in the "Integrations" tab.
+2.  **Create a View**: In Bases, create a new view and select either the "TaskNotes Task List" or "TaskNotes Kanban" view.
+
+Your tasks will now be available in the Bases view.

--- a/docs/features/task-management.md
+++ b/docs/features/task-management.md
@@ -6,6 +6,8 @@ TaskNotes provides a system for managing tasks, which is built on the principle 
 
 You can create and edit tasks in a variety of ways. The primary method is through the **Task Creation Modal**, which can be accessed via the "Create new task" command or by clicking on dates or time slots in the calendar views. This modal provides an interface for setting all available task properties, including title, status, priority, and due dates.
 
+When creating a task, the title will be automatically sanitized to remove any characters that are forbidden in filenames.
+
 TaskNotes also supports **Natural Language Creation**, which allows you to create tasks by typing descriptions in plain English. The built-in parser can extract structured data from phrases like "Buy groceries tomorrow at 3pm @home #errands high priority."
 
 ### Auto-Suggestions in Natural Language Input
@@ -125,13 +127,22 @@ Tasks can have subtasks created directly from their context menu. When viewing a
 
 ### Template Integration
 
-Projects support template variables for automated workflows. The `{{parentNote}}` variable inserts the parent note as a properly formatted markdown link. For project organization, it's recommended to use it as a YAML list item (e.g., `project:\n  - {{parentNote}}`) to align with the projects system behavior when creating tasks from project notes through instant conversion.
+Projects support template variables for automated workflows. The `{{parentNote}}` variable inserts the parent note as a properly formatted markdown link. For project organization, it's recommended to use it as a YAML list item (e.g., `project:
+  - {{parentNote}}`) to align with the projects system behavior when creating tasks from project notes through instant conversion.
+
+## Automation
+
+### Auto-Archiving
+
+TaskNotes can automatically archive tasks when they are set to a specific status. This feature is useful for keeping your task list clean and organized.
+
+To enable auto-archiving, go to the TaskNotes settings and select the "Automation" tab. From there, you can enable the "Auto-archive tasks" option and select the status that should trigger the archive. You can also configure a timeout period, which will delay the archiving of the task for a specified amount of time.
 
 ## File Management and Templates
 
 TaskNotes provides a system for managing your task files. You can specify a **Default Tasks Folder** where all new tasks will be created, and you can choose from a variety of **Filename Generation** patterns, including title-based, timestamp-based, and Zettelkasten-style.
 
-TaskNotes also supports **Templates** for both the YAML frontmatter and the body of your task notes. You can use templates to pre-fill common values, add boilerplate text, and create a consistent structure for your tasks. Templates can also include variables, such as `{{title}}`, `{{date}}`, and `{{parentNote}}` (which inserts the parent note as a properly formatted markdown link), which will be automatically replaced with the appropriate values when a new task is created.
+TaskNotes also supports **Templates** for both the YAML frontmatter and the body of your task notes. You can use templates to pre-fill common values, add boilerplate text, and create a consistent structure for your tasks. Templates can also include variables, such as `{{title}}`, `{{date}}`, `{{contexts}}`, `{{projects}}`, and `{{parentNote}}` (which inserts the parent note as a properly formatted markdown link), which will be automatically replaced with the appropriate values when a new task is created.
 
 ## Recurring Tasks
 
@@ -167,6 +178,22 @@ Recurring tasks require:
 All recurrence rules now include DTSTART (start date and optionally time):
 - **Date-only**: `DTSTART:20250804;FREQ=DAILY` (pattern instances appear all-day)
 - **Date and time**: `DTSTART:20250804T090000Z;FREQ=DAILY` (pattern instances appear at 9:00 AM)
+
+### Recurring Task Due Date
+
+When a recurring task is completed, the scheduled date is advanced to the next occurrence. By default, the due date is not changed. However, you can enable the `Maintain due date offset in recurring tasks` setting to automatically update the due date as well.
+
+When this setting is enabled, the offset between the original scheduled date and due date is calculated. This offset is then applied to the new scheduled date to determine the new due date.
+
+For example, consider a task with the following properties:
+
+- **Scheduled Date**: 2025-01-01
+- **Due Date**: 2025-01-03
+- **Recurrence**: Every week
+
+In this case, the due date is 2 days after the scheduled date. When this task is completed, the new scheduled date will be 2025-01-08. If the `Maintain due date offset in recurring tasks` setting is enabled, the new due date will be set to 2025-01-10, preserving the 2-day offset.
+
+To enable this feature, go to the TaskNotes settings and select the "Features" tab. From there, you can enable the `Maintain due date offset in recurring tasks` option.
 
 ### Recurrence Pattern Examples
 

--- a/docs/features/user-fields.md
+++ b/docs/features/user-fields.md
@@ -1,0 +1,41 @@
+
+# User Fields
+
+TaskNotes allows you to define your own custom fields for tasks. This feature allows you to add custom data to your tasks and use it for filtering, sorting, and grouping.
+
+[← Back to Features](features.md)
+
+## Creating User Fields
+
+User fields are created in the TaskNotes settings, under the "Task Properties" tab. To create a new user field, click the "Add new user field" button.
+
+Each user field has the following properties:
+
+- **Display Name**: The name of the field as it will be displayed in the UI.
+- **Property Name**: The name of the field as it will be stored in the frontmatter of the task note.
+- **Type**: The data type of the field. The following types are supported:
+    - **Text**: A single line of text.
+    - **Number**: A number.
+    - **Date**: A date.
+    - **List**: A list of values.
+
+## Using User Fields
+
+Once you have created a user field, it will be available in the following places:
+
+- **Task Modals**: The user field will be displayed as a field in the task creation and edit modals.
+- **Filtering**: You can filter your tasks by the user field in the FilterBar.
+- **Sorting**: You can sort your tasks by the user field.
+- **Grouping**: You can group your tasks by the user field.
+
+## Frontmatter
+
+User field data is stored in the frontmatter of the task note. The property name you define for the user field is used as the key in the frontmatter.
+
+For example, if you create a user field with the property name "my_field", the data for that field will be stored in the frontmatter as follows:
+
+```yaml
+---
+my_field: value
+---
+```

--- a/docs/features/user-fields.md
+++ b/docs/features/user-fields.md
@@ -3,7 +3,7 @@
 
 TaskNotes allows you to define your own custom fields for tasks. This feature allows you to add custom data to your tasks and use it for filtering, sorting, and grouping.
 
-[← Back to Features](features.md)
+[← Back to Features](../features.md)
 
 ## Creating User Fields
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,86 +1,50 @@
 # TaskNotes Documentation
 
-TaskNotes is a task and note management plugin for Obsidian. It is built on the principle of "one note per task," and it stores task information in YAML frontmatter.
+TaskNotes is a task and note management plugin for Obsidian that follows the "one note per task" principle. Task information is stored in YAML frontmatter, keeping your data in plain text files that work with any text editor.
 
-## Approach and Design
+## How It Works
 
-TaskNotes stores all task information in YAML frontmatter within each note. This means that your task data is stored in plain text files that can be read and edited with any text editor.
+The plugin treats each task as a separate note with structured metadata in the frontmatter. This approach aligns with Obsidian's "files over applications" philosophy - your tasks have structured data for organization while the note content remains completely flexible.
 
-The plugin follows Obsidian's "files over applications" philosophy. Each task has structured metadata in its frontmatter for filtering and organization, while the note content is free-form.
+TaskNotes builds on Obsidian's native metadata cache, which means it works well with other plugins and benefits from Obsidian's existing performance optimizations. Since task data lives in YAML frontmatter, you can add custom fields and modify property names to match your vault's existing structure.
 
-## Core Design Principles
-
-The plugin is built around several key principles:
-
-**Native Integration**: TaskNotes uses Obsidian's native metadata cache as its primary data source. This allows for compatibility with other plugins and takes advantage of Obsidian's existing performance optimizations.
-
-**Extensible Data Model**: Task data is stored in YAML frontmatter, which allows you to add custom fields as needed. The plugin's field mapping system allows you to customize property names to match your existing vault structure.
-
-**Multiple Views**: TaskNotes provides eight different view types, including task lists, calendar views, Kanban boards, and agenda views.
-
-**Workflow Agnostic**: The plugin does not enforce a specific task management methodology. It provides a set of tools that can be used to support a variety of approaches, such as Getting Things Done (GTD), timeboxing, and project-based organization.
+The plugin doesn't lock you into any specific task management methodology. Whether you prefer Getting Things Done, timeboxing, or project-based organization, TaskNotes provides the tools without forcing a particular workflow.
 
 ## Features
 
-TaskNotes includes the following capabilities:
+Each task supports standard properties like title, status, priority, due dates, contexts, and tags, plus time estimates, recurrence patterns, and reminders. Custom fields let you extend this structure however you need.
 
-**Task Properties**: Each task can include a title, status, priority, due date, scheduled date, contexts, tags, time estimate, recurrence pattern, and reminders. You can also add custom fields.
+The built-in time tracking records work sessions directly in each task's frontmatter. For focused work, there's an integrated Pomodoro timer that automatically logs sessions to your tasks.
 
-**Time Tracking**: A time tracking feature allows you to record the amount of time that you spend on tasks. This data is stored in the task's frontmatter as time entries with start and stop times.
+You can view your tasks through eight different interfaces: traditional task lists, calendar views (both mini and advanced), Kanban boards, agenda views, notes browsers, and Pomodoro tracking. Each view offers different ways to organize and interact with your data.
 
-**View Types**: Eight different views are provided: Task List, Notes, Agenda, Kanban, Mini Calendar, Advanced Calendar, Pomodoro, and Pomodoro Stats.
+The plugin integrates directly into Obsidian's editor with inline task widgets that show task information right in your notes. Convert existing checkbox tasks instantly, or use natural language processing to create structured tasks from plain text.
 
-**Editor Integration**: Inline task widgets display task information within your notes. An instant conversion feature transforms checkbox tasks into TaskNotes. A natural language parser can interpret phrases to create structured tasks.
+Calendar integration works with external ICS feeds from Google Calendar, Outlook, and similar services. The advanced calendar view supports time-blocking and lets you drag tasks to reschedule them visually.
 
-**Calendar Integration**: The plugin can subscribe to external ICS calendars from Google Calendar, Outlook, and other calendar systems. Time-blocking features are also included.
+## Why One Note Per Task?
 
-**External Tool Compatibility**: The YAML frontmatter format is compatible with other Obsidian plugins and can be processed by external tools.
+Individual task notes give you more than just basic task management. Each task can contain meeting notes, research, brainstorming, or any other content that makes sense alongside the task itself.
 
-## The One-Note-Per-Task Approach
+Since every task is a proper note, you get full access to Obsidian's linking system. Tasks can reference other notes, appear in your graph view, and show up in backlinks just like any other content in your vault.
 
-Using individual notes for each task has several implications:
+This approach gives you structured metadata when you need it (for filtering and organizing) while keeping the actual note content completely flexible. You're not limited to predefined fields or rigid templates.
 
-**Rich Context**: Each task note can contain additional content beyond the basic task properties.
+## Plain Text Advantages
 
-**Obsidian Integration**: Each task can be linked to other notes in the vault, which allows for the use of Obsidian's backlinking and graph visualization features.
+Your task data lives in standard Markdown files with YAML frontmatter. This means you can edit tasks with any text editor, process them with scripts, or migrate them to other systems without vendor lock-in.
 
-**Structured and Flexible**: The frontmatter provides structured metadata for filtering and organization, while the note content is free-form.
+YAML frontmatter is widely supported and human-readable, so other Obsidian plugins can work with your task data. You can extend the structure by adding new fields whenever you need them.
 
-**Portable Data**: Your task data is stored in standard Markdown files that can be read, edited, and processed by any text editor or automation tool.
-
-## YAML Frontmatter Benefits
-
-Using YAML frontmatter as the primary data storage has several implications:
-
-**Standardized Format**: YAML is a human-readable data format with broad tool support.
-
-**Extensibility**: You can add new fields to your task structure by including them in the frontmatter.
-
-**Tool Compatibility**: The YAML format is compatible with other Obsidian plugins and can be processed by external tools.
-
-**Version Control**: Since tasks are plain text files, they can be used with version control systems like Git.
-
-**Performance**: By using Obsidian's native metadata cache, the plugin can maintain good performance with a large number of tasks.
+Since everything is plain text, your tasks work naturally with version control systems like Git. The plugin leverages Obsidian's native metadata cache, so performance stays good even with thousands of tasks.
 
 ## Getting Started
 
-You can start with basic task creation and then explore more advanced features like calendar integration, time tracking, and custom workflows. The plugin includes default settings that can be customized.
+To begin using TaskNotes effectively:
 
-## Documentation Navigation
+1. **Install and Enable**: Install the plugin from the Obsidian Community Plugins directory
+2. **Create Your First Task**: Use the "Create Task" command or convert an existing checkbox
+3. **Explore Views**: Try the different view types to find what works for your workflow
+4. **Configure Settings**: Customize task properties, views, and integrations as needed
 
-### Core Documentation
-- **[Features](features.md)** - Complete overview of TaskNotes capabilities
-- **[Views](views.md)** - Guide to all available view types
-- **[Settings](settings.md)** - Configuration options and customization
-- **[Core Concepts](core-concepts.md)** - Understanding TaskNotes architecture
-- **[Workflows](workflows.md)** - Example workflows and use cases
-- **[Troubleshooting](troubleshooting.md)** - Common issues and solutions
-
-### API Documentation
-- **[HTTP API](HTTP_API.md)** - External integrations and automation
-- **[NLP API](nlp-api.md)** - Natural language processing features
-- **[Webhooks](webhooks.md)** - Event-driven integrations
-
-### Advanced Topics
-- **[Timezone Handling](TIMEZONE_HANDLING_GUIDE.md)** - Understanding timezone behavior
-- **[Release Notes](releases.md)** - Version history and updates
+The plugin includes default settings that can be customized to support various task management approaches. Use the navigation menu to explore features, configuration options, and advanced capabilities.

--- a/docs/nlp-api.md
+++ b/docs/nlp-api.md
@@ -1,3 +1,4 @@
+
 # TaskNotes NLP API
 
 TaskNotes now exposes its natural language parsing capabilities through API endpoints, allowing external clients to parse task descriptions and create tasks using natural language input.
@@ -11,7 +12,8 @@ Parses natural language input and returns structured task data without creating 
 **Request:**
 ```json
 {
-  "text": "Review PR #123 tomorrow high priority @work"
+  "text": "Review PR #123 tomorrow high priority @work",
+  "locale": "en"
 }
 ```
 
@@ -58,7 +60,8 @@ Parses natural language input and creates a task in one step.
 **Request:**
 ```json
 {
-  "text": "Call mom due friday 2pm #personal"
+  "text": "Call mom due friday 2pm #personal",
+  "locale": "en"
 }
 ```
 
@@ -135,6 +138,25 @@ The NLP parser can extract the following from text input:
 - **Keywords**: "done", "completed", "todo", "in-progress"
 - **Custom**: Uses your configured status types
 
+### Multi-language Support
+
+The NLP parser supports multiple languages. You can specify the language to use for parsing by providing a `locale` parameter in the request body. The following locales are supported:
+
+- `en` (English)
+- `de` (German)
+- `es` (Spanish)
+- `fr` (French)
+- `it` (Italian)
+- `ja` (Japanese)
+- `nl` (Dutch)
+- `pt` (Portuguese)
+- `ru` (Russian)
+- `sv` (Swedish)
+- `uk` (Ukrainian)
+- `zh` (Chinese)
+
+If no locale is provided, the parser will default to English.
+
 ## Example Inputs
 
 | Input | Extracted |
@@ -166,21 +188,21 @@ Common errors:
 ### JavaScript Example
 ```javascript
 // Parse text only
-async function parseTask(text) {
+async function parseTask(text, locale = 'en') {
   const response = await fetch('http://localhost:8080/api/nlp/parse', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text })
+    body: JSON.stringify({ text, locale })
   });
   return response.json();
 }
 
 // Parse and create task
-async function createTaskFromText(text) {
+async function createTaskFromText(text, locale = 'en') {
   const response = await fetch('http://localhost:8080/api/nlp/create', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text })
+    body: JSON.stringify({ text, locale })
   });
   return response.json();
 }
@@ -190,14 +212,14 @@ async function createTaskFromText(text) {
 ```python
 import requests
 
-def parse_task(text):
+def parse_task(text, locale='en'):
     response = requests.post('http://localhost:8080/api/nlp/parse', 
-                           json={'text': text})
+                           json={'text': text, 'locale': locale})
     return response.json()
 
-def create_task_from_text(text):
+def create_task_from_text(text, locale='en'):
     response = requests.post('http://localhost:8080/api/nlp/create', 
-                           json={'text': text})
+                           json={'text': text, 'locale': locale})
     return response.json()
 ```
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,41 +1,41 @@
 # Settings
 
-TaskNotes provides a variety of settings to customize its behavior and appearance. The settings are organized into several categories, each controlling a different aspect of the plugin.
+TaskNotes provides a variety of settings to customize its behavior and appearance. The settings are organized into several tabs, each controlling a different aspect of the plugin.
 
 [← Back to Documentation](index.md)
 
-## Task Defaults
+## General
 
-These settings control the default properties for new tasks, such as the default status, priority, and folder location. You can also configure templates for new tasks, and set up filename generation patterns.
+These settings control the foundational aspects of the plugin, such as task identification, file storage, and click behavior.
 
-For more detailed information, see the [Task Defaults](settings/task-defaults.md) documentation.
+For more detailed information, see the [General Settings](settings/general.md) documentation.
 
-## Inline Task Settings
+## Features
 
-These settings control the behavior of TaskNotes' inline task management features, such as the Task Link Overlay and Instant Task Conversion. You can also configure the natural language processor from this section.
+These settings allow you to enable, disable, and configure the various features of the plugin, such as inline tasks, natural language processing, the Pomodoro timer, and notifications.
 
-For more detailed information, see the [Inline Task Settings](settings/inline-task-settings.md) documentation.
+For more detailed information, see the [Features Settings](settings/features.md) documentation.
 
-## Calendar Settings
+## Defaults & Templates
 
-These settings control the appearance and behavior of the calendar views, including the default view mode, time slot duration, and event visibility. You can also manage your external calendar subscriptions from this section.
+These settings control the default properties for new tasks, such as the default status, priority, and folder location. You can also configure templates for new tasks.
 
-For more detailed information, see the [Calendar Settings](settings/calendar-settings.md) documentation.
+For more detailed information, see the [Defaults & Templates Settings](settings/defaults.md) documentation.
 
-## Advanced Settings
+## Appearance & UI
 
-These settings provide more advanced customization options, such as field mapping, custom status and priority workflows, and user-defined fields. You can also configure the Pomodoro timer from this section.
+These settings control the visual appearance of the plugin, including the calendar, task cards, and other UI elements.
 
-**User Fields** allow you to define custom frontmatter properties that become filterable across all TaskNotes views, supporting text, number, date, boolean, and list data types with intelligent parsing.
+For more detailed information, see the [Appearance & UI Settings](settings/appearance.md) documentation.
 
-For more detailed information, see the [Advanced Settings](settings/advanced-settings.md) documentation.
+## Task Properties
 
-## Misc Settings
+These settings allow you to define custom statuses, priorities, and user fields for your tasks.
 
-These settings control various plugin features and display options, including status bar visibility, project subtasks widget, and performance tuning.
+For more detailed information, see the [Task Properties Settings](settings/task-properties.md) documentation.
 
-For more detailed information, see the [Misc Settings](settings/misc-settings.md) documentation.
+## Integrations
 
-## Property-based Identification (Boolean note)
+These settings control the integration with other plugins and services, such as Bases and external calendars.
 
-If you identify task files by a frontmatter property, enter boolean values as true/false (without quotes) in Settings. Obsidian stores checkbox properties as real booleans; TaskNotes matches them correctly (e.g., setting "true" matches frontmatter `true`). See [Property-based Task Identification](settings/property-identification.md) for examples.
+For more detailed information, see the [Integrations Settings](settings/integrations.md) documentation.

--- a/docs/settings/appearance.md
+++ b/docs/settings/appearance.md
@@ -1,0 +1,70 @@
+
+# Appearance & UI Settings
+
+These settings control the visual appearance of the plugin, including the calendar, task cards, and other UI elements.
+
+[← Back to Settings](settings.md)
+
+## Task Cards
+
+- **Default visible properties**: Choose which properties appear on task cards by default.
+
+## Task Filenames
+
+- **Store title in filename**: Use the task title as the filename. The filename will update when the task title is changed.
+- **Filename format**: If "Store title in filename" is disabled, you can choose from a variety of filename generation patterns, including title-based, timestamp-based, and Zettelkasten-style.
+- **Custom filename template**: If you choose the "custom" filename format, you can define your own template using a variety of variables.
+
+## Display Formatting
+
+- **Time format**: Display time in 12-hour or 24-hour format throughout the plugin.
+
+## Calendar View
+
+- **Default view**: The calendar view shown when opening the calendar tab.
+- **Custom view day count**: Number of days to show in custom multi-day view.
+- **First day of week**: Which day should be the first column in week views.
+- **Show weekends**: Display weekends in calendar views.
+- **Show week numbers**: Display week numbers in calendar views.
+- **Show today highlight**: Highlight the current day in calendar views.
+- **Show current time indicator**: Display a line showing the current time in timeline views.
+- **Selection mirror**: Show a visual preview while dragging to select time ranges.
+- **Calendar locale**: Calendar locale for date formatting and calendar system (e.g., "en", "fa" for Farsi/Persian, "de" for German). Leave empty to auto-detect from browser.
+
+## Default Event Visibility
+
+- **Show scheduled tasks**: Display tasks with scheduled dates by default.
+- **Show due dates**: Display task due dates by default.
+- **Show due dates when scheduled**: Display due dates even for tasks that already have scheduled dates.
+- **Show time entries**: Display completed time tracking entries by default.
+- **Show recurring tasks**: Display recurring task instances by default.
+- **Show ICS events**: Display events from ICS subscriptions by default.
+
+## Timeblocking
+
+- **Enable timeblocking**: Enable timeblock functionality for lightweight scheduling in daily notes.
+- **Show timeblocks**: Display timeblocks from daily notes by default.
+
+## Time Settings
+
+- **Time slot duration**: Duration of each time slot in timeline views.
+- **Start time**: Earliest time shown in timeline views (HH:MM format).
+- **End time**: Latest time shown in timeline views (HH:MM format).
+- **Initial scroll time**: Time to scroll to when opening timeline views (HH:MM format).
+
+## UI Elements
+
+- **Show tracked tasks in status bar**: Display currently tracked tasks in Obsidian's status bar.
+- **Show project subtasks widget**: Display a widget showing subtasks for the current project note.
+- **Project subtasks position**: Where to position the project subtasks widget.
+- **Show expandable subtasks**: Allow expanding/collapsing subtask sections in task cards.
+- **Subtask chevron position**: Position of expand/collapse chevrons in task cards.
+- **Views button alignment**: Alignment of the views/filters button in the task interface.
+
+## Project Autosuggest
+
+- **Required tags**: Show only notes with any of these tags (comma-separated). Leave empty to show all notes.
+- **Include folders**: Show only notes in these folders (comma-separated paths). Leave empty to show all folders.
+- **Customize suggestion display**: Show advanced options to configure how project suggestions appear and what information they display.
+- **Enable fuzzy matching**: Allow typos and partial matches in project search. May be slower in large vaults.
+- **Row 1, 2, 3**: Configure up to 3 lines of information to show for each project suggestion.

--- a/docs/settings/appearance.md
+++ b/docs/settings/appearance.md
@@ -3,7 +3,7 @@
 
 These settings control the visual appearance of the plugin, including the calendar, task cards, and other UI elements.
 
-[← Back to Settings](settings.md)
+[← Back to Settings](../settings.md)
 
 ## Task Cards
 

--- a/docs/settings/defaults.md
+++ b/docs/settings/defaults.md
@@ -1,0 +1,35 @@
+
+# Defaults & Templates Settings
+
+These settings control the default properties for new tasks, such as the default status, priority, and folder location. You can also configure templates for new tasks.
+
+[← Back to Settings](settings.md)
+
+## Basic Defaults
+
+- **Default status**: The default status for new tasks.
+- **Default priority**: The default priority for new tasks.
+- **Default contexts**: A comma-separated list of default contexts (e.g., @home, @work).
+- **Default tags**: A comma-separated list of default tags (without #).
+- **Default projects**: Default project links for new tasks.
+- **Use parent note as project during instant conversion**: Automatically link the parent note as a project when using instant task conversion.
+- **Default time estimate**: Default time estimate in minutes (0 = no default).
+- **Default recurrence**: Default recurrence pattern for new tasks.
+
+## Date Defaults
+
+- **Default due date**: Default due date for new tasks.
+- **Default scheduled date**: Default scheduled date for new tasks.
+
+## Default reminders
+
+- **Add default reminder**: Create a new default reminder that will be added to all new tasks.
+
+## Body Template
+
+- **Use body template**: Use a template file for task body content.
+- **Body template file**: Path to template file for task body content. Supports template variables like `{{title}}`, `{{date}}`, `{{time}}`, `{{priority}}`, `{{status}}`, etc.
+
+## Instant Task Conversion
+
+- **Use task defaults on instant convert**: Apply default task settings when converting text to tasks instantly.

--- a/docs/settings/defaults.md
+++ b/docs/settings/defaults.md
@@ -3,7 +3,7 @@
 
 These settings control the default properties for new tasks, such as the default status, priority, and folder location. You can also configure templates for new tasks.
 
-[← Back to Settings](settings.md)
+[← Back to Settings](../settings.md)
 
 ## Basic Defaults
 

--- a/docs/settings/features.md
+++ b/docs/settings/features.md
@@ -2,7 +2,7 @@
 
 These settings allow you to enable, disable, and configure the various features of the plugin, such as inline tasks, natural language processing, the Pomodoro timer, and notifications.
 
-[← Back to Settings](settings.md)
+[← Back to Settings](../settings.md)
 
 ## Inline Tasks
 

--- a/docs/settings/features.md
+++ b/docs/settings/features.md
@@ -1,0 +1,51 @@
+# Features Settings
+
+These settings allow you to enable, disable, and configure the various features of the plugin, such as inline tasks, natural language processing, the Pomodoro timer, and notifications.
+
+[← Back to Settings](settings.md)
+
+## Inline Tasks
+
+- **Task link overlay**: Replaces links to tasks with an interactive widget in Live Preview mode. The widget is not shown when the cursor is on the link, to allow for editing.
+- **Instant task convert**: Shows a button next to list items and checkboxes to convert them to tasks.
+- **Inline task convert folder**: The folder for inline task conversion. Use `{{currentNotePath}}` for a path relative to the current note.
+
+## Natural Language Processing
+
+- **Enable natural language task input**: Parse due dates, priorities, and contexts from natural language when creating tasks.
+- **Default to scheduled**: When NLP detects a date without context, treat it as scheduled rather than due.
+- **NLP language**: The language for natural language processing patterns and date parsing.
+- **Status suggestion trigger**: Text to trigger status suggestions (leave empty to disable).
+
+## Pomodoro Timer
+
+- **Work duration**: Duration of work intervals in minutes.
+- **Short break duration**: Duration of short breaks in minutes.
+- **Long break duration**: Duration of long breaks in minutes.
+- **Long break interval**: Number of work sessions before a long break.
+- **Auto-start breaks**: Automatically start break timers after work sessions.
+- **Auto-start work**: Automatically start work sessions after breaks.
+- **Pomodoro notifications**: Show notifications when Pomodoro sessions end.
+- **Sound enabled**: Play sound when Pomodoro sessions end.
+- **Sound volume**: Volume for Pomodoro sounds (0-100).
+- **Pomodoro data storage**: Where to store Pomodoro session history. Can be either "Plugin data" or "Daily notes".
+
+## Notifications
+
+- **Enable notifications**: Enable task reminder notifications.
+- **Notification type**: Type of notifications to show. Can be either "In-app notifications" or "System notifications".
+
+## Performance & Behavior
+
+- **Hide completed tasks from overdue**: Exclude completed tasks from overdue task calculations.
+- **Disable note indexing**: Disable automatic indexing of notes for better performance (may reduce some features).
+- **Suggestion debounce**: Debounce delay for file suggestions in milliseconds (0 = disabled).
+
+## Time Tracking
+
+- **Auto-stop tracking on complete**: Automatically stop time tracking when a task is marked complete.
+- **Time tracking stop notification**: Show notification when time tracking is automatically stopped.
+
+## Recurring Tasks
+
+- **Maintain due date offset in recurring tasks**: When completing recurring tasks, maintain the offset between due and scheduled dates.

--- a/docs/settings/general.md
+++ b/docs/settings/general.md
@@ -3,7 +3,7 @@
 
 These settings control the foundational aspects of the plugin, such as task identification, file storage, and click behavior.
 
-[← Back to Settings](settings.md)
+[← Back to Settings](../settings.md)
 
 ## Task Storage
 

--- a/docs/settings/general.md
+++ b/docs/settings/general.md
@@ -1,0 +1,27 @@
+
+# General Settings
+
+These settings control the foundational aspects of the plugin, such as task identification, file storage, and click behavior.
+
+[← Back to Settings](settings.md)
+
+## Task Storage
+
+- **Default tasks folder**: The default location for new tasks.
+- **Move archived tasks to folder**: If enabled, tasks with a status of "archived" will be moved to the specified archive folder.
+- **Archive folder**: The folder to move archived tasks to.
+
+## Task Identification
+
+- **Identify tasks by**: Choose whether to identify tasks by a tag or by a frontmatter property.
+    - **Tag**: If you choose to identify tasks by tag, you must specify the tag to use.
+    - **Property**: If you choose to identify tasks by property, you must specify the property name and value.
+
+## Folder Management
+
+- **Excluded folders**: A comma-separated list of folders to exclude from the Notes tab.
+
+## Task Interaction
+
+- **Single-click action**: The action to perform when single-clicking a task card. Can be either "Edit task" or "Open note".
+- **Double-click action**: The action to perform when double-clicking a task card. Can be "Edit task", "Open note", or "No action".

--- a/docs/settings/integrations.md
+++ b/docs/settings/integrations.md
@@ -3,7 +3,7 @@
 
 These settings control the integration with other plugins and services, such as Bases and external calendars.
 
-[← Back to Settings](settings.md)
+[← Back to Settings](../settings.md)
 
 ## Bases integration
 

--- a/docs/settings/integrations.md
+++ b/docs/settings/integrations.md
@@ -1,0 +1,36 @@
+
+# Integrations Settings
+
+These settings control the integration with other plugins and services, such as Bases and external calendars.
+
+[← Back to Settings](settings.md)
+
+## Bases integration
+
+- **Enable Bases integration**: Enable TaskNotes views to be used within Obsidian Bases plugin. Bases plugin must be enabled for this to work.
+
+## Calendar subscriptions
+
+- **Default note template**: Path to template file for notes created from ICS events.
+- **Default note folder**: Folder for notes created from ICS events.
+- **ICS note filename format**: How filenames are generated for notes created from ICS events.
+- **Custom ICS filename template**: Template for custom ICS event filenames.
+- **Add Calendar Subscription**: Add a new calendar subscription from ICS/iCal URL or local file.
+- **Refresh all subscriptions**: Manually refresh all enabled calendar subscriptions.
+
+## Automatic ICS export
+
+- **Enable automatic export**: Automatically keep an ICS file updated with all your tasks.
+- **Export file path**: Path where the ICS file will be saved (relative to vault root).
+- **Update interval (between 5 and 1440 minutes)**: How often to update the export file.
+- **Export now**: Manually trigger an immediate export.
+
+## HTTP API
+
+- **Enable HTTP API**: Start local HTTP server for API access.
+- **API port**: Port number for the HTTP API server.
+- **API authentication token**: Token required for API authentication (leave empty for no auth).
+
+## Webhooks
+
+- **Add Webhook**: Register a new webhook endpoint.

--- a/docs/settings/task-properties.md
+++ b/docs/settings/task-properties.md
@@ -3,7 +3,7 @@
 
 These settings allow you to define custom statuses, priorities, and user fields for your tasks.
 
-[← Back to Settings](settings.md)
+[← Back to Settings](../settings.md)
 
 ## Task Statuses
 

--- a/docs/settings/task-properties.md
+++ b/docs/settings/task-properties.md
@@ -1,0 +1,33 @@
+
+# Task Properties Settings
+
+These settings allow you to define custom statuses, priorities, and user fields for your tasks.
+
+[← Back to Settings](settings.md)
+
+## Task Statuses
+
+Customize the status options available for your tasks. These statuses control the task lifecycle and determine when tasks are considered complete.
+
+- **Value**: The internal identifier stored in your task files (e.g., "in-progress").
+- **Label**: The display name shown in the interface (e.g., "In Progress").
+- **Color**: Visual indicator color for the status dot and badges.
+- **Completed**: When checked, tasks with this status are considered finished and may be filtered differently.
+- **Auto-archive**: When enabled, tasks will be automatically archived after the specified delay (1-1440 minutes).
+
+## Task Priorities
+
+Customize the priority levels available for your tasks. Priority weights determine sorting order and visual hierarchy in your task views.
+
+- **Value**: The internal identifier stored in your task files (e.g., "high").
+- **Display Label**: The display name shown in the interface (e.g., "High Priority").
+- **Color**: Visual indicator color for the priority dot and badges.
+- **Weight**: Numeric value for sorting (higher weights appear first in lists).
+
+## Field Mapping
+
+Configure which frontmatter properties TaskNotes should use for each field. TaskNotes will read AND write using these property names. Changing these after creating tasks may cause inconsistencies.
+
+## Custom User Fields
+
+Define custom frontmatter properties to appear as type-aware filter options across views. Each row has a Display Name, Property Name, and Type.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,7 +17,7 @@ This section covers common issues and their solutions when using TaskNotes.
 
 **Solutions**:
 
-1. Check that task files include the task tag configured in settings (default: `#task`)
+1. Check that task files include the task tag configured in settings (default: `task`)
 2. Verify task files are not in folders listed in "Excluded folders" setting
 3. Ensure YAML frontmatter is properly formatted with opening and closing `---` lines
 4. Try closing and reopening TaskNotes views to refresh the cache

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -155,7 +155,7 @@ Habits can be modified over time by editing the recurrence pattern:
 
 ## Project Management
 
-TaskNotes provides integrated project management capabilities through its project assignment and organization features. Projects can be either plain text labels or links to actual Obsidian notes, enabling flexible project organization strategies.
+TaskNotes provides project management capabilities through its project assignment and organization features. Projects can be either plain text labels or links to actual Obsidian notes.
 
 ### Project Types and Formats
 
@@ -178,6 +178,7 @@ projects: ["[[Market Research]]", "[[Q1 Strategy]]"]
 ```
 
 Wikilink projects provide additional benefits:
+
 - Clickable links that open project notes
 - Bidirectional linking between tasks and project notes
 - Integration with Obsidian's graph view and backlinks
@@ -244,16 +245,19 @@ Projects are included in search functionality:
 #### Setting Up a New Project
 
 1. **Create Project Note** (for wikilink projects):
+
    - Create a new note in Obsidian for the project
    - Add project description, goals, and relevant information
    - Consider using a consistent naming convention
 
 2. **Configure Default Projects**:
+
    - Set default projects in task creation settings
    - New tasks will automatically include specified projects
    - Useful for focused project work periods
 
 3. **Project Organization**:
+
    - Use folders to organize project notes hierarchically
    - Create project templates for consistent structure
    - Link related project notes together
@@ -261,36 +265,22 @@ Projects are included in search functionality:
 #### Daily Project Work
 
 1. **Filter by Current Project**:
+
    - Use FilterBar to show only current project tasks
    - Focus on specific project work without distractions
    - Switch between projects using saved filter presets
 
 2. **Project Progress Tracking**:
+
    - Group tasks by project to see progress across initiatives
    - Use status filters to identify blocked or completed work
    - Review overdue tasks within specific projects
 
 3. **Cross-Project Task Management**:
+
    - Assign tasks to multiple projects when work spans initiatives
    - Use contexts and tags alongside projects for additional organization
    - Track dependencies between projects through linked notes
-
-#### Project Review and Planning
-
-1. **Project Dashboard Creation**:
-   - Create project notes with embedded queries showing related tasks
-   - Use Obsidian's dataview plugin to create project dashboards
-   - Link to task files from project notes for easy navigation
-
-2. **Project-Based Time Tracking**:
-   - Filter time tracking reports by project
-   - Use project assignment with Pomodoro sessions
-   - Analyze time spent across different projects
-
-3. **Project Completion Workflows**:
-   - Review all project tasks before marking projects complete
-   - Archive or reorganize completed project tasks
-   - Update project notes with outcomes and lessons learned
 
 ### Project Integration Strategies
 
@@ -302,6 +292,7 @@ Projects are included in search functionality:
 title: "Prepare presentation slides"
 projects: ["[[Q4 Planning]]"]
 contexts: ["@computer", "@office"]
+
 ```
 Use contexts to specify where or how project work happens.
 
@@ -311,6 +302,7 @@ Use contexts to specify where or how project work happens.
 title: "Review budget proposal"
 projects: ["[[Budget Planning]]"]
 tags: ["#review", "#finance"]
+
 ```
 Use tags for cross-cutting themes that span multiple projects.
 
@@ -325,6 +317,6 @@ Use tags for cross-cutting themes that span multiple projects.
 - Projects are stored as arrays in task frontmatter
 - Wikilink projects must reference existing notes or will display as plain text
 - Project filtering uses exact name matching (case-sensitive)
-- Project selection modal searches note titles and file paths
 - Tasks with multiple projects appear in all relevant filtered views
 - Project links in task displays open the referenced notes when clicked
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,19 +44,39 @@ nav:
     - Inline Task Integration: features/inline-tasks.md
     - Time Management: features/time-management.md
     - Calendar Integration: features/calendar-integration.md
+    - ICS Integration: features/ics-integration.md
+    - Filtering & Views: features/filtering-and-views.md
+    - Third-party Integrations: features/integrations.md
+    - User Fields: features/user-fields.md
   - Views:
     - Overview: views.md
     - Task List View: views/task-list.md
     - Notes View: views/notes-view.md
     - Agenda View: views/agenda-view.md
     - Kanban View: views/kanban-view.md
+    - Calendar Views: views/calendar-views.md
     - Pomodoro View: views/pomodoro-view.md
   - Settings:
     - Overview: settings.md
+    - General: settings/general.md
+    - Features: settings/features.md
+    - Task Properties: settings/task-properties.md
+    - Defaults & Templates: settings/defaults.md
     - Task Defaults: settings/task-defaults.md
+    - Appearance & UI: settings/appearance.md
     - Inline Task Settings: settings/inline-task-settings.md
     - Calendar Settings: settings/calendar-settings.md
+    - Integrations: settings/integrations.md
     - Advanced Settings: settings/advanced-settings.md
+  - APIs & Integration:
+    - HTTP API: HTTP_API.md
+    - NLP API: nlp-api.md
+    - Webhooks: webhooks.md
+    - Workflows: workflows.md
+  - Advanced Topics:
+    - Timezone Handling: TIMEZONE_HANDLING_GUIDE.md
+    - UTC Implementation: TIMEZONE_HANDLING_UTC.md
+    - Timezone Quick Reference: TIMEZONE_QUICK_REFERENCE.md
   - Release Notes: releases.md
   - Troubleshooting: troubleshooting.md
 


### PR DESCRIPTION
## Summary
- Fix project name references from "ChronoSync" to "TaskNotes" in timezone documentation
- Correct broken relative paths in settings and features navigation links
- Fix incorrect default task tag reference in troubleshooting documentation

## Technical Changes
- Updated timezone documentation files to use correct project name
- Fixed 8 broken back navigation links using incorrect relative paths
- Corrected default task tag from "#task" to "task" in troubleshooting guide
- Clarified time-blocking interaction method in calendar integration
- Removed circular function reference in timezone handling guide

All changes maintain neutral tone and improve technical accuracy.