### PR TITLE
Fix screens failing to load with non-string tags

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -25,3 +25,10 @@ Example:
 
 -->
 
+## Fixed
+
+- (#776) Fixed screens failing to load with "toLowerCase is not a function" error
+  - Issue occurred when frontmatter tags array contained non-string values (numbers, booleans, etc.)
+  - Added type validation to filter out non-string values before processing tags
+  - Valid string tags continue to work normally while invalid types are safely skipped
+  - Thanks to @kmf and @Andre-Ioda for help debugging this issue

--- a/src/utils/MinimalNativeCache.ts
+++ b/src/utils/MinimalNativeCache.ts
@@ -123,7 +123,7 @@ export class MinimalNativeCache extends Events {
 			// Use exact matching (no substring fallback) for task identification
 			if (!Array.isArray(frontmatter.tags)) return false;
 			return frontmatter.tags.some((tag: string) =>
-				FilterUtils.matchesHierarchicalTagExact(tag, this.taskTag)
+				typeof tag === 'string' && FilterUtils.matchesHierarchicalTagExact(tag, this.taskTag)
 			);
 		}
 	}

--- a/tests/utils/MinimalNativeCache.isTaskFile.test.ts
+++ b/tests/utils/MinimalNativeCache.isTaskFile.test.ts
@@ -1,0 +1,119 @@
+import { MinimalNativeCache } from '../../src/utils/MinimalNativeCache';
+import { TaskNotesSettings } from '../../src/types/settings';
+
+// Mock FilterUtils
+jest.mock('../../src/utils/FilterUtils', () => ({
+	FilterUtils: {
+		matchesHierarchicalTagExact: jest.fn((tag: string, taskTag: string) => {
+			return tag.toLowerCase() === taskTag.toLowerCase();
+		}),
+	},
+}));
+
+describe('MinimalNativeCache - isTaskFile with non-string tags', () => {
+	let cache: MinimalNativeCache;
+	let mockApp: any;
+	let settings: TaskNotesSettings;
+
+	beforeEach(() => {
+		mockApp = {
+			metadataCache: {
+				on: jest.fn(),
+			},
+			vault: {
+				on: jest.fn(),
+			},
+		};
+
+		settings = {
+			taskTag: 'task',
+			taskIdentificationMethod: 'tag',
+			excludedFolders: '',
+			disableNoteIndexing: false,
+			storeTitleInFilename: false,
+		} as TaskNotesSettings;
+
+		cache = new MinimalNativeCache(mockApp, settings);
+	});
+
+	test('handles frontmatter with valid string tags', () => {
+		const frontmatter = {
+			tags: ['task', 'project', 'important'],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(true);
+	});
+
+	test('handles frontmatter with number in tags array', () => {
+		const frontmatter = {
+			tags: ['task', 123, 'project'],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(true);
+	});
+
+	test('handles frontmatter with boolean in tags array', () => {
+		const frontmatter = {
+			tags: [true, 'task', false],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(true);
+	});
+
+	test('handles frontmatter with mixed non-string types', () => {
+		const frontmatter = {
+			tags: [123, true, 'task', null, undefined, 'project'],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(true);
+	});
+
+	test('returns false when all tags are non-strings', () => {
+		const frontmatter = {
+			tags: [123, true, null, undefined, 456],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(false);
+	});
+
+	test('handles frontmatter with object in tags array', () => {
+		const frontmatter = {
+			tags: [{ nested: 'value' }, 'task'],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(true);
+	});
+
+	test('handles frontmatter with array in tags array', () => {
+		const frontmatter = {
+			tags: [['nested', 'array'], 'task'],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(true);
+	});
+
+	test('handles empty tags array', () => {
+		const frontmatter = {
+			tags: [],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(false);
+	});
+
+	test('handles nested tag hierarchy with non-strings', () => {
+		const frontmatter = {
+			tags: ['task', 123, 'other/tag'],
+		};
+
+		const result = (cache as any).isTaskFile(frontmatter);
+		expect(result).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
Fixes #776 - screens failing to load when frontmatter tags array contains non-string values.

## Changes
- Added type validation in `MinimalNativeCache.ts` to filter out non-string values before calling string methods
- Updated changelog

## Test plan
- Verified fix handles frontmatter with mixed tag types (strings, numbers, booleans)
- Confirmed valid string tags continue to work normally