### PR TITLE
feat: allow slashes in hierarchical tags and contexts

### DIFF
--- a/src/ui/renderers/tagRenderer.ts
+++ b/src/ui/renderers/tagRenderer.ts
@@ -6,8 +6,8 @@ export interface TagServices {
 
 /** Render a single tag string as an Obsidian-like tag element */
 export function renderTag(
-  container: HTMLElement, 
-  tag: string, 
+  container: HTMLElement,
+  tag: string,
   services?: TagServices
 ): void {
   if (!tag || typeof tag !== 'string') return;
@@ -18,7 +18,7 @@ export function renderTag(
   const el = container.createEl('a', {
     cls: 'tag',
     text: normalized,
-    attr: { 
+    attr: {
       'href': normalized,
       'role': 'button',
       'tabindex': '0'
@@ -32,7 +32,7 @@ export function renderTag(
       e.stopPropagation();
       services.onTagClick!(normalized, e as MouseEvent);
     });
-    
+
     // Add keyboard support
     el.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
@@ -45,8 +45,8 @@ export function renderTag(
 
 /** Render a list or single tag value into a container */
 export function renderTagsValue(
-  container: HTMLElement, 
-  value: unknown, 
+  container: HTMLElement,
+  value: unknown,
   services?: TagServices
 ): void {
   if (typeof value === 'string') {
@@ -57,7 +57,7 @@ export function renderTagsValue(
     const validTags = value
       .flat(2)
       .filter(t => t !== null && t !== undefined && typeof t === 'string');
-      
+
     validTags.forEach((t, idx) => {
       if (idx > 0) container.appendChild(document.createTextNode(' '));
       renderTag(container, String(t), services);
@@ -70,7 +70,7 @@ export function renderTagsValue(
 
 /** Render contexts with @ prefix */
 export function renderContextsValue(
-  container: HTMLElement, 
+  container: HTMLElement,
   value: unknown,
   services?: TagServices
 ): void {
@@ -85,14 +85,14 @@ export function renderContextsValue(
           'tabindex': '0'
         }
       });
-      
+
       if (services?.onTagClick) {
         el.addEventListener('click', (e) => {
           e.preventDefault();
           e.stopPropagation();
           services.onTagClick!(normalized, e as MouseEvent);
         });
-        
+
         el.addEventListener('keydown', (e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
@@ -107,13 +107,13 @@ export function renderContextsValue(
     const validContexts = value
       .flat(2)
       .filter(c => c !== null && c !== undefined && typeof c === 'string');
-      
+
     validContexts.forEach((context, idx) => {
       if (idx > 0) container.appendChild(document.createTextNode(', '));
-      
+
       // Render each context directly instead of recursively calling renderContextsValue
       const normalized = normalizeContext(context);
-      
+
       if (normalized) {
         const el = container.createEl('span', {
           cls: 'context-tag',
@@ -123,14 +123,14 @@ export function renderContextsValue(
             'tabindex': '0'
           }
         });
-        
+
         if (services?.onTagClick) {
           el.addEventListener('click', (e) => {
             e.preventDefault();
             e.stopPropagation();
             services.onTagClick!(normalized, e as MouseEvent);
           });
-          
+
           el.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
@@ -149,46 +149,41 @@ export function renderContextsValue(
   if (value != null) container.appendChild(document.createTextNode(String(value)));
 }
 
-/** 
- * Normalize arbitrary tag strings into #tag form 
+/**
+ * Normalize arbitrary tag strings into #tag form
  * Enhanced to handle spaces and special characters
  */
 export function normalizeTag(raw: string): string | null {
   if (!raw || typeof raw !== 'string') return null;
-  
   const s = raw.trim();
   if (!s) return null;
-  
-  // Already has # prefix
-  if (s.startsWith('#')) {
-    // Remove invalid characters and spaces
-    const cleaned = s.replace(/[^\w#-]/g, '');
+
+  // Clean input: keep word chars, hyphens, and slashes for hierarchical tags
+  const hasPrefix = s.startsWith('#');
+  const cleaned = s.replace(/[^\w#/-]/g, '');
+
+  if (hasPrefix) {
     return cleaned.length > 1 ? cleaned : null;
   }
-  
-  // Add # prefix and clean
-  const cleaned = s.replace(/[^\w-]/g, '');
-  return cleaned ? `#${cleaned}` : null;
-}
 
-/** 
- * Normalize context strings into @context form 
+  return cleaned ? `#${cleaned}` : null;
+}/**
+ * Normalize context strings into @context form
  * Enhanced to handle spaces and special characters
  */
 export function normalizeContext(raw: string): string | null {
   if (!raw || typeof raw !== 'string') return null;
-  
+
   const s = raw.trim();
   if (!s) return null;
-  
-  // Already has @ prefix
-  if (s.startsWith('@')) {
-    // Remove invalid characters and spaces
-    const cleaned = s.replace(/[^\w@-]/g, '');
+
+  // Clean input: keep word chars, hyphens, and slashes for hierarchical contexts
+  const hasPrefix = s.startsWith('@');
+  const cleaned = s.replace(/[^\w@/-]/g, '');
+
+  if (hasPrefix) {
     return cleaned.length > 1 ? cleaned : null;
   }
-  
-  // Add @ prefix and clean
-  const cleaned = s.replace(/[^\w-]/g, '');
+
   return cleaned ? `@${cleaned}` : null;
 }

--- a/tests/unit/tagRenderer.test.ts
+++ b/tests/unit/tagRenderer.test.ts
@@ -1,0 +1,41 @@
+import { normalizeTag, normalizeContext } from '../../src/ui/renderers/tagRenderer';
+
+describe('normalizeTag', () => {
+    it('adds # prefix when missing and preserves slash in hierarchical tags', () => {
+        expect(normalizeTag('project/frontend')).toBe('#project/frontend');
+    });
+
+    it('preserves existing # prefix and slash', () => {
+        expect(normalizeTag('#project/frontend')).toBe('#project/frontend');
+    });
+
+    it('removes invalid characters but keeps slash', () => {
+        expect(normalizeTag('  pr$oj!@/front*end  ')).toBe('#proj/frontend');
+    });
+
+    it('returns null for empty or invalid results', () => {
+        expect(normalizeTag('')).toBeNull();
+        expect(normalizeTag('   ')).toBeNull();
+        expect(normalizeTag('#')).toBeNull();
+    });
+});
+
+describe('normalizeContext', () => {
+    it('adds @ prefix when missing and preserves slash in hierarchical contexts', () => {
+        expect(normalizeContext('home/computer')).toBe('@home/computer');
+    });
+
+    it('preserves existing @ prefix and slash', () => {
+        expect(normalizeContext('@office/phone')).toBe('@office/phone');
+    });
+
+    it('removes invalid characters but keeps slash', () => {
+        expect(normalizeContext('  h$me!#/comp*uter  ')).toBe('@hme/computer');
+    });
+
+    it('returns null for empty or invalid results', () => {
+        expect(normalizeContext('')).toBeNull();
+        expect(normalizeContext('   ')).toBeNull();
+        expect(normalizeContext('@')).toBeNull();
+    });
+});


### PR DESCRIPTION
This changeset includes the following changes:

- Update normalizeTag to preserve slashes for hierarchical tags (e.g. #project/frontend)
- Update normalizeContext to preserve slashes for hierarchical contexts (e.g. @home/computer)
- Refactor both functions to eliminate code duplication
- Add comprehensive unit tests for both functions

**Before this fix**
<img width="660" height="96" alt="image" src="https://github.com/user-attachments/assets/8fea7aae-0016-4069-adc5-c567647e5781" />

**After this change**
<img width="656" height="92" alt="image" src="https://github.com/user-attachments/assets/43586bd7-5703-4a6e-88ca-d5f07a8721b2" />

Fixes #712 