### PR TITLE
fix: support markdown links in projects and dependencies frontmatter

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,14 +9,14 @@
 **Fixed** for any bug fixes.
 **Security** in case of vulnerabilities.
 
-Always acknowledge contributors and those who report issues. 
+Always acknowledge contributors and those who report issues.
 
 Example:
 
 ```
 ## Fixed
 
-- (#768) Fixed calendar view appearing empty in week and day views due to invalid time configuration values 
+- (#768) Fixed calendar view appearing empty in week and day views due to invalid time configuration values
   - Added time validation in settings UI with proper error messages and debouncing
   - Added runtime sanitization in calendar with safe defaults (00:00:00, 24:00:00, 08:00:00)
   - Prevents "Cannot read properties of null (reading 'years')" error from FullCalendar
@@ -24,4 +24,15 @@ Example:
 ```
 
 -->
+
+## Fixed
+
+- (#792, #800) Fixed markdown-style project and dependency links not being recognized in frontmatter
+  - Added support for markdown link format `[text](path)` in projects and blockedBy fields
+  - Handles URL-encoded paths like `[Car Maintenance](../../projects/Car%20Maintenance.md)`
+  - Markdown links now render as clickable links showing display text instead of raw `[text](path)` format
+  - Links are properly resolved for grouping, filtering, and project-task associations
+  - Previously only wikilink format `[[path]]` was supported
+  - Prevents automatic removal of project assignments when editing tasks
+  - Thanks to @minchinweb for reporting
 

--- a/src/utils/dependencyUtils.ts
+++ b/src/utils/dependencyUtils.ts
@@ -128,12 +128,30 @@ export function resolveDependencyEntry(
 		return null;
 	}
 
-	// Use Obsidian's parseLinktext for proper wikilink parsing
-	// This handles both [[link]] and [[link|alias]] formats correctly
+	// Parse link text to extract path (handles both wikilinks and markdown links)
 	let target = trimmed;
+
+	// Handle wikilinks: [[link]] or [[link|alias]]
 	if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) {
 		const inner = trimmed.slice(2, -2).trim();
 		target = parseLinktext(inner).path;
+	}
+	// Handle markdown links: [text](path)
+	else {
+		const markdownMatch = trimmed.match(/^\[([^\]]*)\]\(([^)]+)\)$/);
+		if (markdownMatch) {
+			let linkPath = markdownMatch[2].trim();
+
+			// URL decode the link path - crucial for paths with spaces
+			try {
+				linkPath = decodeURIComponent(linkPath);
+			} catch (error) {
+				console.debug("Failed to decode URI component:", linkPath, error);
+			}
+
+			// Use parseLinktext to handle subpaths/headings
+			target = parseLinktext(linkPath).path;
+		}
 	}
 
 	if (!target) {

--- a/src/utils/linkUtils.ts
+++ b/src/utils/linkUtils.ts
@@ -1,4 +1,45 @@
-import { App, TFile } from "obsidian";
+import { App, TFile, parseLinktext } from "obsidian";
+
+/**
+ * Parse a link string (wikilink or markdown) to extract the path.
+ * Handles both [[wikilink]] and [text](path) formats.
+ *
+ * @param linkText - The link text to parse
+ * @returns The extracted path, or the original string if it's not a recognized link format
+ */
+export function parseLinkToPath(linkText: string): string {
+	if (!linkText) return linkText;
+
+	const trimmed = linkText.trim();
+
+	// Handle wikilinks: [[path]] or [[path|alias]]
+	if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) {
+		const inner = trimmed.slice(2, -2).trim();
+		const parsed = parseLinktext(inner);
+		return parsed.path;
+	}
+
+	// Handle markdown links: [text](path)
+	const markdownMatch = trimmed.match(/^\[([^\]]*)\]\(([^)]+)\)$/);
+	if (markdownMatch) {
+		let linkPath = markdownMatch[2].trim();
+
+		// URL decode the link path - crucial for paths with spaces like Car%20Maintenance.md
+		try {
+			linkPath = decodeURIComponent(linkPath);
+		} catch (error) {
+			// If decoding fails, use the original path
+			console.debug("Failed to decode URI component:", linkPath, error);
+		}
+
+		// Use parseLinktext to handle subpaths/headings
+		const parsed = parseLinktext(linkPath);
+		return parsed.path;
+	}
+
+	// Not a link format, return as-is
+	return trimmed;
+}
 
 /**
  * Generate a properly formatted markdown link using Obsidian's API.


### PR DESCRIPTION
## Summary

Adds support for markdown-style links `[text](path)` in project and dependency frontmatter fields.

## Changes

- **FilterService**: Parse markdown links when resolving project paths
- **dependencyUtils**: Parse markdown links when resolving dependency entries  
- **linkRenderer**: Render markdown links as clickable links with display text
- Handle URL-encoded paths (e.g., `Car%20Maintenance.md`)

## Fixes

Closes #792, #800

Previously, markdown links were not recognized and would be removed when editing tasks. They now work the same as wikilinks for grouping, filtering, and project-task associations.