### PR TITLE
fix: Bases view crash on Obsidian 1.10.0 startup

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,6 +27,12 @@ Example:
 
 ## Fixed
 
+- (#806) Fixed Bases views crashing on Obsidian 1.10.0 startup
+  - TaskNotes Bases views (Task List and Kanban) now restore correctly when already open at startup
+  - Added defensive checks in `setEphemeralState` to handle early lifecycle calls
+  - Added `focus()` method to view objects for proper restoration
+  - Made root elements focusable to support Obsidian 1.10.0 view lifecycle
+
 - (#780) Fixed "Cannot Create Timeblocks" error when daily notes folder doesn't exist
   - Added proper error handling when `createDailyNote` fails due to missing folder
   - Improved error messages to guide users to check Daily Notes plugin configuration

--- a/src/bases/base-view-factory.ts
+++ b/src/bases/base-view-factory.ts
@@ -49,6 +49,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 		// Root container for TaskNotes view
 		const root = document.createElement("div");
 		root.className = "tn-bases-integration tasknotes-plugin tasknotes-container";
+		root.tabIndex = -1; // Make focusable without adding to tab order
 		viewContainerEl.appendChild(root);
 		currentRoot = root;
 
@@ -289,8 +290,27 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 				return { scrollTop: currentRoot?.scrollTop || 0 };
 			},
 			setEphemeralState: (state: any) => {
-				if (state?.scrollTop && currentRoot) {
-					currentRoot.scrollTop = state.scrollTop;
+				if (!state) return;
+
+				try {
+					// Only set scroll if element exists and is connected to DOM
+					if (currentRoot && currentRoot.isConnected && state.scrollTop !== undefined) {
+						currentRoot.scrollTop = state.scrollTop;
+					}
+				} catch (e) {
+					// Silently fail - ephemeral state restoration is non-critical
+					console.debug("[TaskNotes][Bases] Failed to restore ephemeral state:", e);
+				}
+			},
+			focus: () => {
+				// Focus the root element if it exists and is connected
+				try {
+					if (currentRoot && currentRoot.isConnected && typeof currentRoot.focus === "function") {
+						currentRoot.focus();
+					}
+				} catch (e) {
+					// Silently fail - focus is non-critical
+					console.debug("[TaskNotes][Bases] Failed to focus view:", e);
 				}
 			},
 			destroy: () => {


### PR DESCRIPTION
Fixes #806

## Problem

Bases views (Task List and Kanban) crashed on Obsidian 1.10.0 startup when restoring from previous session with error: `TypeError: n.focus is not a function`

## Solution

- Added defensive checks in `setEphemeralState` for DOM readiness
- Added `focus()` method to view objects
- Made root elements focusable with `tabIndex=-1`

Views now restore correctly on startup without crashes.