### PR TITLE
Fix property value truncation in project autosuggest settings

### DIFF
--- a/src/settings/components/settingHelpers.ts
+++ b/src/settings/components/settingHelpers.ts
@@ -14,6 +14,7 @@ export interface TextSettingOptions {
     getValue: () => string;
     setValue: (value: string) => void;
     ariaLabel?: string;
+    debounceMs?: number; // Optional debounce time in milliseconds
 }
 
 export interface DropdownSettingOptions {
@@ -65,20 +66,27 @@ export function createTextSetting(container: HTMLElement, options: TextSettingOp
         .setName(options.name)
         .setDesc(options.desc)
         .addText(text => {
-            text.setValue(options.getValue())
-                .onChange(options.setValue);
-            
+            text.setValue(options.getValue());
+
+            // Use debounced onChange if debounceMs is specified
+            if (options.debounceMs && options.debounceMs > 0) {
+                const debouncedSetValue = debounce(options.setValue, options.debounceMs);
+                text.onChange(debouncedSetValue);
+            } else {
+                text.onChange(options.setValue);
+            }
+
             if (options.placeholder) {
                 text.setPlaceholder(options.placeholder);
             }
-            
+
             if (options.ariaLabel) {
                 text.inputEl.setAttribute('aria-label', options.ariaLabel);
             }
-            
+
             // Apply consistent styling
             text.inputEl.addClass('settings-view__input');
-            
+
             return text;
         });
 }

--- a/src/settings/tabs/appearanceTab.ts
+++ b/src/settings/tabs/appearanceTab.ts
@@ -564,7 +564,8 @@ export function renderAppearanceTab(container: HTMLElement, plugin: TaskNotesPlu
             plugin.settings.projectAutosuggest.propertyKey = value.trim();
             save();
         },
-        ariaLabel: 'Required frontmatter property key for project suggestions'
+        ariaLabel: 'Required frontmatter property key for project suggestions',
+        debounceMs: 500 // Prevent rapid save calls while typing
     });
 
     createTextSetting(container, {
@@ -579,7 +580,8 @@ export function renderAppearanceTab(container: HTMLElement, plugin: TaskNotesPlu
             plugin.settings.projectAutosuggest.propertyValue = value.trim();
             save();
         },
-        ariaLabel: 'Required frontmatter property value for project suggestions'
+        ariaLabel: 'Required frontmatter property value for project suggestions',
+        debounceMs: 500 // Prevent rapid save calls while typing
     });
 
     createToggleSetting(container, {


### PR DESCRIPTION
## Summary
Fixes property value truncation in project autosuggest settings by adding input debouncing.

## Changes
- Added optional `debounceMs` parameter to `TextSettingOptions` interface
- Enhanced `createTextSetting` to support debounced input handling
- Applied 500ms debouncing to Required Property Key and Required Property Value fields

## Test plan
- [x] TypeScript compilation passes
- [x] Build completes successfully  
- [x] All existing tests pass
- [ ] Manual testing: Type "project" in Required Property Value field and verify full text is saved

Fixes #705