### PR TITLE
Add icon to note cards in agenda view

### DIFF
--- a/src/ui/NoteCard.ts
+++ b/src/ui/NoteCard.ts
@@ -1,4 +1,4 @@
-import { TFile } from 'obsidian';
+import { TFile, setIcon } from 'obsidian';
 import { NoteInfo } from '../types';
 import TaskNotesPlugin from '../main';
 import { formatDateForDisplay } from '../utils/dateUtils';
@@ -57,11 +57,19 @@ export function createNoteCard(note: NoteInfo, plugin: TaskNotesPlugin, options:
         });
     }
     
-    // Main content container  
-    const contentContainer = item.createDiv({ cls: 'note-card__content' });
-    
+    // Main content container with icon
+    const mainRow = item.createDiv({ cls: 'note-card__main-row' });
+
+    // Left indicator area: note icon
+    const leftIconWrap = mainRow.createEl('span', { cls: 'note-card__icon' });
+    const leftIcon = leftIconWrap.createEl('span');
+    setIcon(leftIcon, 'file-text');
+
+    // Content container
+    const contentContainer = mainRow.createDiv({ cls: 'note-card__content' });
+
     // Title
-    contentContainer.createDiv({ 
+    contentContainer.createDiv({
         cls: 'note-card__title',
         text: note.title
     });
@@ -160,7 +168,22 @@ export function updateNoteCard(element: HTMLElement, note: NoteInfo, plugin: Tas
     
     
     element.className = cardClasses.join(' ');
-    
+
+    // Ensure icon exists (for cards created before this update)
+    let iconWrap = element.querySelector('.note-card__icon') as HTMLElement;
+    if (!iconWrap) {
+        const mainRow = element.querySelector('.note-card__main-row') || element.createDiv({ cls: 'note-card__main-row' });
+        iconWrap = mainRow.createEl('span', { cls: 'note-card__icon' });
+        const leftIcon = iconWrap.createEl('span');
+        setIcon(leftIcon, 'file-text');
+
+        // Move existing content into the main row structure if needed
+        const existingContent = element.querySelector('.note-card__content');
+        if (existingContent && !existingContent.parentElement?.classList.contains('note-card__main-row')) {
+            mainRow.appendChild(existingContent);
+        }
+    }
+
     // Update title
     const titleEl = element.querySelector('.note-card__title') as HTMLElement;
     if (titleEl) {

--- a/styles/note-card-bem.css
+++ b/styles/note-card-bem.css
@@ -74,6 +74,31 @@
    NOTECARD ELEMENTS (BEM __element)
    ================================================================= */
 
+.tasknotes-plugin .note-card__main-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0;
+    width: 100%;
+}
+
+.tasknotes-plugin .note-card__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    margin-right: 8px;
+    flex-shrink: 0;
+    color: var(--tn-text-muted);
+    align-self: center;
+    opacity: 0.7;
+}
+
+.tasknotes-plugin .note-card__icon svg {
+    width: 16px;
+    height: 16px;
+}
+
 .tasknotes-plugin .note-card__content {
     flex: 1;
     display: flex;


### PR DESCRIPTION
## Summary

- Adds file-text icon to note cards for better visual distinction
- Maintains consistent styling with task and calendar event icons
- Handles both new cards and existing card updates

## Test plan

- [x] Built and tested locally
- [x] Verified icon appears correctly in note cards
- [x] Ensured backwards compatibility for existing cards

Fixes #662