### PR TITLE
Improve mini calendar interactions and settings organization

### DIFF
--- a/docs/settings/appearance.md
+++ b/docs/settings/appearance.md
@@ -40,10 +40,6 @@ These settings control the visual appearance of the plugin, including the calend
 - **Show recurring tasks**: Display recurring task instances by default.
 - **Show ICS events**: Display events from ICS subscriptions by default.
 
-## Timeblocking
-
-- **Enable timeblocking**: Enable timeblock functionality for lightweight scheduling in daily notes.
-- **Show timeblocks**: Display timeblocks from daily notes by default.
 
 ## Time Settings
 

--- a/docs/settings/calendar-settings.md
+++ b/docs/settings/calendar-settings.md
@@ -20,7 +20,7 @@ You can control which types of events are shown by default in the calendar views
 
 ## Timeblocking Features
 
-You can enable or disable the **Timeblocking** feature, which allows you to create and manage timeblocks in the calendar views.
+You can enable or disable the **Timeblocking** feature in the Features tab, which allows you to create and manage timeblocks in the calendar views. Usage: hold Shift + drag in the advanced calendar view to create timeblocks.
 
 ## External Calendar Integration
 

--- a/docs/settings/features.md
+++ b/docs/settings/features.md
@@ -49,3 +49,12 @@ These settings allow you to enable, disable, and configure the various features 
 ## Recurring Tasks
 
 - **Maintain due date offset in recurring tasks**: When completing recurring tasks, maintain the offset between due and scheduled dates.
+
+## Timeblocking
+
+- **Enable timeblocking**: Enable timeblock functionality for lightweight scheduling in daily notes.
+- **Show timeblocks**: Display timeblocks from daily notes by default.
+
+### Usage
+
+In the advanced calendar view, hold Shift + drag to create timeblocks. Drag to move existing timeblocks. Resize edges to adjust duration.

--- a/src/settings/tabs/appearanceTab.ts
+++ b/src/settings/tabs/appearanceTab.ts
@@ -369,33 +369,6 @@ export function renderAppearanceTab(container: HTMLElement, plugin: TaskNotesPlu
         }
     });
 
-    // Timeblocking section
-    createSectionHeader(container, 'Timeblocking');
-    createHelpText(container, 'Configure timeblock functionality for lightweight scheduling in daily notes.');
-
-    createToggleSetting(container, {
-        name: 'Enable timeblocking',
-        desc: 'Enable timeblock functionality for lightweight scheduling in daily notes',
-        getValue: () => plugin.settings.calendarViewSettings.enableTimeblocking,
-        setValue: async (value: boolean) => {
-            plugin.settings.calendarViewSettings.enableTimeblocking = value;
-            save();
-            // Re-render to show/hide timeblocks visibility setting
-            renderAppearanceTab(container, plugin, save);
-        }
-    });
-
-    if (plugin.settings.calendarViewSettings.enableTimeblocking) {
-        createToggleSetting(container, {
-            name: 'Show timeblocks',
-            desc: 'Display timeblocks from daily notes by default',
-            getValue: () => plugin.settings.calendarViewSettings.defaultShowTimeblocks,
-            setValue: async (value: boolean) => {
-                plugin.settings.calendarViewSettings.defaultShowTimeblocks = value;
-                save();
-            }
-        });
-    }
 
     // Time Settings
     createSectionHeader(container, 'Time Settings');

--- a/src/settings/tabs/featuresTab.ts
+++ b/src/settings/tabs/featuresTab.ts
@@ -367,4 +367,34 @@ export function renderFeaturesTab(container: HTMLElement, plugin: TaskNotesPlugi
             save();
         }
     });
+
+    // Timeblocking Section
+    createSectionHeader(container, 'Timeblocking');
+    createHelpText(container, 'Configure timeblock functionality for lightweight scheduling in daily notes.');
+
+    createToggleSetting(container, {
+        name: 'Enable timeblocking',
+        desc: 'Enable timeblock functionality for lightweight scheduling in daily notes',
+        getValue: () => plugin.settings.calendarViewSettings.enableTimeblocking,
+        setValue: async (value: boolean) => {
+            plugin.settings.calendarViewSettings.enableTimeblocking = value;
+            save();
+            // Re-render to show/hide timeblocks visibility setting
+            renderFeaturesTab(container, plugin, save);
+        }
+    });
+
+    if (plugin.settings.calendarViewSettings.enableTimeblocking) {
+        createToggleSetting(container, {
+            name: 'Show timeblocks',
+            desc: 'Display timeblocks from daily notes by default',
+            getValue: () => plugin.settings.calendarViewSettings.defaultShowTimeblocks,
+            setValue: async (value: boolean) => {
+                plugin.settings.calendarViewSettings.defaultShowTimeblocks = value;
+                save();
+            }
+        });
+
+        createHelpText(container, 'Usage: In the advanced calendar view, hold Shift + drag to create timeblocks. Drag to move existing timeblocks. Resize edges to adjust duration.');
+    }
 }

