### PR TITLE
Improve status bar tracked task navigation and fix widget updates

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -40,6 +40,12 @@ Example:
 - (#778) Fixed cursor artifacts in CodeMirror widgets
   - Thanks to @jhedlund for the fix
 
+- Fixed task card widgets in note editor not updating for archive and time tracking changes
+  - Task card widgets now properly detect when tasks are archived/unarchived
+  - Task card widgets now properly detect when time tracking starts/stops
+  - Blue "tracking" border now appears/disappears correctly in live preview
+  - Archive styling now updates correctly in live preview
+
 ## Changed
 
 - (#751) Status bar tracked task click behavior now opens task notes directly

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -42,6 +42,11 @@ Example:
 
 ## Changed
 
+- (#751) Status bar tracked task click behavior now opens task notes directly
+  - Single tracked task: opens the task note immediately
+  - Multiple tracked tasks: shows selector modal to choose which task note to open
+  - Provides faster access to tracked tasks compared to previous task list view
+
 - Improved link handling throughout the plugin using Obsidian's native APIs
   - Replaced manual wikilink generation with `FileManager.generateMarkdownLink()`
   - Now respects user's link format settings (wikilink vs markdown, relative paths)

--- a/src/editor/TaskCardNoteDecorations.ts
+++ b/src/editor/TaskCardNoteDecorations.ts
@@ -35,6 +35,13 @@ export class TaskCardWidget extends WidgetType {
 
 	// Override eq to ensure widget updates when task changes
 	eq(other: TaskCardWidget): boolean {
+		// Helper to check if task has active time tracking session
+		const hasActiveSession = (task: TaskInfo): boolean => {
+			if (!task.timeEntries || task.timeEntries.length === 0) return false;
+			const lastEntry = task.timeEntries[task.timeEntries.length - 1];
+			return !lastEntry.endTime; // Active if no endTime
+		};
+
 		// Check if the task data has changed
 		const taskEqual =
 			this.task.title === other.task.title &&
@@ -43,6 +50,8 @@ export class TaskCardWidget extends WidgetType {
 			this.task.due === other.task.due &&
 			this.task.scheduled === other.task.scheduled &&
 			this.task.path === other.task.path &&
+			this.task.archived === other.task.archived &&
+			hasActiveSession(this.task) === hasActiveSession(other.task) &&
 			JSON.stringify(this.task.contexts || []) ===
 				JSON.stringify(other.task.contexts || []) &&
 			JSON.stringify(this.task.projects || []) ===

--- a/src/editor/TaskCardNoteDecorations.ts
+++ b/src/editor/TaskCardNoteDecorations.ts
@@ -209,6 +209,13 @@ class TaskCardNoteDecorationsPlugin implements PluginValue {
 				// This will return null if the file is not a task note
 				const newTask = this.plugin.cacheManager.getCachedTaskInfoSync(file.path);
 
+				// Helper to check if task has active time tracking session
+				const hasActiveSession = (task: TaskInfo | null): boolean => {
+					if (!task?.timeEntries || task.timeEntries.length === 0) return false;
+					const lastEntry = task.timeEntries[task.timeEntries.length - 1];
+					return !lastEntry.endTime;
+				};
+
 				// Check if task actually changed
 				const taskChanged =
 					this.cachedTask?.title !== newTask?.title ||
@@ -216,7 +223,9 @@ class TaskCardNoteDecorationsPlugin implements PluginValue {
 					this.cachedTask?.priority !== newTask?.priority ||
 					this.cachedTask?.due !== newTask?.due ||
 					this.cachedTask?.scheduled !== newTask?.scheduled ||
-					this.cachedTask?.path !== newTask?.path;
+					this.cachedTask?.path !== newTask?.path ||
+					this.cachedTask?.archived !== newTask?.archived ||
+					hasActiveSession(this.cachedTask) !== hasActiveSession(newTask);
 
 				if (taskChanged) {
 					this.cachedTask = newTask;

--- a/src/editor/TaskCardNoteDecorations.ts
+++ b/src/editor/TaskCardNoteDecorations.ts
@@ -216,7 +216,7 @@ class TaskCardNoteDecorationsPlugin implements PluginValue {
 					return !lastEntry.endTime;
 				};
 
-				// Check if task actually changed
+				// Check if task actually changed - must check all properties that affect widget display
 				const taskChanged =
 					this.cachedTask?.title !== newTask?.title ||
 					this.cachedTask?.status !== newTask?.status ||
@@ -225,7 +225,17 @@ class TaskCardNoteDecorationsPlugin implements PluginValue {
 					this.cachedTask?.scheduled !== newTask?.scheduled ||
 					this.cachedTask?.path !== newTask?.path ||
 					this.cachedTask?.archived !== newTask?.archived ||
-					hasActiveSession(this.cachedTask) !== hasActiveSession(newTask);
+					this.cachedTask?.timeEstimate !== newTask?.timeEstimate ||
+					this.cachedTask?.recurrence !== newTask?.recurrence ||
+					hasActiveSession(this.cachedTask) !== hasActiveSession(newTask) ||
+					JSON.stringify(this.cachedTask?.tags || []) !==
+						JSON.stringify(newTask?.tags || []) ||
+					JSON.stringify(this.cachedTask?.contexts || []) !==
+						JSON.stringify(newTask?.contexts || []) ||
+					JSON.stringify(this.cachedTask?.projects || []) !==
+						JSON.stringify(newTask?.projects || []) ||
+					JSON.stringify(this.cachedTask?.complete_instances || []) !==
+						JSON.stringify(newTask?.complete_instances || []);
 
 				if (taskChanged) {
 					this.cachedTask = newTask;


### PR DESCRIPTION
## Summary

- Status bar now opens task notes directly instead of task list view
- Fixed task card widgets not updating for archive and time tracking changes

## Changes

**Status Bar (#751)**
- Single tracked task: opens note immediately
- Multiple tracked tasks: shows selector modal

**Widget Updates**
- Widgets now detect archive status changes
- Widgets now detect time tracking start/stop
- Added comprehensive property change detection (tags, contexts, projects, etc.)

Closes #751