### PR TITLE
Fix: Apply subgroups consistently to overdue section in Agenda View

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,6 +9,8 @@
 **Fixed** for any bug fixes.
 **Security** in case of vulnerabilities.
 
+Always acknowledge contributors and those who report issues. 
+
 Example:
 
 ```
@@ -30,6 +32,11 @@ Example:
   - Preserved substring matching behavior for filter bar searches where it's desired
   - Only exact matches or hierarchical children (like "task/work") now identify notes as tasks
   - Thanks to @anareaty and @fastrick for reporting this issue
+- (#767) Fixed subgroups not rendering under the "Overdue" agenda group
+  - Overdue section now properly renders subgroups when enabled in Agenda View
+  - Added expand/collapse controls for overdue subgroups matching regular day sections
+  - Maintains consistent functionality and styling across all agenda groups
+  - Thanks to @renatomen for reporting this issue
 - (#768) Fixed calendar view appearing empty in week and day views due to invalid time configuration values
   - Added time validation in settings UI with proper error messages and debouncing
   - Added runtime sanitization in calendar with safe defaults (00:00:00, 24:00:00, 08:00:00)


### PR DESCRIPTION
## Summary

Fixes #767 - Subgroups are now consistently applied to the "Overdue" agenda group.

## Changes Made

- Modified overdue section rendering to detect and apply subgroups when enabled
- Added expand/collapse controls for overdue subgroups matching regular day sections  
- Maintains same functionality and styling as regular day sections
- Ensures consistent subgroup behavior across all agenda groups

## Testing

- ✅ TypeScript compilation passes
- ✅ Build completes successfully  
- ✅ ESLint passes with no new issues
- ✅ Overdue section now properly renders subgroups when enabled
- ✅ Expand/collapse controls work correctly for overdue subgroups

Thanks to @renatomen for reporting this issue.