### PR TITLE
Fix recurring task completion styling in Bases views

### DIFF
--- a/src/bases/base-view-factory.ts
+++ b/src/bases/base-view-factory.ts
@@ -205,6 +205,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
             showArchiveButton: false,
             showTimeTracking: false,
             showRecurringControls: true,
+            targetDate: new Date()
           });
 
           // Add update animation

--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -19,7 +19,8 @@ function createTaskInfoFromProperties(props: Record<string, any>, basesItem: Bas
   const knownProperties = new Set([
     'title', 'status', 'priority', 'archived', 'due', 'scheduled', 'contexts',
     'projects', 'tags', 'timeEstimate', 'completedDate', 'recurrence',
-    'dateCreated', 'dateModified', 'timeEntries', 'reminders', 'icsEventId'
+    'dateCreated', 'dateModified', 'timeEntries', 'reminders', 'icsEventId',
+    'complete_instances'
   ]);
 
   const customProperties: Record<string, any> = {};
@@ -48,6 +49,7 @@ function createTaskInfoFromProperties(props: Record<string, any>, basesItem: Bas
     timeEntries: props.timeEntries,
     reminders: props.reminders,
     icsEventId: props.icsEventId,
+    complete_instances: props.complete_instances,
     customProperties: Object.keys(customProperties).length > 0 ? customProperties : undefined,
     basesData: basesItem.basesData
   };
@@ -243,7 +245,12 @@ export async function renderTaskNotesInBasesView(
 
   for (const taskInfo of taskNotes) {
     try {
-      const taskCard = createTaskCard(taskInfo, plugin, visibleProperties, cardOptions);
+      // Pass current date as targetDate for proper recurring task completion styling
+      const cardOptionsWithDate = {
+        ...cardOptions,
+        targetDate: new Date()
+      };
+      const taskCard = createTaskCard(taskInfo, plugin, visibleProperties, cardOptionsWithDate);
       taskListEl.appendChild(taskCard);
 
       // Track task elements for selective updates


### PR DESCRIPTION
## Summary
Fixes #669 - recurring tasks now show proper completion styling in Bases views.

## Root Cause
Two issues prevented recurring task completion styling:
1. Missing `complete_instances` field in TaskInfo objects created from Bases data
2. No date context passed to determine completion status for current date

## Changes
- Add `complete_instances` to known properties mapping in Bases helpers
- Pass `targetDate: new Date()` to task card creation/updates in Bases views

## Test Plan
- [x] Verify recurring tasks show completion styling in Bases views
- [x] Confirm non-recurring tasks still work correctly
- [x] Check that other views are unaffected
- [x] TypeScript compilation passes
- [x] Existing tests pass