### PR TITLE
Fix agenda duplication for all-day ICS events

### DIFF
--- a/src/views/AgendaView.ts
+++ b/src/views/AgendaView.ts
@@ -734,8 +734,11 @@ export class AgendaView extends ItemView implements OptimizedView {
                 const evStart = new Date(ev.start);
                 const evEnd = ev.end ? new Date(ev.end) : null;
                 if (evEnd) {
-                    // Overlaps if start <= dayEnd and end >= dayStart
-                    return evStart <= dayEnd && evEnd >= dayStart;
+                    // All-day events use exclusive DTEND; subtract a millisecond so the
+                    // final day is inclusive without spilling into the next one.
+                    const effectiveEnd = ev.allDay ? new Date(evEnd.getTime() - 1) : evEnd;
+                    // Overlaps if start <= dayEnd and effective end >= dayStart
+                    return evStart <= dayEnd && effectiveEnd >= dayStart;
                 }
                 // No end: occurs on day if start between start and end of day
                 return evStart >= dayStart && evStart <= dayEnd;

--- a/tests/unit/issues/issue-695-agenda-ics-all-day-dup.test.ts
+++ b/tests/unit/issues/issue-695-agenda-ics-all-day-dup.test.ts
@@ -1,0 +1,35 @@
+import { AgendaView } from '../../../src/views/AgendaView';
+import { ICSEvent } from '../../../src/types';
+import { createUTCDateFromLocalCalendarDate } from '../../../src/utils/dateUtils';
+
+describe('Issue #695 - Agenda all-day ICS duplication', () => {
+    it('should not surface exclusive-end all-day events on the following day', () => {
+        const filterFn = (AgendaView.prototype as any).filterICSEventsForDate as (
+            events: ICSEvent[],
+            date: Date
+        ) => ICSEvent[];
+
+        const localStart = new Date(2025, 1, 20); // Feb 20, 2025
+        const localEndExclusive = new Date(2025, 1, 21); // Feb 21, 2025 (exclusive end)
+
+        const events: ICSEvent[] = [
+            {
+                id: 'sub-uid',
+                subscriptionId: 'sub',
+                title: 'All day test',
+                start: localStart.toISOString(),
+                end: localEndExclusive.toISOString(),
+                allDay: true,
+                description: undefined,
+                location: undefined,
+                url: undefined
+            }
+        ];
+
+        const firstDay = createUTCDateFromLocalCalendarDate(localStart);
+        const secondDay = createUTCDateFromLocalCalendarDate(localEndExclusive);
+
+        expect(filterFn(events, firstDay)).toHaveLength(1);
+        expect(filterFn(events, secondDay)).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary
- adjust AgendaView ICS filtering to treat all-day exclusive end times as inclusive
- add regression test covering issue #695 

## Testing
- npm run test -- --runInBand tests/unit/issues/issue-695-agenda-ics-all-day-dup.test.ts
