### PR TITLE
Disable save buttons to prevent creating duplicate tasks

### DIFF
--- a/src/modals/TaskEditModal.ts
+++ b/src/modals/TaskEditModal.ts
@@ -723,7 +723,9 @@ export class TaskEditModal extends TaskModal {
         });
         
         saveButton.addEventListener('click', async () => {
+            saveButton.disabled = true;
             await this.handleSave();
+            saveButton.disabled = false;
             this.close();
         });
 

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -451,7 +451,9 @@ export abstract class TaskModal extends Modal {
         });
         
         saveButton.addEventListener('click', async () => {
+            saveButton.disabled = true;
             await this.handleSave();
+            saveButton.disabled = false;
             this.close();
         });
 


### PR DESCRIPTION
This is a proposed change/fix to disable the save button from both the Edit and Create task modals. I noticed locally when using the plugin that I was sometimes accidentally creating duplicates of the task because I clicked on the save button more than once.

With this fix, even if the user clicks multiple times on the save button - only one task will be created. Additionally, [the ReminderModal seems to use a similar pattern](https://github.com/callumalpass/tasknotes/blob/11f2e0742aea587c3798ad848e443883192f84f2/src/modals/ReminderModal.ts#L479).

Tested these changes locally by:

- Creating a local test vault
- Running `npm run dev` (pointing the copy action to the local test vault)
- Creating a task note (and spamming the add button)
  - Additionally for testing I added a new `await new Promise(r => setTimeout(r, 10_000))` to test a long delay and spamming the save button