### PR TITLE
Fix Unicode characters not displaying in tags and contexts

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,6 +27,10 @@ Example:
 
 ## Fixed
 
+- (#601) Fixed Unicode characters not displaying in tags and contexts
+  - Unicode characters (Š, Ė, Ž, Ą, etc.) are now properly preserved in tags and contexts
+  - Affects Agenda View, Task List View, and all other views displaying tags
+  - Thanks to @Kapinekas for reporting
 - (#778) Fixed cursor artifacts in CodeMirror widgets
   - Thanks to @jhedlund for the fix
 

--- a/src/ui/renderers/tagRenderer.ts
+++ b/src/ui/renderers/tagRenderer.ts
@@ -147,16 +147,17 @@ export function renderContextsValue(
 
 /**
  * Normalize arbitrary tag strings into #tag form
- * Enhanced to handle spaces and special characters
+ * Enhanced to handle spaces and special characters including Unicode
  */
 export function normalizeTag(raw: string): string | null {
 	if (!raw || typeof raw !== "string") return null;
 	const s = raw.trim();
 	if (!s) return null;
 
-	// Clean input: keep word chars, hyphens, and slashes for hierarchical tags
+	// Clean input: keep Unicode word chars, hyphens, and slashes for hierarchical tags
+	// Use \p{L} (Unicode letters), \p{N} (Unicode numbers), and _ (underscore)
 	const hasPrefix = s.startsWith("#");
-	const cleaned = s.replace(/[^\w#/-]/g, "");
+	const cleaned = s.replace(/[^\p{L}\p{N}_#/-]/gu, "");
 
 	if (hasPrefix) {
 		return cleaned.length > 1 ? cleaned : null;
@@ -165,7 +166,7 @@ export function normalizeTag(raw: string): string | null {
 	return cleaned ? `#${cleaned}` : null;
 } /**
  * Normalize context strings into @context form
- * Enhanced to handle spaces and special characters
+ * Enhanced to handle spaces and special characters including Unicode
  */
 export function normalizeContext(raw: string): string | null {
 	if (!raw || typeof raw !== "string") return null;
@@ -173,9 +174,10 @@ export function normalizeContext(raw: string): string | null {
 	const s = raw.trim();
 	if (!s) return null;
 
-	// Clean input: keep word chars, hyphens, and slashes for hierarchical contexts
+	// Clean input: keep Unicode word chars, hyphens, and slashes for hierarchical contexts
+	// Use \p{L} (Unicode letters), \p{N} (Unicode numbers), and _ (underscore)
 	const hasPrefix = s.startsWith("@");
-	const cleaned = s.replace(/[^\w@/-]/g, "");
+	const cleaned = s.replace(/[^\p{L}\p{N}_@/-]/gu, "");
 
 	if (hasPrefix) {
 		return cleaned.length > 1 ? cleaned : null;


### PR DESCRIPTION
## Summary

Fixes #601 - Unicode characters (Š, Ė, Ž, Ą, etc.) are now properly preserved in tags and contexts across all views.

## Changes

- Updated `normalizeTag()` and `normalizeContext()` functions in `tagRenderer.ts`
- Changed regex patterns from `\w` (ASCII only) to Unicode property escapes:
  - `\p{L}` for Unicode letters
  - `\p{N}` for Unicode numbers
- Added `u` flag to enable Unicode mode

## Test plan

- [ ] Verify tags with Unicode characters display correctly in Agenda View
- [ ] Verify tags with Unicode characters display correctly in Task List View
- [ ] Verify contexts with Unicode characters display correctly
- [ ] Verify existing ASCII tags still work as expected