### PR TITLE
Advanced calendar + Pomodoro fixes for multi-day events and auto-start (#641, $647)

### DIFF
--- a/src/modals/TimeblockInfoModal.ts
+++ b/src/modals/TimeblockInfoModal.ts
@@ -6,6 +6,7 @@ import {
     getAllDailyNotes,
     appHasDailyNotesPluginLoaded
 } from 'obsidian-daily-notes-interface';
+import { formatDateForStorage } from '../utils/dateUtils';
 
 export interface TimeBlock {
     title: string;
@@ -23,6 +24,7 @@ export interface TimeBlock {
 export class TimeblockInfoModal extends Modal {
     private timeblock: TimeBlock;
     private eventDate: Date;
+    private timeblockDate: string;
     private plugin: TaskNotesPlugin;
     private originalTimeblock: TimeBlock;
     
@@ -35,12 +37,13 @@ export class TimeblockInfoModal extends Modal {
     private selectedAttachments: TAbstractFile[] = [];
     private attachmentsList: HTMLElement;
 
-    constructor(app: App, plugin: TaskNotesPlugin, timeblock: TimeBlock, eventDate: Date) {
+    constructor(app: App, plugin: TaskNotesPlugin, timeblock: TimeBlock, eventDate: Date, timeblockDate?: string) {
         super(app);
         this.plugin = plugin;
         this.timeblock = { ...timeblock }; // Create a copy for editing
         this.originalTimeblock = timeblock; // Keep original for comparison
         this.eventDate = eventDate;
+        this.timeblockDate = timeblockDate || formatDateForStorage(eventDate);
     }
 
     async onOpen() {
@@ -280,8 +283,8 @@ export class TimeblockInfoModal extends Modal {
         }
 
         // Get daily note for the date
-        const dateStr = this.eventDate.toISOString().split('T')[0]; // YYYY-MM-DD
-        const moment = (window as any).moment(dateStr);
+        const dateStr = this.timeblockDate;
+        const moment = (window as any).moment(dateStr, 'YYYY-MM-DD');
         const allDailyNotes = getAllDailyNotes();
         const dailyNote = getDailyNote(moment, allDailyNotes);
 
@@ -406,8 +409,8 @@ export class TimeblockInfoModal extends Modal {
         }
 
         // Get daily note for the date
-        const dateStr = this.eventDate.toISOString().split('T')[0]; // YYYY-MM-DD
-        const moment = (window as any).moment(dateStr);
+        const dateStr = this.timeblockDate;
+        const moment = (window as any).moment(dateStr, 'YYYY-MM-DD');
         const allDailyNotes = getAllDailyNotes();
         const dailyNote = getDailyNote(moment, allDailyNotes);
 

--- a/src/utils/viewOptimizations.ts
+++ b/src/utils/viewOptimizations.ts
@@ -73,7 +73,9 @@ export function shouldRefreshForDateBasedView(
            originalTask.completedDate !== updatedTask.completedDate ||
            originalTask.recurrence !== updatedTask.recurrence ||
            originalTask.priority !== updatedTask.priority || // Priority affects event visual appearance
-           originalTask.title !== updatedTask.title; // Title changes should be reflected
+           originalTask.title !== updatedTask.title || // Title changes should be reflected
+           originalTask.archived !== updatedTask.archived || // Archived tasks should disappear from date-based views
+           originalTask.path !== updatedTask.path; // Path changes indicate the file moved and need re-render
 }
 
 /**

--- a/src/utils/viewOptimizations.ts
+++ b/src/utils/viewOptimizations.ts
@@ -1,6 +1,6 @@
 import { ItemView } from 'obsidian';
 import { ViewPerformanceService, ViewPerformanceConfig, ViewUpdateHandler } from '../services/ViewPerformanceService';
-import { TaskInfo } from '../types';
+import { TaskInfo, TimeEntry } from '../types';
 import TaskNotesPlugin from '../main';
 
 /**
@@ -67,6 +67,7 @@ export function shouldRefreshForDateBasedView(
     if (!originalTask) return true;
 
     // For date-based views (calendars, agendas), check if date-related fields or visual properties changed
+    const timeEntriesChanged = !areTimeEntriesEqual(originalTask.timeEntries, updatedTask.timeEntries);
     return originalTask.due !== updatedTask.due ||
            originalTask.scheduled !== updatedTask.scheduled ||
            originalTask.status !== updatedTask.status ||
@@ -75,7 +76,10 @@ export function shouldRefreshForDateBasedView(
            originalTask.priority !== updatedTask.priority || // Priority affects event visual appearance
            originalTask.title !== updatedTask.title || // Title changes should be reflected
            originalTask.archived !== updatedTask.archived || // Archived tasks should disappear from date-based views
-           originalTask.path !== updatedTask.path; // Path changes indicate the file moved and need re-render
+           originalTask.path !== updatedTask.path || // Path changes indicate the file moved and need re-render
+           originalTask.timeEstimate !== updatedTask.timeEstimate || // Duration changes affect multi-day rendering
+           originalTask.totalTrackedTime !== updatedTask.totalTrackedTime || // Time tracking summary changes event info
+           timeEntriesChanged; // Time entry adjustments affect rendered segments
 }
 
 /**
@@ -221,4 +225,23 @@ export class ViewPerformanceMonitor {
         this.startTimer(operation);
         return fn().finally(() => this.endTimer(operation));
     }
+}
+
+function areTimeEntriesEqual(a?: TimeEntry[], b?: TimeEntry[]): boolean {
+    if (a === b) return true;
+    if (!a || !b) return a === b;
+    if (a.length !== b.length) return false;
+
+    for (let i = 0; i < a.length; i++) {
+        const entryA = a[i];
+        const entryB = b[i];
+        if (entryA.startTime !== entryB.startTime ||
+            entryA.endTime !== entryB.endTime ||
+            entryA.description !== entryB.description ||
+            entryA.duration !== entryB.duration) {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/src/views/AdvancedCalendarView.ts
+++ b/src/views/AdvancedCalendarView.ts
@@ -1015,6 +1015,8 @@ export class AdvancedCalendarView extends ItemView implements OptimizedView {
             const start = parseDateToLocal(startDate);
             const end = new Date(start.getTime() + (task.timeEstimate * 60 * 1000));
             endDate = format(end, "yyyy-MM-dd'T'HH:mm");
+        } else if (!hasTime) {
+            endDate = this.calculateAllDayEndDate(startDate, task.timeEstimate);
         }
         
         // Get priority-based color for border
@@ -1231,6 +1233,8 @@ export class AdvancedCalendarView extends ItemView implements OptimizedView {
             const start = parseDateToLocal(eventStart);
             const end = new Date(start.getTime() + (task.timeEstimate * 60 * 1000));
             endDate = format(end, "yyyy-MM-dd'T'HH:mm");
+        } else if (!hasTime) {
+            endDate = this.calculateAllDayEndDate(eventStart, task.timeEstimate);
         }
         
         // Get priority-based color for border
@@ -1273,6 +1277,8 @@ export class AdvancedCalendarView extends ItemView implements OptimizedView {
             const start = parseDateToLocal(eventStart);
             const end = new Date(start.getTime() + (task.timeEstimate * 60 * 1000));
             endDate = format(end, "yyyy-MM-dd'T'HH:mm");
+        } else if (!hasTime) {
+            endDate = this.calculateAllDayEndDate(eventStart, task.timeEstimate);
         }
         
         // Get priority-based color for border
@@ -1305,6 +1311,18 @@ export class AdvancedCalendarView extends ItemView implements OptimizedView {
                 recurringTemplateTime: templateTime
             }
         };
+    }
+
+    private calculateAllDayEndDate(startDate: string, timeEstimate?: number): string | undefined {
+        if (!timeEstimate || timeEstimate <= 0) {
+            return undefined;
+        }
+
+        const minutesPerDay = 60 * 24;
+        const start = parseDateToLocal(startDate);
+        const days = Math.max(1, Math.ceil(timeEstimate / minutesPerDay));
+        const end = new Date(start.getTime() + (days * minutesPerDay * 60 * 1000));
+        return format(end, 'yyyy-MM-dd');
     }
 
     // Event handlers

--- a/src/views/AdvancedCalendarView.ts
+++ b/src/views/AdvancedCalendarView.ts
@@ -81,6 +81,7 @@ interface CalendarEvent {
         recurringTemplateTime?: string; // Original scheduled time
         subscriptionName?: string; // For ICS events
         attachments?: string[]; // For timeblocks
+        originalDate?: string; // For timeblock daily note reference
     };
 }
 
@@ -1514,7 +1515,7 @@ export class AdvancedCalendarView extends ItemView implements OptimizedView {
             console.warn('[AdvancedCalendarView] Event clicked without extendedProps');
             return;
         }
-        const { taskInfo, icsEvent, timeblock, eventType, subscriptionName } = clickInfo.event.extendedProps;
+        const { taskInfo, icsEvent, timeblock, eventType, subscriptionName, originalDate } = clickInfo.event.extendedProps;
         const jsEvent = clickInfo.jsEvent;
 
         // Skip task events in list view - they have their own TaskCard-style handlers
@@ -1533,8 +1534,8 @@ export class AdvancedCalendarView extends ItemView implements OptimizedView {
         }
         
         if (eventType === 'timeblock') {
-            // Timeblocks are read-only for now, could add editing later
-            this.showTimeblockInfo(timeblock, clickInfo.event.start);
+            // Timeblocks can be edited via modal
+            this.showTimeblockInfo(timeblock, clickInfo.event.start, originalDate);
             return;
         }
         
@@ -2785,8 +2786,8 @@ export class AdvancedCalendarView extends ItemView implements OptimizedView {
         modal.open();
     }
 
-    private showTimeblockInfo(timeblock: TimeBlock, eventDate: Date): void {
-        const modal = new TimeblockInfoModal(this.app, this.plugin, timeblock, eventDate);
+    private showTimeblockInfo(timeblock: TimeBlock, eventDate: Date, originalDate?: string): void {
+        const modal = new TimeblockInfoModal(this.app, this.plugin, timeblock, eventDate, originalDate);
         modal.open();
     }
 


### PR DESCRIPTION
- **fix: render all-day tasks across multiple days**
- **fix: refresh calendar after archive/move**
- **fix: refresh calendar when duration/time tracking changes (#382)**
- **fix(pomodoro): preserve task when auto-starting sessions (#641)**
- **fix(timeblocks): use stored date for editing (#647)**

