### PR TITLE
fix: handle missing daily notes folder when creating timeblocks (#780)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,14 +9,14 @@
 **Fixed** for any bug fixes.
 **Security** in case of vulnerabilities.
 
-Always acknowledge contributors and those who report issues. 
+Always acknowledge contributors and those who report issues.
 
 Example:
 
 ```
 ## Fixed
 
-- (#768) Fixed calendar view appearing empty in week and day views due to invalid time configuration values 
+- (#768) Fixed calendar view appearing empty in week and day views due to invalid time configuration values
   - Added time validation in settings UI with proper error messages and debouncing
   - Added runtime sanitization in calendar with safe defaults (00:00:00, 24:00:00, 08:00:00)
   - Prevents "Cannot read properties of null (reading 'years')" error from FullCalendar
@@ -24,4 +24,12 @@ Example:
 ```
 
 -->
+
+## Fixed
+
+- (#780) Fixed "Cannot Create Timeblocks" error when daily notes folder doesn't exist
+  - Added proper error handling when `createDailyNote` fails due to missing folder
+  - Improved error messages to guide users to check Daily Notes plugin configuration
+  - Prevents uncaught errors from `obsidian-daily-notes-interface` package
+  - Thanks to @uberunix for reporting
 

--- a/src/modals/TimeblockCreationModal.ts
+++ b/src/modals/TimeblockCreationModal.ts
@@ -248,7 +248,14 @@ export class TimeblockCreationModal extends Modal {
 
 		if (!dailyNote) {
 			// Create daily note if it doesn't exist
-			dailyNote = await createDailyNote(moment);
+			try {
+				dailyNote = await createDailyNote(moment);
+			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : String(error);
+				throw new Error(
+					`Failed to create daily note: ${errorMessage}. Please check your Daily Notes plugin configuration and ensure the daily notes folder exists.`
+				);
+			}
 
 			// Validate that daily note was created successfully
 			if (!dailyNote) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1227,7 +1227,14 @@ async function addTimeblockToDailyNote(
 	let dailyNote = getDailyNote(moment, allDailyNotes);
 
 	if (!dailyNote) {
-		dailyNote = await createDailyNote(moment);
+		try {
+			dailyNote = await createDailyNote(moment);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			throw new Error(
+				`Failed to create daily note: ${errorMessage}. Please check your Daily Notes plugin configuration and ensure the daily notes folder exists.`
+			);
+		}
 
 		// Validate that daily note was created successfully
 		if (!dailyNote) {


### PR DESCRIPTION
## Summary

Fixes #780 - resolves "Cannot Create Timeblocks" error when the daily notes folder doesn't exist.

## Changes

- Added try-catch blocks around `createDailyNote` calls in `TimeblockCreationModal.ts` and `helpers.ts`
- Improved error messages to guide users to check Daily Notes plugin configuration
- Prevents uncaught errors from `obsidian-daily-notes-interface` package

## Testing

Error now properly caught and user receives actionable error message when daily notes folder is missing.