--- a/src/views/MiniCalendarView.ts
+++ b/src/views/MiniCalendarView.ts
@@ -425,7 +425,7 @@ export class MiniCalendarView extends ItemView {
         // Previous Month Button
         const prevButton = navSection.createEl('button', { 
             text: '‹', 
-            cls: 'mini-calendar-view__nav-button mini-calendar-view__nav-button--prev',
+            cls: 'mini-calendar-view__nav-button mini-calendar-view__nav-button--prev tn-btn tn-btn--icon tn-btn--ghost',
             attr: {
                 'aria-label': 'Previous month',
                 'title': 'Previous month'
@@ -440,11 +440,11 @@ export class MiniCalendarView extends ItemView {
             cls: 'mini-calendar-view__month-display',
             text: format(this.plugin.selectedDate, 'MMMM yyyy')
         });
-        
+
         // Next Month Button
         const nextButton = navSection.createEl('button', { 
             text: '›', 
-            cls: 'mini-calendar-view__nav-button mini-calendar-view__nav-button--next',
+            cls: 'mini-calendar-view__nav-button mini-calendar-view__nav-button--next tn-btn tn-btn--icon tn-btn--ghost',
             attr: {
                 'aria-label': 'Next month',
                 'title': 'Next month'
@@ -457,7 +457,7 @@ export class MiniCalendarView extends ItemView {
         // Today button (moved to end)
         const todayButton = headerContainer.createEl('button', { 
             text: 'Today', 
-            cls: 'mini-calendar-view__today-button',
+            cls: 'mini-calendar-view__today-button tn-btn tn-btn--ghost tn-btn--sm',
             attr: {
                 'aria-label': 'Go to today',
                 'title': 'Go to today'

--- a/src/views/MiniCalendarView.ts
+++ b/src/views/MiniCalendarView.ts
@@ -805,7 +805,7 @@ export class MiniCalendarView extends ItemView {
         });
     }
 
-    private getTaskIndicatorInfo(tasks?: TaskInfo[]): { type: 'due' | 'scheduled' | 'completed'; count: number } | null {
+    private getTaskIndicatorInfo(tasks: TaskInfo[] | undefined, dateKey: string): { type: 'due' | 'scheduled' | 'completed'; count: number } | null {
         if (!tasks || tasks.length === 0) {
             return null;
         }
@@ -822,17 +822,26 @@ export class MiniCalendarView extends ItemView {
             const statusValue = task.status ?? '';
             const isCompleted = this.plugin.statusManager.isCompletedStatus(statusValue);
 
+            const taskDueDate = task.due ? getDatePart(task.due) : null;
+            const taskScheduledDate = task.scheduled ? getDatePart(task.scheduled) : null;
+            const matchesDue = taskDueDate === dateKey;
+            const matchesScheduled = taskScheduledDate === dateKey;
+
+            if (!matchesDue && !matchesScheduled) {
+                continue;
+            }
+
             if (isCompleted) {
                 completedCount++;
                 continue;
             }
 
-            if (task.due) {
+            if (matchesDue) {
                 dueCount++;
                 continue;
             }
 
-            if (task.scheduled) {
+            if (matchesScheduled) {
                 scheduledCount++;
             }
         }
@@ -909,7 +918,7 @@ export class MiniCalendarView extends ItemView {
                 
                 // Get task info for this date
                 const taskInfo = tasksCache.get(dateKey);
-                const indicatorInfo = this.getTaskIndicatorInfo(taskInfo?.tasks as TaskInfo[] | undefined);
+                const indicatorInfo = this.getTaskIndicatorInfo(taskInfo?.tasks as TaskInfo[] | undefined, dateKey);
 
                 if (indicatorInfo) {
                     // Create indicator element
@@ -1136,7 +1145,7 @@ export class MiniCalendarView extends ItemView {
 
         // Get task info for this date
         const taskInfo = tasksCache.get(dateKey);
-        const indicatorInfo = this.getTaskIndicatorInfo(taskInfo?.tasks as TaskInfo[] | undefined);
+        const indicatorInfo = this.getTaskIndicatorInfo(taskInfo?.tasks as TaskInfo[] | undefined, dateKey);
 
         if (indicatorInfo) {
             // Create indicator element
@@ -1343,8 +1352,8 @@ source: 'tasknotes-calendar',
         });
 
         const interactions = [
-            { action: 'Ctrl/Cmd+Hover', description: 'Preview the daily note for that date' },
-            { action: 'Click', description: 'Select the date and update the Agenda view' },
+            { action: 'Hover / Ctrl/Cmd + Hover', description: 'Preview the daily note for that date' },
+            { action: 'Click', description: 'Select the date and update the Agenda and Notes views' },
             { action: 'Ctrl/Cmd + Click', description: 'Open the daily note in the current workspace' },
             { action: 'Double-click', description: 'Open the daily note immediately' }
         ];

--- a/src/views/MiniCalendarView.ts
+++ b/src/views/MiniCalendarView.ts
@@ -103,6 +103,12 @@ export class MiniCalendarView extends ItemView {
             this.handleTaskUpdate(originalTask, updatedTask);
         });
         this.listeners.push(taskUpdateListener);
+
+        const indexBuiltListener = this.plugin.emitter.on('indexes-built', () => {
+            // Recolor calendar once essential indexes are ready
+            this.refresh();
+        });
+        this.listeners.push(indexBuiltListener);
     }
   
     getViewType(): string {
@@ -150,6 +156,7 @@ export class MiniCalendarView extends ItemView {
         
         // Create the calendar grid
         this.createCalendarGrid(container);
+        this.createLegend(container);
         this.colorizeCalendar();
     }
     
@@ -577,10 +584,7 @@ export class MiniCalendarView extends ItemView {
                 }
             });
             
-            // Add click handler
-            dayEl.addEventListener('click', () => {
-                this.plugin.setSelectedDate(dayDate);
-            });
+            this.setupDayInteractionEvents(dayEl, dayDate);
             
             // Add hover preview functionality for daily notes
             dayEl.addEventListener('mouseover', (event) => {
@@ -633,10 +637,7 @@ export class MiniCalendarView extends ItemView {
                 }
             });
             
-            // Add click handler
-            dayEl.addEventListener('click', () => {
-                this.plugin.setSelectedDate(dayDate);
-            });
+            this.setupDayInteractionEvents(dayEl, dayDate);
             
             // Add hover preview functionality for daily notes
             dayEl.addEventListener('mouseover', (event) => {
@@ -680,10 +681,7 @@ export class MiniCalendarView extends ItemView {
                 }
             });
             
-            // Add click handler
-            dayEl.addEventListener('click', () => {
-                this.plugin.setSelectedDate(dayDate);
-            });
+            this.setupDayInteractionEvents(dayEl, dayDate);
             
             // Add hover preview functionality for daily notes
             dayEl.addEventListener('mouseover', (event) => {
@@ -806,7 +804,54 @@ export class MiniCalendarView extends ItemView {
         });
         });
     }
-    
+
+    private getTaskIndicatorInfo(tasks?: TaskInfo[]): { type: 'due' | 'scheduled' | 'completed'; count: number } | null {
+        if (!tasks || tasks.length === 0) {
+            return null;
+        }
+
+        let dueCount = 0;
+        let scheduledCount = 0;
+        let completedCount = 0;
+
+        for (const task of tasks) {
+            if (!task || task.archived) {
+                continue;
+            }
+
+            const statusValue = task.status ?? '';
+            const isCompleted = this.plugin.statusManager.isCompletedStatus(statusValue);
+
+            if (isCompleted) {
+                completedCount++;
+                continue;
+            }
+
+            if (task.due) {
+                dueCount++;
+                continue;
+            }
+
+            if (task.scheduled) {
+                scheduledCount++;
+            }
+        }
+
+        if (dueCount > 0) {
+            return { type: 'due', count: dueCount };
+        }
+
+        if (scheduledCount > 0) {
+            return { type: 'scheduled', count: scheduledCount };
+        }
+
+        if (completedCount > 0) {
+            return { type: 'completed', count: completedCount };
+        }
+
+        return null;
+    }
+
     // Method to colorize calendar for tasks (tasks tab)
     async colorizeCalendarForTasks() {
         // First clear all existing colorization
@@ -864,41 +909,36 @@ export class MiniCalendarView extends ItemView {
                 
                 // Get task info for this date
                 const taskInfo = tasksCache.get(dateKey);
-                
-                if (taskInfo && (taskInfo.hasDue || taskInfo.hasScheduled)) {
+                const indicatorInfo = this.getTaskIndicatorInfo(taskInfo?.tasks as TaskInfo[] | undefined);
+
+                if (indicatorInfo) {
                     // Create indicator element
                     const indicator = document.createElement('div');
                     indicator.className = 'task-indicator';
                     
-                    // Different styling for completed, due, scheduled, and archived tasks
-                    // Priority order: archived > completed > due > scheduled
+                    // Different styling for due, scheduled, completed (due wins)
                     let taskStatus = '';
-                    if (taskInfo.hasArchived) {
-                        // Archived tasks get a different style
-                        day.classList.add('mini-calendar-view__day--has-archived-tasks');
-                        indicator.classList.add('archived-tasks');
-                        taskStatus = 'Archived';
-                    } else if (taskInfo.hasCompleted) {
-                        // Completed tasks
-                        day.classList.add('mini-calendar-view__day--has-completed-tasks');
-                        indicator.classList.add('completed-tasks');
-                        taskStatus = 'Completed';
-                    } else if (taskInfo.hasDue) {
-                        // Due tasks (prioritized over scheduled)
+                    if (indicatorInfo.type === 'due') {
+                        // Due tasks (highest priority)
                         day.classList.add('mini-calendar-view__day--has-tasks');
                         indicator.classList.add('due-tasks');
                         taskStatus = 'Due';
-                    } else if (taskInfo.hasScheduled) {
+                    } else if (indicatorInfo.type === 'scheduled') {
                         // Scheduled tasks
                         day.classList.add('mini-calendar-view__day--has-scheduled-tasks');
                         indicator.classList.add('scheduled-tasks');
                         taskStatus = 'Scheduled';
+                    } else if (indicatorInfo.type === 'completed') {
+                        // Completed tasks (lowest priority)
+                        day.classList.add('mini-calendar-view__day--has-completed-tasks');
+                        indicator.classList.add('completed-tasks');
+                        taskStatus = 'Completed';
                     }
-                    
+
                     // Add tooltip with task count information
-                    indicator.setAttribute('aria-label', `${taskStatus} tasks (${taskInfo.count})`);
-                    setTooltip(indicator, `${taskStatus} tasks (${taskInfo.count})`, { placement: 'top' });
-                    
+                    indicator.setAttribute('aria-label', `${taskStatus} tasks (${indicatorInfo.count})`);
+                    setTooltip(indicator, `${taskStatus} tasks (${indicatorInfo.count})`, { placement: 'top' });
+
                     // Add indicator to the day cell
                     day.appendChild(indicator);
                 }
@@ -1088,44 +1128,43 @@ export class MiniCalendarView extends ItemView {
     private updateSingleCalendarCell(dayEl: HTMLElement, dateKey: string, tasksCache: Map<string, any>) {
         // Remove existing task indicators and classes
         dayEl.querySelectorAll('.task-indicator').forEach(el => el.remove());
-        dayEl.classList.remove('has-tasks', 'has-scheduled-tasks', 'has-completed-tasks', 'has-archived-tasks');
-        
+        dayEl.classList.remove(
+            'mini-calendar-view__day--has-tasks',
+            'mini-calendar-view__day--has-scheduled-tasks',
+            'mini-calendar-view__day--has-completed-tasks'
+        );
+
         // Get task info for this date
         const taskInfo = tasksCache.get(dateKey);
-        
-        if (taskInfo && (taskInfo.hasDue || taskInfo.hasScheduled)) {
+        const indicatorInfo = this.getTaskIndicatorInfo(taskInfo?.tasks as TaskInfo[] | undefined);
+
+        if (indicatorInfo) {
             // Create indicator element
             const indicator = document.createElement('div');
             indicator.className = 'task-indicator';
             
-            // Different styling for completed, due, scheduled, and archived tasks
-            // Priority order: archived > completed > due > scheduled
+            // Different styling for due, scheduled, completed (due wins)
             let taskStatus = '';
-            if (taskInfo.hasArchived) {
-                // Archived tasks get a different style
-                dayEl.classList.add('has-archived-tasks');
-                indicator.classList.add('archived-tasks');
-                taskStatus = 'Archived';
-            } else if (taskInfo.hasCompleted) {
-                // Completed tasks
-                dayEl.classList.add('has-completed-tasks');
-                indicator.classList.add('completed-tasks');
-                taskStatus = 'Completed';
-            } else if (taskInfo.hasDue) {
-                // Due tasks (prioritized over scheduled)
-                dayEl.classList.add('has-tasks');
+            if (indicatorInfo.type === 'due') {
+                // Due tasks (highest priority)
+                dayEl.classList.add('mini-calendar-view__day--has-tasks');
                 indicator.classList.add('due-tasks');
                 taskStatus = 'Due';
-            } else if (taskInfo.hasScheduled) {
+            } else if (indicatorInfo.type === 'scheduled') {
                 // Scheduled tasks
-                dayEl.classList.add('has-scheduled-tasks');
+                dayEl.classList.add('mini-calendar-view__day--has-scheduled-tasks');
                 indicator.classList.add('scheduled-tasks');
                 taskStatus = 'Scheduled';
+            } else if (indicatorInfo.type === 'completed') {
+                // Completed tasks
+                dayEl.classList.add('mini-calendar-view__day--has-completed-tasks');
+                indicator.classList.add('completed-tasks');
+                taskStatus = 'Completed';
             }
             
             // Add tooltip with task count information
-            indicator.setAttribute('aria-label', `${taskStatus} tasks (${taskInfo.count})`);
-            setTooltip(indicator, `${taskStatus} tasks (${taskInfo.count})`, { placement: 'top' });
+            indicator.setAttribute('aria-label', `${taskStatus} tasks (${indicatorInfo.count})`);
+            setTooltip(indicator, `${taskStatus} tasks (${indicatorInfo.count})`, { placement: 'top' });
             
             // Add indicator to the day cell
             dayEl.appendChild(indicator);
@@ -1253,6 +1292,97 @@ source: 'tasknotes-calendar',
             // Daily Notes interface not available, return null
             return null;
         }
+    }
+
+    private createLegend(container: HTMLElement): void {
+        const legend = container.createEl('details', {
+            cls: 'mini-calendar-view__legend'
+        });
+        legend.createEl('summary', {
+            cls: 'mini-calendar-view__legend-summary',
+            text: 'Legend'
+        });
+
+        const indicatorsSection = legend.createDiv({
+            cls: 'mini-calendar-view__legend-section'
+        });
+        indicatorsSection.createSpan({
+            cls: 'mini-calendar-view__legend-section-title',
+            text: 'Indicators'
+        });
+
+        const indicatorItems = [
+            { dotClass: 'mini-calendar-view__legend-dot--due', label: 'Due task' },
+            { dotClass: 'mini-calendar-view__legend-dot--scheduled', label: 'Scheduled task' },
+            { dotClass: 'mini-calendar-view__legend-dot--completed', label: 'Completed task' },
+            { dotClass: 'mini-calendar-view__legend-dot--notes', label: 'Notes present' },
+            { dotClass: 'mini-calendar-view__legend-dot--daily', label: 'Daily note exists' }
+        ];
+
+        indicatorItems.forEach(item => {
+            const legendItem = indicatorsSection.createDiv({
+                cls: 'mini-calendar-view__legend-item'
+            });
+
+            legendItem.createSpan({
+                cls: `mini-calendar-view__legend-dot ${item.dotClass}`
+            });
+
+            legendItem.createSpan({
+                cls: 'mini-calendar-view__legend-label',
+                text: item.label
+            });
+        });
+
+        const interactionsSection = legend.createDiv({
+            cls: 'mini-calendar-view__legend-section'
+        });
+        interactionsSection.createSpan({
+            cls: 'mini-calendar-view__legend-section-title',
+            text: 'Interactions'
+        });
+
+        const interactions = [
+            { action: 'Ctrl/Cmd+Hover', description: 'Preview the daily note for that date' },
+            { action: 'Click', description: 'Select the date and update the Agenda view' },
+            { action: 'Ctrl/Cmd + Click', description: 'Open the daily note in the current workspace' },
+            { action: 'Double-click', description: 'Open the daily note immediately' }
+        ];
+
+        interactions.forEach(item => {
+            const interactionRow = interactionsSection.createDiv({
+                cls: 'mini-calendar-view__legend-interaction'
+            });
+
+            interactionRow.createSpan({
+                cls: 'mini-calendar-view__legend-action',
+                text: item.action
+            });
+
+            interactionRow.createSpan({
+                cls: 'mini-calendar-view__legend-description',
+                text: item.description
+            });
+        });
+    }
+
+    private setupDayInteractionEvents(dayEl: HTMLElement, dayDate: Date): void {
+        dayEl.addEventListener('click', (event: MouseEvent) => {
+            this.plugin.setSelectedDate(dayDate);
+
+            if (event.ctrlKey || event.metaKey) {
+                event.preventDefault();
+                event.stopPropagation();
+                void this.plugin.navigateToDailyNote(dayDate);
+            }
+        });
+
+        dayEl.addEventListener('dblclick', (event: MouseEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            this.plugin.setSelectedDate(dayDate);
+            void this.plugin.navigateToDailyNote(dayDate);
+        });
     }
     
     /**

--- a/src/views/MiniCalendarView.ts
+++ b/src/views/MiniCalendarView.ts
@@ -1353,9 +1353,9 @@ source: 'tasknotes-calendar',
 
         const interactions = [
             { action: 'Ctrl/Cmd + Hover', description: 'Preview the daily note for that date' },
-            { action: 'Click', description: 'Select the date and update the Agenda views' },
-            { action: 'Ctrl/Cmd + Click', description: 'Open the daily note in the current workspace' },
-            { action: 'Double-click', description: 'Open the daily note immediately' }
+            { action: 'Click', description: 'Select the date and update the Agenda view' },
+            { action: 'Ctrl/Cmd + Click', description: 'Open the daily note' },
+            { action: 'Double-click', description: 'Open the daily note' }
         ];
 
         interactions.forEach(item => {

--- a/src/views/MiniCalendarView.ts
+++ b/src/views/MiniCalendarView.ts
@@ -1352,8 +1352,8 @@ source: 'tasknotes-calendar',
         });
 
         const interactions = [
-            { action: 'Hover / Ctrl/Cmd + Hover', description: 'Preview the daily note for that date' },
-            { action: 'Click', description: 'Select the date and update the Agenda and Notes views' },
+            { action: 'Ctrl/Cmd + Hover', description: 'Preview the daily note for that date' },
+            { action: 'Click', description: 'Select the date and update the Agenda views' },
             { action: 'Ctrl/Cmd + Click', description: 'Open the daily note in the current workspace' },
             { action: 'Double-click', description: 'Open the daily note immediately' }
         ];

--- a/styles/calendar-view.css
+++ b/styles/calendar-view.css
@@ -526,6 +526,184 @@
     transform: translateX(1px);
 }
 
+/* Mini calendar minimalist adjustments */
+.tasknotes-plugin .mini-calendar-view {
+    padding: var(--tn-spacing-xs);
+    gap: var(--tn-spacing-xs);
+}
+
+.tasknotes-plugin .mini-calendar-view__controls {
+    padding: 0;
+    gap: var(--tn-spacing-xs);
+    background: transparent;
+    border: none;
+    box-shadow: none;
+}
+
+.tasknotes-plugin .mini-calendar-view__header {
+    padding: 0;
+    margin-bottom: var(--tn-spacing-xs);
+    gap: var(--tn-spacing-sm);
+}
+
+.tasknotes-plugin .mini-calendar-view__navigation {
+    gap: var(--tn-spacing-xs);
+}
+
+.tasknotes-plugin .mini-calendar-view__nav-button {
+    width: var(--tn-button-height-sm);
+    height: var(--tn-button-height-sm);
+    font-size: var(--tn-font-size-lg);
+    color: var(--tn-text-muted);
+}
+
+.tasknotes-plugin .mini-calendar-view__nav-button:hover {
+    color: var(--tn-text-normal);
+}
+
+.tasknotes-plugin .mini-calendar-view__view-selector {
+    padding: 0;
+    border: none;
+    background: transparent;
+    font-weight: 600;
+    font-size: var(--tn-font-size-sm);
+    color: var(--tn-text-muted);
+}
+
+.tasknotes-plugin .mini-calendar-view__view-selector:hover,
+.tasknotes-plugin .mini-calendar-view__view-selector:focus {
+    background: transparent;
+    color: var(--tn-text-normal);
+}
+
+.tasknotes-plugin .mini-calendar-view__view-selector:focus-visible {
+    outline: 1px solid var(--tn-interactive-accent);
+    outline-offset: 2px;
+}
+
+.tasknotes-plugin .mini-calendar-view__month-display {
+    font-weight: 600;
+    font-size: var(--tn-font-size-md);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--tn-text-muted);
+}
+
+.tasknotes-plugin .mini-calendar-view__grid-container {
+    margin-bottom: 0;
+}
+
+.tasknotes-plugin .mini-calendar-view__grid {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    gap: 1px;
+}
+
+.tasknotes-plugin .mini-calendar-view__grid-header {
+    background: transparent;
+}
+
+.tasknotes-plugin .mini-calendar-view__day-header {
+    background: transparent;
+    color: var(--tn-text-muted);
+    letter-spacing: 0.08em;
+    padding: calc(var(--tn-spacing-xs) * 0.75) 0;
+}
+
+.tasknotes-plugin .mini-calendar-view__week {
+    gap: 1px;
+}
+
+.tasknotes-plugin .mini-calendar-view__day {
+    background: transparent;
+    border-radius: var(--tn-radius-sm);
+    min-height: 2.25rem;
+    border: none;
+    transition: border-color var(--tn-transition-fast), background-color var(--tn-transition-fast), color var(--tn-transition-fast);
+}
+
+.tasknotes-plugin .mini-calendar-view__day:hover {
+    background: color-mix(in srgb, var(--tn-interactive-hover) 25%, transparent);
+}
+
+.tasknotes-plugin .mini-calendar-view__day--today {
+    background: none !important;
+    color: var(--tn-text-normal);
+    border: 1px solid color-mix(in srgb, var(--tn-interactive-accent) 80%, transparent);
+}
+
+.tasknotes-plugin .mini-calendar-view__day--today::after {
+    bottom: 6px;
+    background: color-mix(in srgb, var(--tn-interactive-accent) 85%, transparent);
+}
+
+.tasknotes-plugin .mini-calendar-view__day--selected {
+    background: color-mix(in srgb, var(--tn-interactive-accent) 20%, transparent);
+    border: 1px solid var(--tn-interactive-accent);
+}
+
+.tasknotes-plugin .mini-calendar-view__day--today.mini-calendar-view__day--selected {
+    background: color-mix(in srgb, var(--tn-interactive-accent) 25%, transparent);
+}
+
+.tasknotes-plugin .mini-calendar-view__day--outside-month {
+    opacity: 0.45;
+}
+
+.tasknotes-plugin .mini-calendar-view__day--has-content,
+.tasknotes-plugin .mini-calendar-view__day--has-notes-few,
+.tasknotes-plugin .mini-calendar-view__day--has-notes-some,
+.tasknotes-plugin .mini-calendar-view__day--has-notes-many,
+.tasknotes-plugin .mini-calendar-view__day--has-tasks,
+.tasknotes-plugin .mini-calendar-view__day--has-scheduled-tasks,
+.tasknotes-plugin .mini-calendar-view__day--has-completed-tasks,
+.tasknotes-plugin .mini-calendar-view__day--has-archived-tasks,
+.tasknotes-plugin .mini-calendar-view__day--has-daily-note {
+    background: transparent;
+}
+
+.tasknotes-plugin .mini-calendar-view__day--has-content:hover {
+    transform: none;
+}
+
+.tasknotes-plugin .mini-calendar-view__day-indicators {
+    margin-top: 4px;
+    gap: 4px;
+}
+
+.tasknotes-plugin .mini-calendar-view__content-indicator {
+    width: 6px;
+    height: 6px;
+    bottom: 6px;
+    box-shadow: none;
+}
+
+.tasknotes-plugin .mini-calendar-view__day:hover .mini-calendar-view__content-indicator {
+    transform: translateX(-50%);
+    box-shadow: none;
+}
+
+.tasknotes-plugin .mini-calendar-view__content-indicator--notes-some,
+.tasknotes-plugin .mini-calendar-view__content-indicator--notes-many {
+    width: 7px;
+    height: 7px;
+}
+
+.tasknotes-plugin .mini-calendar-view__content-indicator--notes-many {
+    width: 8px;
+    height: 8px;
+}
+
+.tasknotes-plugin .mini-calendar-view__content-indicator--tasks-due,
+.tasknotes-plugin .mini-calendar-view__content-indicator--tasks-completed,
+.tasknotes-plugin .mini-calendar-view__content-indicator--tasks-scheduled,
+.tasknotes-plugin .mini-calendar-view__content-indicator--tasks-archived,
+.tasknotes-plugin .mini-calendar-view__content-indicator--daily-note {
+    width: 6px;
+    height: 6px;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
     .tasknotes-plugin .calendar-view,

--- a/styles/calendar-view.css
+++ b/styles/calendar-view.css
@@ -237,7 +237,6 @@
 .tasknotes-plugin .calendar-view__day:hover,
 .tasknotes-plugin .mini-calendar-view__day:hover {
     background-color: var(--tn-interactive-hover);
-    border: none;
     transform: none;
     box-shadow: none;
 }
@@ -550,6 +549,91 @@
     gap: var(--tn-spacing-xs);
 }
 
+.tasknotes-plugin .mini-calendar-view__legend {
+    margin-top: var(--tn-spacing-sm);
+    font-size: var(--tn-font-size-xs);
+    color: var(--tn-text-muted);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-summary {
+    cursor: pointer;
+    list-style: none;
+    padding: calc(var(--tn-spacing-xs) * 0.25) 0;
+}
+
+.tasknotes-plugin .mini-calendar-view__legend[open] .mini-calendar-view__legend-summary {
+    color: var(--tn-text-normal);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-section {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--tn-spacing-xs) * 0.5);
+    margin-top: calc(var(--tn-spacing-xs) * 0.75);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-item {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--tn-spacing-xs) * 0.5);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-section-title {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--tn-text-muted);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-dot--due {
+    background-color: var(--tn-color-error);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-dot--scheduled {
+    background-color: var(--tn-interactive-accent);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-dot--completed {
+    background-color: var(--tn-text-muted);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-dot--notes {
+    background-color: var(--tn-color-notes-medium);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-dot--daily {
+    background-color: var(--tn-color-daily-note);
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-label {
+    line-height: 1.1;
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-interaction {
+    display: flex;
+    gap: var(--tn-spacing-xs);
+    align-items: baseline;
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-action {
+    font-weight: 600;
+    color: var(--tn-text-muted);
+    min-width: 96px;
+    white-space: nowrap;
+}
+
+.tasknotes-plugin .mini-calendar-view__legend-description {
+    color: var(--tn-text-muted);
+    flex: 1;
+}
+
 .tasknotes-plugin .mini-calendar-view__nav-button {
     width: var(--tn-button-height-sm);
     height: var(--tn-button-height-sm);
@@ -658,7 +742,6 @@
 .tasknotes-plugin .mini-calendar-view__day--has-tasks,
 .tasknotes-plugin .mini-calendar-view__day--has-scheduled-tasks,
 .tasknotes-plugin .mini-calendar-view__day--has-completed-tasks,
-.tasknotes-plugin .mini-calendar-view__day--has-archived-tasks,
 .tasknotes-plugin .mini-calendar-view__day--has-daily-note {
     background: transparent;
 }
@@ -793,16 +876,11 @@
 }
 
 .tasknotes-plugin .task-indicator.completed-tasks {
-    background-color: var(--tn-color-success);
+    background-color: var(--tn-text-muted);
 }
 
 .tasknotes-plugin .task-indicator.scheduled-tasks {
     background-color: var(--tn-interactive-accent);
-}
-
-.tasknotes-plugin .task-indicator.archived-tasks {
-    background-color: var(--tn-color-archived);
-    opacity: 0.8;
 }
 
 .tasknotes-plugin .daily-note-indicator {

--- a/styles/calendar-view.css
+++ b/styles/calendar-view.css
@@ -41,8 +41,8 @@
 /* Use consistent button system for view selector */
 .tasknotes-plugin .calendar-view__view-selector,
 .tasknotes-plugin .mini-calendar-view__view-selector {
-    margin-right: var(--tn-spacing-md);
-    min-width: 120px;
+    /* margin-right: var(--tn-spacing-md); */
+    /* min-width: 120px; */
     padding: var(--tn-spacing-xs) var(--tn-spacing-sm);
     border: none;
     box-shadow: none;
@@ -80,8 +80,9 @@
 .tasknotes-plugin .mini-calendar-view__month-display {
     font-weight: 500;
     font-size: var(--tn-font-size-lg);
-    min-width: 140px;
+    /* min-width: 140px; */
     text-align: center;
+    padding-inline: 5px;
     color: var(--tn-text-normal);
 }
 
@@ -116,6 +117,7 @@
     transition: opacity var(--tn-transition-fast);
     cursor: pointer;
     border-radius: var(--tn-radius-sm);
+    font-size: var(--tn-font-size-lg);
 }
 
 .tasknotes-plugin .calendar-view__today-button:hover,


### PR DESCRIPTION
## Summary
- Move timeblocking settings from Appearance tab to Features tab with usage instructions
- Improve mini calendar styling and interactions (Ctrl/Cmd + click, double-click, hover preview)
- Add legend to mini calendar with indicators and interaction help
- Fix task dot indicators to reflect matching dates correctly
- Refine overall mini calendar appearance with better spacing and colors

## Test plan
- [ ] Verify timeblocking settings moved to Features tab and include usage instructions
- [ ] Test mini calendar interactions: Ctrl/Cmd + hover for preview, Ctrl/Cmd + click to open daily note, double-click functionality
- [ ] Confirm legend displays correctly with proper indicators for due/scheduled/completed tasks
- [ ] Verify task dots show correct colors based on task types and dates
- [ ] Check that mini calendar styling improvements look good across different themes