### PR TITLE
Fix NLP tag parsing for hyphenated tags

### DIFF
--- a/src/services/NaturalLanguageParser.ts
+++ b/src/services/NaturalLanguageParser.ts
@@ -197,10 +197,10 @@ export class NaturalLanguageParser {
 
     /** Extracts #tags from the text and adds them to the result object. */
     private extractTags(text: string, result: ParsedTaskData): string {
-        const tagMatches = text.match(/#[\w/]+/g);
+        const tagMatches = text.match(/#[\w/-]+/g);
         if (tagMatches) {
             result.tags.push(...tagMatches.map(tag => tag.substring(1)));
-            return this.cleanupWhitespace(text.replace(/#[\w/]+/g, ''));
+            return this.cleanupWhitespace(text.replace(/#[\w/-]+/g, ''));
         }
         return text;
     }

--- a/tests/unit/services/NaturalLanguageParser.test.ts
+++ b/tests/unit/services/NaturalLanguageParser.test.ts
@@ -153,6 +153,13 @@ describe('NaturalLanguageParser', () => {
       expect(result.priority).toBe('urgent');
       expect(result.title).toBe('Meeting');
     });
+
+    it('should extract tags with hyphens correctly', () => {
+      const result = parser.parseInput('Configure #Home-Assistant integration');
+
+      expect(result.tags).toEqual(['Home-Assistant']);
+      expect(result.title).toBe('Configure integration');
+    });
   });
 
   describe('Projects Extraction', () => {


### PR DESCRIPTION
## Summary
• Fixes regex pattern to properly parse tags containing hyphens
• Adds test case to prevent regression

## Test plan
- [x] Existing tests pass
- [x] New test validates hyphenated tag parsing
- [x] Manual verification with example from issue

Fixes #568