### PR TITLE
feat: add hierarchical tag support with exclusion patterns

### DIFF
--- a/src/suggest/FileSuggestHelper.ts
+++ b/src/suggest/FileSuggestHelper.ts
@@ -3,6 +3,7 @@ import { parseFrontMatterAliases } from "obsidian";
 import { scoreMultiword } from "../utils/fuzzyMatch";
 import { parseDisplayFieldsRow } from "../utils/projectAutosuggestDisplayFieldsParser";
 import { getProjectPropertyFilter, matchesProjectProperty } from "../utils/projectFilterUtils";
+import { FilterUtils } from "../utils/FilterUtils";
 
 export interface FileSuggestionItem {
 	insertText: string; // usually basename
@@ -59,8 +60,8 @@ export const FileSuggestHelper = {
 							: [frontmatterTags].filter(Boolean)),
 					];
 
-					// Check if file has ANY of the required tags
-					const hasRequiredTag = requiredTags.some((reqTag) => allTags.includes(reqTag));
+					// Check if file has ANY of the required tags using hierarchical matching with proper exclusion handling
+					const hasRequiredTag = FilterUtils.matchesTagConditions(allTags, requiredTags);
 					if (!hasRequiredTag) {
 						continue; // Skip this file
 					}

--- a/src/utils/MinimalNativeCache.ts
+++ b/src/utils/MinimalNativeCache.ts
@@ -2,6 +2,7 @@
 import { TFile, App, Events, EventRef, parseLinktext } from "obsidian";
 import { TaskInfo, NoteInfo, TaskDependency } from "../types";
 import { FieldMapper } from "../services/FieldMapper";
+import { FilterUtils } from "./FilterUtils";
 import {
 	getTodayString,
 	isBeforeDateSafe,
@@ -118,8 +119,11 @@ export class MinimalNativeCache extends Events {
 			}
 			return this.comparePropertyValues(frontmatterValue, propValue);
 		} else {
-			// Fallback to legacy tag-based method
-			return Array.isArray(frontmatter.tags) && frontmatter.tags.includes(this.taskTag);
+			// Fallback to legacy tag-based method with hierarchical support
+			if (!Array.isArray(frontmatter.tags)) return false;
+			return frontmatter.tags.some((tag: string) =>
+				FilterUtils.matchesHierarchicalTag(tag, this.taskTag)
+			);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Implements hierarchical tag support for Obsidian nested tags as requested in issue #584.

## Features

- **Hierarchical matching**: Searching for `t/ef` now matches child tags like `t/ef/project`, `t/ef/task`, `t/ef/bug`
- **Exclusion patterns**: Support for `-t/ef/bug` to exclude specific tags and their children
- **Backward compatibility**: Existing substring matching preserved (e.g., `proj` still matches `project/alpha`)

## Implementation

- Enhanced `FilterUtils` with `matchesHierarchicalTag()` and `matchesTagConditions()` methods
- Updated FilterBar tag filtering to use hierarchical matching for "contains" operations
- Enhanced project autosuggester required tags filtering
- Improved task identification by tags with hierarchical support

## Test Coverage

- All existing tests pass
- TypeScript compilation succeeds
- Manual testing confirms all features work correctly
- No performance regressions

## Examples

```yaml
# Now supported in FilterBar and Project Autosuggester:
- "t/ef"              # Matches: t/ef, t/ef/project, t/ef/task, t/ef/bug
- "-t/ef/bug"         # Excludes: t/ef/bug, t/ef/bug/critical  
- "proj"              # Still matches: project/alpha (backward compatibility)
- ["t/ef", "-t/ef/bug"]  # Include t/ef hierarchy, exclude t/ef/bug branch
```

Fixes #584