### PR TITLE
feat: inline task creation respects "Include Current Note in Project" setting (#727)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -42,6 +42,11 @@ Example:
 
 ## Changed
 
+- (#727) "Create New Inline Task" command now respects the "Include Current Note in Project" setting
+  - When enabled, the current note is automatically added as a project to inline tasks
+  - Provides consistency with instant convert functionality
+  - Thanks to @chrisfeagles for the suggestion
+
 - Improved link handling throughout the plugin using Obsidian's native APIs
   - Replaced manual wikilink generation with `FileManager.generateMarkdownLink()`
   - Now respects user's link format settings (wikilink vs markdown, relative paths)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2285,8 +2285,24 @@ export default class TaskNotesPlugin extends Plugin {
 				insertionPoint,
 			};
 
+			// Prepare pre-populated values
+			const prePopulatedValues: Partial<TaskInfo> = {};
+
+			// Include current note as project if enabled
+			if (this.settings.taskCreationDefaults.useParentNoteAsProject) {
+				const currentFile = this.app.workspace.getActiveFile();
+				if (currentFile) {
+					const parentNote = this.app.fileManager.generateMarkdownLink(
+						currentFile,
+						currentFile.path
+					);
+					prePopulatedValues.projects = [parentNote];
+				}
+			}
+
 			// Open task creation modal with callback to insert link
 			const modal = new TaskCreationModal(this.app, this, {
+				prePopulatedValues: Object.keys(prePopulatedValues).length > 0 ? prePopulatedValues : undefined,
 				onTaskCreated: (task: TaskInfo) => {
 					this.handleInlineTaskCreated(task, insertionContext);
 				},


### PR DESCRIPTION
## Summary

The "Create New Inline Task" command now respects the "Include Current Note in Project" setting, providing consistency with the instant convert functionality.

## Changes

- Modified `createInlineTask` method to check `useParentNoteAsProject` setting
- When enabled, automatically includes current note as a project in the task creation modal
- Uses the same approach as instant convert (generates markdown link to current file)

## Related Issue

Closes #727

## Testing

1. Enable "Include Current Note in Project" setting in Task Creation Defaults
2. Open a note and use "Create New Inline Task" command
3. Verify that the task creation modal pre-populates the current note as a project