### PR TITLE
Fix project/subtask functionality to respect user field mapping

### DIFF
--- a/src/services/ProjectSubtasksService.ts
+++ b/src/services/ProjectSubtasksService.ts
@@ -112,9 +112,12 @@ export class ProjectSubtasksService {
             if (!(sourceFile instanceof TFile)) return false;
 
             const metadata = this.plugin.app.metadataCache.getFileCache(sourceFile);
-            if (!metadata?.frontmatter?.projects) return false;
 
-            const projects = metadata.frontmatter.projects;
+            // Use the user's configured field mapping for projects
+            const projectsFieldName = this.plugin.fieldMapper.toUserField('projects');
+            if (!metadata?.frontmatter?.[projectsFieldName]) return false;
+
+            const projects = metadata.frontmatter[projectsFieldName];
             if (!Array.isArray(projects)) return false;
 
             // Check if any project reference resolves to our target
@@ -172,7 +175,10 @@ export class ProjectSubtasksService {
 
                 // Check if source has projects frontmatter
                 const metadata = this.plugin.app.metadataCache.getCache(sourcePath);
-                const projects = metadata?.frontmatter?.projects;
+
+                // Use the user's configured field mapping for projects
+                const projectsFieldName = this.plugin.fieldMapper.toUserField('projects');
+                const projects = metadata?.frontmatter?.[projectsFieldName];
 
                 if (Array.isArray(projects) && projects.some((p: any) =>
                     typeof p === 'string' && p.startsWith('[[') && p.endsWith(']]')

--- a/src/utils/MinimalNativeCache.ts
+++ b/src/utils/MinimalNativeCache.ts
@@ -619,7 +619,8 @@ export class MinimalNativeCache extends Events {
                     if (!metadata?.frontmatter || !this.isTaskFile(metadata.frontmatter)) continue;
 
                     // Check if this task has projects field with wikilinks
-                    const projectsField = metadata.frontmatter.projects;
+                    const projectsFieldName = this.fieldMapper?.toUserField('projects') || 'projects';
+                    const projectsField = metadata.frontmatter[projectsFieldName];
                     if (!Array.isArray(projectsField)) continue;
 
                     // Check if projects field contains wikilinks (not just plain text)


### PR DESCRIPTION
## Problem
ProjectSubtasksService and MinimalNativeCache were hardcoded to look for `projects` in frontmatter, ignoring user's custom field mapping configuration. This broke subtask/project functionality when users customized their project field name.

## Solution
- Use `fieldMapper.toUserField('projects')` instead of hardcoded `'projects'`
- Apply fix to both ProjectSubtasksService and MinimalNativeCache

## Files Changed
- `src/services/ProjectSubtasksService.ts`
- `src/utils/MinimalNativeCache.ts`

Fixes reported issue where subtask/project functionality wasn't working for users with custom project field mappings.