### PR TITLE
fix: force wikilinks in frontmatter properties (#827)

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,275 @@
+# Issue #827 Analysis: Project Links Are No Longer Wiki Links (Regression)
+
+## Problem Understanding
+
+### Summary
+After commit `918297a` (released in v3.24.4), TaskNotes started creating project links using markdown format `[text](path)` instead of wikilink format `[[link]]` for users who have markdown links enabled in their Obsidian settings. This is a regression that breaks project functionality because **Obsidian does not support markdown links in frontmatter properties** - they are not rendered as clickable links and don't work properly for grouping/filtering.
+
+### Root Cause
+The refactor in commit `918297a` introduced centralized link utilities (`linkUtils.ts`) that use Obsidian's native `app.fileManager.generateMarkdownLink()` API. This API **respects user preferences** for link format (wikilink vs markdown). While this is normally desirable for links in document content, it's problematic for frontmatter properties where only wikilinks are supported.
+
+### Impact
+- Users with markdown link format enabled in Obsidian settings get broken project links
+- Project properties show non-clickable text instead of links
+- Project grouping and filtering may be affected
+- Affects all project link creation: task modals, context menus, inline task creation, subtask relationships
+
+### Related Issues/PRs
+- Introduced in: commit `918297a` (refactor: improve link handling with Obsidian API)
+- Released in: v3.24.4
+- Related PR: #805 (this PR added markdown link _parsing_ support, but the regression was caused by subsequent link _generation_ changes)
+
+## Test File Location
+
+**Test file:** `/home/calluma/projects/tasknotes/tests/unit/utils/linkUtils.test.ts`
+
+**How to run:**
+```bash
+npm test -- tests/unit/utils/linkUtils.test.ts
+```
+
+**Current status:** Tests are created but will fail because:
+1. The mock in `tests/__mocks__/obsidian.ts` needs to be updated (currently returns async/wrong signature)
+2. The actual bug needs to be fixed in `linkUtils.ts`
+
+**Note:** The test currently fails due to mock issues (returns `{}` instead of string). The mock's `generateMarkdownLink` method needs to be fixed to match the real Obsidian API signature (synchronous, not async).
+
+## Relevant Code Locations
+
+### Primary Functions (require changes)
+
+1. **`src/utils/linkUtils.ts:55-68`** - `generateLink()` function
+   - Currently calls `app.fileManager.generateMarkdownLink()` which respects user settings
+   - This is the core function used throughout the codebase for project links
+
+2. **`src/utils/linkUtils.ts:79-90`** - `generateLinkWithBasename()` function
+   - Wraps `generateLink()` with basename as alias
+
+3. **`src/utils/linkUtils.ts:102-114`** - `generateLinkWithDisplay()` function
+   - Wraps `generateLink()` with custom display name
+
+### Usage Locations (callers that create project links)
+
+4. **`src/modals/TaskModal.ts:1386-1388`** - `buildProjectReference()` method
+   - Used when collecting projects from selected project files
+   - Called from `collectProjects()` at line 1381
+
+5. **`src/modals/TaskCreationModal.ts:1153`** - Adding subtask relations
+   - Creates project reference when adding subtasks to a task
+
+6. **`src/modals/TaskEditModal.ts:1042`** - `addSubtaskRelation()` method
+   - Creates project reference when adding a subtask
+
+7. **`src/modals/TaskEditModal.ts:1066`** - `removeSubtaskRelation()` method
+   - Creates project reference for comparison when removing subtask
+
+8. **`src/components/TaskContextMenu.ts:972`** - `buildProjectReference()` method
+   - Used in context menu operations for assigning/removing projects
+
+9. **`src/editor/ProjectNoteDecorations.ts`** - Project note decorations
+   - Uses `generateLink()` for creating subtask links (line references from commit 918297a)
+
+10. **`src/main.ts:2295-2297`** - Inline task creation with parent note as project
+    - Creates markdown link for current file as project
+
+### Supporting Code
+
+11. **`src/utils/linkUtils.ts:10-42`** - `parseLinkToPath()` function
+    - Parses both wikilink and markdown link formats (this works correctly)
+    - Added in PR #805 to support _reading_ markdown links
+
+12. **`src/utils/dependencyUtils.ts`** - Uses link utilities for dependency formatting
+    - May also be affected if dependencies are stored in frontmatter
+
+## Proposed Solutions
+
+### Solution 1: Force Wikilinks for Frontmatter Properties (Recommended)
+
+**Description:** Create a new function `generateWikilink()` that always generates wikilink format, and update all frontmatter-related code to use it instead of `generateLink()`.
+
+**Implementation:**
+```typescript
+// In src/utils/linkUtils.ts
+export function generateWikilink(
+    app: App,
+    targetFile: TFile,
+    sourcePath: string,
+    subpath?: string,
+    alias?: string
+): string {
+    // Always generate wikilink format for frontmatter compatibility
+    const linktext = app.metadataCache.fileToLinktext(targetFile, sourcePath, true);
+    let link = `[[${linktext}`;
+
+    if (subpath) {
+        link += subpath;
+    }
+
+    if (alias) {
+        link += `|${alias}`;
+    }
+
+    link += ']]';
+    return link;
+}
+
+// Update existing functions to use generateWikilink for frontmatter
+export function generateLink(...) {
+    // Keep current behavior for backward compatibility with non-frontmatter uses
+    return generateWikilink(app, targetFile, sourcePath, subpath, alias);
+}
+```
+
+**Files to modify:**
+- `src/utils/linkUtils.ts` - Add `generateWikilink()` function, update existing functions
+- Update all callers to use `generateWikilink()` (or keep as-is if we make it the default)
+- `tests/__mocks__/obsidian.ts` - Fix mock signature (remove async, add parameters)
+- `tests/unit/utils/linkUtils.test.ts` - Verify tests pass
+
+**Pros:**
+- ✅ Simple, focused fix that addresses the root cause
+- ✅ Clear intent: wikilinks for frontmatter properties
+- ✅ Maintains backward compatibility
+- ✅ Works for all users regardless of Obsidian settings
+- ✅ Minimal code changes required
+- ✅ Aligns with Obsidian's documented frontmatter behavior
+
+**Cons:**
+- ❌ Doesn't allow markdown links in frontmatter (but this is an Obsidian limitation, not a bug)
+- ❌ Users who want markdown links everywhere won't get them in properties
+
+**Estimated effort:** 1-2 hours
+
+---
+
+### Solution 2: Add Configuration Setting for Link Format
+
+**Description:** Add a plugin setting that allows users to choose between wikilinks and markdown links for project/dependency properties, defaulting to wikilinks.
+
+**Implementation:**
+```typescript
+// In settings
+interface Settings {
+    ...
+    useFrontmatterMarkdownLinks: boolean; // default: false
+}
+
+// In linkUtils.ts
+export function generateLink(
+    app: App,
+    targetFile: TFile,
+    sourcePath: string,
+    subpath?: string,
+    alias?: string,
+    forceWikilink?: boolean
+): string {
+    const useWikilink = forceWikilink || !plugin.settings.useFrontmatterMarkdownLinks;
+
+    if (useWikilink) {
+        // Generate wikilink
+        ...
+    } else {
+        // Use Obsidian API (respects user prefs)
+        return app.fileManager.generateMarkdownLink(targetFile, sourcePath, subpath, alias);
+    }
+}
+```
+
+**Pros:**
+- ✅ Gives users control and flexibility
+- ✅ Supports users who have the frontmatter-markdown-links plugin installed
+- ✅ Future-proof if Obsidian adds native markdown link support in frontmatter
+
+**Cons:**
+- ❌ More complex implementation
+- ❌ Requires settings UI changes
+- ❌ Default behavior (wikilinks) still needed to avoid breaking basic functionality
+- ❌ May confuse users who don't understand Obsidian's frontmatter limitations
+- ❌ Adds maintenance burden for a feature most users won't need
+
+**Estimated effort:** 3-4 hours
+
+---
+
+### Solution 3: Hybrid Approach - Detect Context
+
+**Description:** Automatically detect whether a link is being created for frontmatter vs document content, and use appropriate format.
+
+**Implementation:**
+```typescript
+export function generateLink(
+    app: App,
+    targetFile: TFile,
+    sourcePath: string,
+    subpath?: string,
+    alias?: string,
+    context?: 'frontmatter' | 'content'
+): string {
+    // For frontmatter, always use wikilinks (Obsidian limitation)
+    if (context === 'frontmatter') {
+        return generateWikilink(app, targetFile, sourcePath, subpath, alias);
+    }
+
+    // For document content, respect user settings
+    return app.fileManager.generateMarkdownLink(targetFile, sourcePath, subpath, alias);
+}
+```
+
+**Pros:**
+- ✅ Best of both worlds - wikilinks in frontmatter, user preference in content
+- ✅ Respects Obsidian's limitations while honoring user preferences where possible
+- ✅ No settings needed - automatic/smart
+
+**Cons:**
+- ❌ Requires updating all call sites to specify context
+- ❌ Risk of missing call sites or specifying wrong context
+- ❌ More complex API surface
+- ❌ Currently all known uses are for frontmatter, so the complexity isn't justified
+
+**Estimated effort:** 2-3 hours
+
+---
+
+## Recommended Approach
+
+**Solution 1: Force Wikilinks for Frontmatter Properties**
+
+### Justification
+
+1. **Correctness:** Wikilinks are the only format that works reliably in Obsidian frontmatter properties. This is documented behavior, not a limitation we can work around.
+
+2. **Simplicity:** The fix is straightforward and focused on the actual problem. We're not adding complexity for edge cases that may never be needed.
+
+3. **User Experience:** The maintainer already acknowledged in the issue that wikilinks should be the default, with markdown links being an optional enhancement for users who have the `obsidian-frontmatter-markdown-links` plugin.
+
+4. **Backward Compatibility:** By fixing `generateLink()` to always produce wikilinks, we ensure all existing and future uses are correct by default.
+
+5. **Future Extensibility:** If we later want to support markdown links (Solution 2), we can add that as an opt-in feature on top of the working wikilink foundation.
+
+### Implementation Plan
+
+1. Update `linkUtils.ts`:
+   - Modify `generateLink()` to always generate wikilinks
+   - Update helper functions accordingly
+   - Add comprehensive JSDoc explaining why wikilinks are required
+
+2. Fix test infrastructure:
+   - Update `tests/__mocks__/obsidian.ts` mock to match real API signature
+   - Ensure existing tests pass
+
+3. Run existing tests:
+   - Verify no regressions in project/dependency handling
+   - Check related tests: `TaskCreationModal.projects-with-commas.test.ts`, etc.
+
+4. Manual testing:
+   - Test with various scenarios: creating tasks, adding projects, subtask relationships
+   - Verify links in frontmatter are clickable and work correctly
+
+### Future Enhancement (Optional)
+
+After the fix is stable, if there's user demand, implement Solution 2 to add an opt-in setting for markdown links in frontmatter for users who have the `obsidian-frontmatter-markdown-links` plugin. This would be behind a setting that:
+- Defaults to `false` (wikilinks)
+- Warns users it requires a third-party plugin
+- Only affects frontmatter link generation
+
+This keeps the fix simple now while leaving the door open for enhancement later.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,24 +27,10 @@ Example:
 
 ## Fixed
 
-- (#806) Fixed Bases views crashing on Obsidian 1.10.0 startup
-  - TaskNotes Bases views (Task List and Kanban) now restore correctly when already open at startup
-  - Added defensive checks in `setEphemeralState` to handle early lifecycle calls
-  - Added `focus()` method to view objects for proper restoration
-  - Made root elements focusable to support Obsidian 1.10.0 view lifecycle
-
-- (#792, #800) Fixed markdown-style project and dependency links not being recognized in frontmatter
-  - Added support for markdown link format `[text](path)` in projects and blockedBy fields
-  - Handles URL-encoded paths like `[Car Maintenance](../../projects/Car%20Maintenance.md)`
-  - Markdown links now render as clickable links showing display text instead of raw `[text](path)` format
-  - Links are properly resolved for grouping, filtering, and project-task associations
-  - Previously only wikilink format `[[path]]` was supported
-  - Prevents automatic removal of project assignments when editing tasks
-  - Thanks to @minchinweb for reporting
-
-- (#780) Fixed "Cannot Create Timeblocks" error when daily notes folder doesn't exist
-  - Added proper error handling when `createDailyNote` fails due to missing folder
-  - Improved error messages to guide users to check Daily Notes plugin configuration
-  - Prevents uncaught errors from `obsidian-daily-notes-interface` package
-  - Thanks to @uberunix for reporting
+- (#827) Fixed project links being generated as markdown links for users with markdown links enabled in Obsidian settings
+  - Project links in frontmatter are now always generated as wikilinks `[[link]]` by default for Obsidian compatibility
+  - Obsidian does not support markdown links in frontmatter properties without third-party plugins
+  - Added optional setting to enable markdown links in frontmatter for users with `obsidian-frontmatter-markdown-links` plugin
+  - Setting only appears when user has markdown links enabled globally in Obsidian
+  - Thanks to @nightroman for reporting
 

--- a/issue-analysis/issue-827.md
+++ b/issue-analysis/issue-827.md
@@ -1,0 +1,275 @@
+# Issue #827 Analysis: Project Links Are No Longer Wiki Links (Regression)
+
+## Problem Understanding
+
+### Summary
+After commit `918297a` (released in v3.24.4), TaskNotes started creating project links using markdown format `[text](path)` instead of wikilink format `[[link]]` for users who have markdown links enabled in their Obsidian settings. This is a regression that breaks project functionality because **Obsidian does not support markdown links in frontmatter properties** - they are not rendered as clickable links and don't work properly for grouping/filtering.
+
+### Root Cause
+The refactor in commit `918297a` introduced centralized link utilities (`linkUtils.ts`) that use Obsidian's native `app.fileManager.generateMarkdownLink()` API. This API **respects user preferences** for link format (wikilink vs markdown). While this is normally desirable for links in document content, it's problematic for frontmatter properties where only wikilinks are supported.
+
+### Impact
+- Users with markdown link format enabled in Obsidian settings get broken project links
+- Project properties show non-clickable text instead of links
+- Project grouping and filtering may be affected
+- Affects all project link creation: task modals, context menus, inline task creation, subtask relationships
+
+### Related Issues/PRs
+- Introduced in: commit `918297a` (refactor: improve link handling with Obsidian API)
+- Released in: v3.24.4
+- Related PR: #805 (this PR added markdown link _parsing_ support, but the regression was caused by subsequent link _generation_ changes)
+
+## Test File Location
+
+**Test file:** `/home/calluma/projects/tasknotes/tests/unit/utils/linkUtils.test.ts`
+
+**How to run:**
+```bash
+npm test -- tests/unit/utils/linkUtils.test.ts
+```
+
+**Current status:** Tests are created but will fail because:
+1. The mock in `tests/__mocks__/obsidian.ts` needs to be updated (currently returns async/wrong signature)
+2. The actual bug needs to be fixed in `linkUtils.ts`
+
+**Note:** The test currently fails due to mock issues (returns `{}` instead of string). The mock's `generateMarkdownLink` method needs to be fixed to match the real Obsidian API signature (synchronous, not async).
+
+## Relevant Code Locations
+
+### Primary Functions (require changes)
+
+1. **`src/utils/linkUtils.ts:55-68`** - `generateLink()` function
+   - Currently calls `app.fileManager.generateMarkdownLink()` which respects user settings
+   - This is the core function used throughout the codebase for project links
+
+2. **`src/utils/linkUtils.ts:79-90`** - `generateLinkWithBasename()` function
+   - Wraps `generateLink()` with basename as alias
+
+3. **`src/utils/linkUtils.ts:102-114`** - `generateLinkWithDisplay()` function
+   - Wraps `generateLink()` with custom display name
+
+### Usage Locations (callers that create project links)
+
+4. **`src/modals/TaskModal.ts:1386-1388`** - `buildProjectReference()` method
+   - Used when collecting projects from selected project files
+   - Called from `collectProjects()` at line 1381
+
+5. **`src/modals/TaskCreationModal.ts:1153`** - Adding subtask relations
+   - Creates project reference when adding subtasks to a task
+
+6. **`src/modals/TaskEditModal.ts:1042`** - `addSubtaskRelation()` method
+   - Creates project reference when adding a subtask
+
+7. **`src/modals/TaskEditModal.ts:1066`** - `removeSubtaskRelation()` method
+   - Creates project reference for comparison when removing subtask
+
+8. **`src/components/TaskContextMenu.ts:972`** - `buildProjectReference()` method
+   - Used in context menu operations for assigning/removing projects
+
+9. **`src/editor/ProjectNoteDecorations.ts`** - Project note decorations
+   - Uses `generateLink()` for creating subtask links (line references from commit 918297a)
+
+10. **`src/main.ts:2295-2297`** - Inline task creation with parent note as project
+    - Creates markdown link for current file as project
+
+### Supporting Code
+
+11. **`src/utils/linkUtils.ts:10-42`** - `parseLinkToPath()` function
+    - Parses both wikilink and markdown link formats (this works correctly)
+    - Added in PR #805 to support _reading_ markdown links
+
+12. **`src/utils/dependencyUtils.ts`** - Uses link utilities for dependency formatting
+    - May also be affected if dependencies are stored in frontmatter
+
+## Proposed Solutions
+
+### Solution 1: Force Wikilinks for Frontmatter Properties (Recommended)
+
+**Description:** Create a new function `generateWikilink()` that always generates wikilink format, and update all frontmatter-related code to use it instead of `generateLink()`.
+
+**Implementation:**
+```typescript
+// In src/utils/linkUtils.ts
+export function generateWikilink(
+    app: App,
+    targetFile: TFile,
+    sourcePath: string,
+    subpath?: string,
+    alias?: string
+): string {
+    // Always generate wikilink format for frontmatter compatibility
+    const linktext = app.metadataCache.fileToLinktext(targetFile, sourcePath, true);
+    let link = `[[${linktext}`;
+
+    if (subpath) {
+        link += subpath;
+    }
+
+    if (alias) {
+        link += `|${alias}`;
+    }
+
+    link += ']]';
+    return link;
+}
+
+// Update existing functions to use generateWikilink for frontmatter
+export function generateLink(...) {
+    // Keep current behavior for backward compatibility with non-frontmatter uses
+    return generateWikilink(app, targetFile, sourcePath, subpath, alias);
+}
+```
+
+**Files to modify:**
+- `src/utils/linkUtils.ts` - Add `generateWikilink()` function, update existing functions
+- Update all callers to use `generateWikilink()` (or keep as-is if we make it the default)
+- `tests/__mocks__/obsidian.ts` - Fix mock signature (remove async, add parameters)
+- `tests/unit/utils/linkUtils.test.ts` - Verify tests pass
+
+**Pros:**
+- ✅ Simple, focused fix that addresses the root cause
+- ✅ Clear intent: wikilinks for frontmatter properties
+- ✅ Maintains backward compatibility
+- ✅ Works for all users regardless of Obsidian settings
+- ✅ Minimal code changes required
+- ✅ Aligns with Obsidian's documented frontmatter behavior
+
+**Cons:**
+- ❌ Doesn't allow markdown links in frontmatter (but this is an Obsidian limitation, not a bug)
+- ❌ Users who want markdown links everywhere won't get them in properties
+
+**Estimated effort:** 1-2 hours
+
+---
+
+### Solution 2: Add Configuration Setting for Link Format
+
+**Description:** Add a plugin setting that allows users to choose between wikilinks and markdown links for project/dependency properties, defaulting to wikilinks.
+
+**Implementation:**
+```typescript
+// In settings
+interface Settings {
+    ...
+    useFrontmatterMarkdownLinks: boolean; // default: false
+}
+
+// In linkUtils.ts
+export function generateLink(
+    app: App,
+    targetFile: TFile,
+    sourcePath: string,
+    subpath?: string,
+    alias?: string,
+    forceWikilink?: boolean
+): string {
+    const useWikilink = forceWikilink || !plugin.settings.useFrontmatterMarkdownLinks;
+
+    if (useWikilink) {
+        // Generate wikilink
+        ...
+    } else {
+        // Use Obsidian API (respects user prefs)
+        return app.fileManager.generateMarkdownLink(targetFile, sourcePath, subpath, alias);
+    }
+}
+```
+
+**Pros:**
+- ✅ Gives users control and flexibility
+- ✅ Supports users who have the frontmatter-markdown-links plugin installed
+- ✅ Future-proof if Obsidian adds native markdown link support in frontmatter
+
+**Cons:**
+- ❌ More complex implementation
+- ❌ Requires settings UI changes
+- ❌ Default behavior (wikilinks) still needed to avoid breaking basic functionality
+- ❌ May confuse users who don't understand Obsidian's frontmatter limitations
+- ❌ Adds maintenance burden for a feature most users won't need
+
+**Estimated effort:** 3-4 hours
+
+---
+
+### Solution 3: Hybrid Approach - Detect Context
+
+**Description:** Automatically detect whether a link is being created for frontmatter vs document content, and use appropriate format.
+
+**Implementation:**
+```typescript
+export function generateLink(
+    app: App,
+    targetFile: TFile,
+    sourcePath: string,
+    subpath?: string,
+    alias?: string,
+    context?: 'frontmatter' | 'content'
+): string {
+    // For frontmatter, always use wikilinks (Obsidian limitation)
+    if (context === 'frontmatter') {
+        return generateWikilink(app, targetFile, sourcePath, subpath, alias);
+    }
+
+    // For document content, respect user settings
+    return app.fileManager.generateMarkdownLink(targetFile, sourcePath, subpath, alias);
+}
+```
+
+**Pros:**
+- ✅ Best of both worlds - wikilinks in frontmatter, user preference in content
+- ✅ Respects Obsidian's limitations while honoring user preferences where possible
+- ✅ No settings needed - automatic/smart
+
+**Cons:**
+- ❌ Requires updating all call sites to specify context
+- ❌ Risk of missing call sites or specifying wrong context
+- ❌ More complex API surface
+- ❌ Currently all known uses are for frontmatter, so the complexity isn't justified
+
+**Estimated effort:** 2-3 hours
+
+---
+
+## Recommended Approach
+
+**Solution 1: Force Wikilinks for Frontmatter Properties**
+
+### Justification
+
+1. **Correctness:** Wikilinks are the only format that works reliably in Obsidian frontmatter properties. This is documented behavior, not a limitation we can work around.
+
+2. **Simplicity:** The fix is straightforward and focused on the actual problem. We're not adding complexity for edge cases that may never be needed.
+
+3. **User Experience:** The maintainer already acknowledged in the issue that wikilinks should be the default, with markdown links being an optional enhancement for users who have the `obsidian-frontmatter-markdown-links` plugin.
+
+4. **Backward Compatibility:** By fixing `generateLink()` to always produce wikilinks, we ensure all existing and future uses are correct by default.
+
+5. **Future Extensibility:** If we later want to support markdown links (Solution 2), we can add that as an opt-in feature on top of the working wikilink foundation.
+
+### Implementation Plan
+
+1. Update `linkUtils.ts`:
+   - Modify `generateLink()` to always generate wikilinks
+   - Update helper functions accordingly
+   - Add comprehensive JSDoc explaining why wikilinks are required
+
+2. Fix test infrastructure:
+   - Update `tests/__mocks__/obsidian.ts` mock to match real API signature
+   - Ensure existing tests pass
+
+3. Run existing tests:
+   - Verify no regressions in project/dependency handling
+   - Check related tests: `TaskCreationModal.projects-with-commas.test.ts`, etc.
+
+4. Manual testing:
+   - Test with various scenarios: creating tasks, adding projects, subtask relationships
+   - Verify links in frontmatter are clickable and work correctly
+
+### Future Enhancement (Optional)
+
+After the fix is stable, if there's user demand, implement Solution 2 to add an opt-in setting for markdown links in frontmatter for users who have the `obsidian-frontmatter-markdown-links` plugin. This would be behind a setting that:
+- Defaults to `false` (wikilinks)
+- Warns users it requires a third-party plugin
+- Only affects frontmatter link generation
+
+This keeps the fix simple now while leaving the door open for enhancement later.

--- a/src/components/TaskContextMenu.ts
+++ b/src/components/TaskContextMenu.ts
@@ -573,7 +573,7 @@ export class TaskContextMenu {
 			item.onClick(() => {
 				const taskFile = plugin.app.vault.getAbstractFileByPath(task.path);
 				if (taskFile instanceof TFile) {
-					const projectReference = generateLink(plugin.app, taskFile, task.path);
+					const projectReference = generateLink(plugin.app, taskFile, task.path, "", "", plugin.settings.useFrontmatterMarkdownLinks);
 					plugin.openTaskCreationModal({
 						projects: [projectReference],
 					});
@@ -710,7 +710,7 @@ export class TaskContextMenu {
 			plugin,
 			(candidate) => {
 				if (candidate.path === task.path) return false;
-				const candidateUid = formatDependencyLink(plugin.app, task.path, candidate.path);
+				const candidateUid = formatDependencyLink(plugin.app, task.path, candidate.path, plugin.settings.useFrontmatterMarkdownLinks);
 				return !existingUids.has(candidateUid);
 			},
 			async (selected) => {
@@ -772,7 +772,7 @@ export class TaskContextMenu {
 
 		try {
 			const dependency: TaskDependency = {
-				uid: formatDependencyLink(plugin.app, task.path, selectedTask.path),
+				uid: formatDependencyLink(plugin.app, task.path, selectedTask.path, plugin.settings.useFrontmatterMarkdownLinks),
 				reltype: DEFAULT_DEPENDENCY_RELTYPE,
 			};
 			const existing = Array.isArray(task.blockedBy) ? task.blockedBy : [];
@@ -809,7 +809,7 @@ export class TaskContextMenu {
 
 		try {
 			const rawEntry: TaskDependency = {
-				uid: formatDependencyLink(plugin.app, blockedPath, task.path),
+				uid: formatDependencyLink(plugin.app, blockedPath, task.path, plugin.settings.useFrontmatterMarkdownLinks),
 				reltype: DEFAULT_DEPENDENCY_RELTYPE,
 			};
 			await plugin.taskService.updateBlockingRelationships(task, [blockedPath], [], {
@@ -905,7 +905,7 @@ export class TaskContextMenu {
 				return;
 			}
 
-			const projectReference = generateLink(plugin.app, projectFile, task.path);
+			const projectReference = generateLink(plugin.app, projectFile, task.path, "", "", plugin.settings.useFrontmatterMarkdownLinks);
 			const legacyReference = `[[${projectFile.basename}]]`;
 			const currentProjects = Array.isArray(task.projects) ? task.projects : [];
 
@@ -940,7 +940,7 @@ export class TaskContextMenu {
 				return;
 			}
 
-			const projectReference = generateLink(plugin.app, currentTaskFile, subtask.path);
+			const projectReference = generateLink(plugin.app, currentTaskFile, subtask.path, "", "", plugin.settings.useFrontmatterMarkdownLinks);
 			const legacyReference = `[[${currentTaskFile.basename}]]`;
 			const subtaskProjects = Array.isArray(subtask.projects) ? subtask.projects : [];
 
@@ -969,7 +969,7 @@ export class TaskContextMenu {
 	}
 
 	private buildProjectReference(targetFile: TFile, sourcePath: string, plugin: TaskNotesPlugin): string {
-		return generateLink(plugin.app, targetFile, sourcePath);
+		return generateLink(plugin.app, targetFile, sourcePath, "", "", plugin.settings.useFrontmatterMarkdownLinks);
 	}
 
 	private updateMainMenuIconColors(task: TaskInfo, plugin: TaskNotesPlugin): void {

--- a/src/editor/ProjectNoteDecorations.ts
+++ b/src/editor/ProjectNoteDecorations.ts
@@ -702,7 +702,7 @@ export class ProjectSubtasksWidget extends WidgetType {
 		}
 
 		// Create link using Obsidian's API for proper format
-		const projectReference = generateLink(this.plugin.app, currentFile, currentFile.path);
+		const projectReference = generateLink(this.plugin.app, currentFile, currentFile.path, "", "", this.plugin.settings.useFrontmatterMarkdownLinks);
 
 		// Open task creation modal with project pre-populated
 		this.plugin.openTaskCreationModal({

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -48,7 +48,7 @@ export abstract class TaskModal extends Modal {
 		options: { sourcePath?: string } = {}
 	): DependencyItem {
 		const sourcePath = options.sourcePath ?? this.getDependencySourcePath();
-		const uid = formatDependencyLink(this.plugin.app, sourcePath, file.path);
+		const uid = formatDependencyLink(this.plugin.app, sourcePath, file.path, this.plugin.settings.useFrontmatterMarkdownLinks);
 		return {
 			dependency: { uid, reltype: DEFAULT_DEPENDENCY_RELTYPE },
 			path: file.path,
@@ -91,7 +91,7 @@ export abstract class TaskModal extends Modal {
 		if (file instanceof TFile) {
 			return {
 				dependency: {
-					uid: formatDependencyLink(this.plugin.app, sourcePath, file.path),
+					uid: formatDependencyLink(this.plugin.app, sourcePath, file.path, this.plugin.settings.useFrontmatterMarkdownLinks),
 					reltype: DEFAULT_DEPENDENCY_RELTYPE,
 				},
 				path: file.path,
@@ -232,7 +232,7 @@ export abstract class TaskModal extends Modal {
 
 	protected addBlockedByTask(file: TFile): void {
 		const dependency: TaskDependency = {
-			uid: formatDependencyLink(this.plugin.app, this.getDependencySourcePath(), file.path),
+			uid: formatDependencyLink(this.plugin.app, this.getDependencySourcePath(), file.path, this.plugin.settings.useFrontmatterMarkdownLinks),
 			reltype: DEFAULT_DEPENDENCY_RELTYPE,
 		};
 		this.addBlockedByDependency(dependency);
@@ -288,7 +288,8 @@ export abstract class TaskModal extends Modal {
 				const candidateUid = formatDependencyLink(
 					this.plugin.app,
 					sourcePath,
-					candidate.path
+					candidate.path,
+					this.plugin.settings.useFrontmatterMarkdownLinks
 				);
 				return !existingUids.has(candidateUid);
 			},
@@ -325,7 +326,8 @@ export abstract class TaskModal extends Modal {
 				const candidateUid = formatDependencyLink(
 					this.plugin.app,
 					sourcePath,
-					candidate.path
+					candidate.path,
+					this.plugin.settings.useFrontmatterMarkdownLinks
 				);
 				return !existingUids.has(candidateUid);
 			},
@@ -1384,7 +1386,7 @@ export abstract class TaskModal extends Modal {
 	}
 
 	protected buildProjectReference(targetFile: TFile, sourcePath: string): string {
-		return generateLink(this.app, targetFile, sourcePath);
+		return generateLink(this.app, targetFile, sourcePath, "", "", this.plugin.settings.useFrontmatterMarkdownLinks);
 	}
 
 	protected initializeProjectsFromStrings(projects: string[]): void {

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -1652,7 +1652,7 @@ export class TaskService {
 
 		if (action === "add" && !hasExistingEntry) {
 			const normalizedIncoming = rawEntry ? normalizeDependencyEntry(rawEntry) : null;
-			const uid = formatDependencyLink(this.plugin.app, blockedTask.path, blockingTaskPath);
+			const uid = formatDependencyLink(this.plugin.app, blockedTask.path, blockingTaskPath, this.plugin.settings.useFrontmatterMarkdownLinks);
 			const dependency: TaskDependency = {
 				uid,
 				reltype: normalizedIncoming?.reltype ?? DEFAULT_DEPENDENCY_RELTYPE,

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -286,4 +286,6 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	enableBases: true,
 	// Recurring task behavior defaults
 	maintainDueDateOffsetInRecurring: false,
+	// Frontmatter link format defaults
+	useFrontmatterMarkdownLinks: false, // Default to wikilinks for compatibility
 };

--- a/src/settings/tabs/generalTab.ts
+++ b/src/settings/tabs/generalTab.ts
@@ -171,19 +171,22 @@ export function renderGeneralTab(
 		},
 	});
 
-	// Frontmatter Section
-	createSectionHeader(container, "Frontmatter");
-	createHelpText(container, "Configure how links are formatted in frontmatter properties.");
+	// Frontmatter Section - only show if user has markdown links enabled globally
+	const useMarkdownLinks = plugin.app.vault.getConfig('useMarkdownLinks');
+	if (useMarkdownLinks) {
+		createSectionHeader(container, "Frontmatter");
+		createHelpText(container, "Configure how links are formatted in frontmatter properties.");
 
-	createToggleSetting(container, {
-		name: "Use markdown links in frontmatter",
-		desc: "Generate markdown links ([text](path)) instead of wikilinks ([[link]]) in frontmatter properties. ⚠️ Requires the 'obsidian-frontmatter-markdown-links' plugin to work correctly.",
-		getValue: () => plugin.settings.useFrontmatterMarkdownLinks,
-		setValue: async (value: boolean) => {
-			plugin.settings.useFrontmatterMarkdownLinks = value;
-			save();
-		},
-	});
+		createToggleSetting(container, {
+			name: "Use markdown links in frontmatter",
+			desc: "Generate markdown links ([text](path)) instead of wikilinks ([[link]]) in frontmatter properties. ⚠️ Requires the 'obsidian-frontmatter-markdown-links' plugin to work correctly.",
+			getValue: () => plugin.settings.useFrontmatterMarkdownLinks,
+			setValue: async (value: boolean) => {
+				plugin.settings.useFrontmatterMarkdownLinks = value;
+				save();
+			},
+		});
+	}
 
 	// Task Interaction Section
 	createSectionHeader(container, translate("settings.general.taskInteraction.header"));

--- a/src/settings/tabs/generalTab.ts
+++ b/src/settings/tabs/generalTab.ts
@@ -171,6 +171,20 @@ export function renderGeneralTab(
 		},
 	});
 
+	// Frontmatter Section
+	createSectionHeader(container, "Frontmatter");
+	createHelpText(container, "Configure how links are formatted in frontmatter properties.");
+
+	createToggleSetting(container, {
+		name: "Use markdown links in frontmatter",
+		desc: "Generate markdown links ([text](path)) instead of wikilinks ([[link]]) in frontmatter properties. ⚠️ Requires the 'obsidian-frontmatter-markdown-links' plugin to work correctly.",
+		getValue: () => plugin.settings.useFrontmatterMarkdownLinks,
+		setValue: async (value: boolean) => {
+			plugin.settings.useFrontmatterMarkdownLinks = value;
+			save();
+		},
+	});
+
 	// Task Interaction Section
 	createSectionHeader(container, translate("settings.general.taskInteraction.header"));
 	createHelpText(container, translate("settings.general.taskInteraction.description"));

--- a/src/settings/tabs/generalTab.ts
+++ b/src/settings/tabs/generalTab.ts
@@ -179,7 +179,7 @@ export function renderGeneralTab(
 
 		createToggleSetting(container, {
 			name: "Use markdown links in frontmatter",
-			desc: "Generate markdown links ([text](path)) instead of wikilinks ([[link]]) in frontmatter properties. ⚠️ Requires the 'obsidian-frontmatter-markdown-links' plugin to work correctly.",
+			desc: "Generate markdown links ([text](path)) instead of wikilinks ([[link]]) in frontmatter properties.\n\n⚠️ Requires the 'obsidian-frontmatter-markdown-links' plugin to work correctly.",
 			getValue: () => plugin.settings.useFrontmatterMarkdownLinks,
 			setValue: async (value: boolean) => {
 				plugin.settings.useFrontmatterMarkdownLinks = value;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -125,6 +125,8 @@ export interface TaskNotesSettings {
 	enableBases: boolean;
 	// Recurring task behavior
 	maintainDueDateOffsetInRecurring: boolean;
+	// Frontmatter link format settings
+	useFrontmatterMarkdownLinks: boolean; // Use markdown links in frontmatter (requires obsidian-frontmatter-markdown-links plugin)
 }
 
 export interface DefaultReminder {

--- a/src/utils/dependencyUtils.ts
+++ b/src/utils/dependencyUtils.ts
@@ -171,10 +171,10 @@ export function resolveDependencyEntry(
 	return null;
 }
 
-export function formatDependencyLink(app: App, sourcePath: string, targetPath: string): string {
+export function formatDependencyLink(app: App, sourcePath: string, targetPath: string, useMarkdownLinks?: boolean): string {
 	const target = app.vault.getAbstractFileByPath(targetPath);
 	if (target instanceof TFile) {
-		return generateLink(app, target, sourcePath);
+		return generateLink(app, target, sourcePath, "", "", useMarkdownLinks);
 	}
 
 	// For unresolved files, create a simple wikilink with the basename

--- a/src/utils/linkUtils.ts
+++ b/src/utils/linkUtils.ts
@@ -42,26 +42,39 @@ export function parseLinkToPath(linkText: string): string {
 }
 
 /**
- * Generate a wikilink for use in frontmatter properties.
- * Always generates wikilink format regardless of user settings because Obsidian
- * does not support markdown links in frontmatter properties.
+ * Generate a link for use in frontmatter properties.
+ * By default generates wikilink format because Obsidian does not support markdown links
+ * in frontmatter properties. Can be configured to use markdown links if the user has
+ * the obsidian-frontmatter-markdown-links plugin installed.
  *
  * @param app - Obsidian app instance
  * @param targetFile - The file to link to
  * @param sourcePath - The path of the file containing the link (for relative paths)
  * @param subpath - Optional subpath (e.g., heading anchor)
  * @param alias - Optional display alias
- * @returns A wikilink string in the format [[link]] or [[link|alias]]
+ * @param useMarkdownLinks - If true, use Obsidian API which respects user's link format preference (requires third-party plugin for frontmatter)
+ * @returns A link string in wikilink or markdown format
  */
 export function generateLink(
 	app: App,
 	targetFile: TFile,
 	sourcePath: string,
 	subpath?: string,
-	alias?: string
+	alias?: string,
+	useMarkdownLinks?: boolean
 ): string {
-	// Always generate wikilink format for frontmatter compatibility (issue #827)
-	// Obsidian does not support markdown links in frontmatter properties
+	// If markdown links are explicitly requested, use Obsidian API
+	if (useMarkdownLinks) {
+		return app.fileManager.generateMarkdownLink(
+			targetFile,
+			sourcePath,
+			subpath || "",
+			alias || ""
+		);
+	}
+
+	// Default: generate wikilink format for frontmatter compatibility (issue #827)
+	// Obsidian does not support markdown links in frontmatter properties without a plugin
 	const linktext = app.metadataCache.fileToLinktext(targetFile, sourcePath, true);
 	let link = `[[${linktext}`;
 
@@ -84,14 +97,16 @@ export function generateLink(
  * @param app - Obsidian app instance
  * @param targetFile - The file to link to
  * @param sourcePath - The path of the file containing the link
- * @returns A wikilink with basename as alias
+ * @param useMarkdownLinks - If true, use Obsidian API which respects user's link format preference
+ * @returns A link with basename as alias
  */
 export function generateLinkWithBasename(
 	app: App,
 	targetFile: TFile,
-	sourcePath: string
+	sourcePath: string,
+	useMarkdownLinks?: boolean
 ): string {
-	return generateLink(app, targetFile, sourcePath, "", targetFile.basename);
+	return generateLink(app, targetFile, sourcePath, "", targetFile.basename, useMarkdownLinks);
 }
 
 /**
@@ -102,13 +117,15 @@ export function generateLinkWithBasename(
  * @param targetFile - The file to link to
  * @param sourcePath - The path of the file containing the link
  * @param displayName - Custom display name
- * @returns A wikilink with custom display name as alias
+ * @param useMarkdownLinks - If true, use Obsidian API which respects user's link format preference
+ * @returns A link with custom display name as alias
  */
 export function generateLinkWithDisplay(
 	app: App,
 	targetFile: TFile,
 	sourcePath: string,
-	displayName: string
+	displayName: string,
+	useMarkdownLinks?: boolean
 ): string {
-	return generateLink(app, targetFile, sourcePath, "", displayName);
+	return generateLink(app, targetFile, sourcePath, "", displayName, useMarkdownLinks);
 }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -361,6 +361,14 @@ export class MetadataCache {
     this.cache.delete(path);
   }
 
+  fileToLinktext(file: TFile, sourcePath: string, omitMdExtension: boolean = true): string {
+    // Simple implementation: return basename without extension if omitMdExtension is true
+    if (omitMdExtension && file.extension === 'md') {
+      return file.basename;
+    }
+    return file.name;
+  }
+
   // Event management
   on(event: 'changed' | 'resolve' | 'resolved', callback: (...args: any[]) => void): void {
     this.emitter.on(event, callback);

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -385,8 +385,17 @@ export class MetadataCache {
 
 // FileManager mock class
 export class FileManager {
-  async generateMarkdownLink(file: TFile, sourcePath?: string): Promise<string> {
-    return `[[${file.basename}]]`;
+  generateMarkdownLink(file: TFile, sourcePath?: string, subpath?: string, alias?: string): string {
+    // Simulate Obsidian's behavior of respecting user settings
+    // For testing, we'll generate markdown link format when this is called
+    const fileName = file.basename;
+    const displayText = alias || fileName;
+    const path = file.path;
+    let link = `[${displayText}](${path})`;
+    if (subpath) {
+      link = `[${displayText}](${path}${subpath})`;
+    }
+    return link;
   }
 
   async processFrontMatter(file: TFile, fn: (frontmatter: any) => void): Promise<void> {

--- a/tests/unit/utils/linkUtils.test.ts
+++ b/tests/unit/utils/linkUtils.test.ts
@@ -62,4 +62,34 @@ describe('linkUtils - frontmatter link format', () => {
       expect(link).toBe('[[Test Project|My Custom Display]]');
     });
   });
+
+  describe('markdown link mode (when useMarkdownLinks=true)', () => {
+    it('should generate markdown links when explicitly requested', () => {
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md', '', '', true);
+
+      // Should be markdown format when enabled
+      expect(link).toMatch(/^\[.*\]\(.*\)$/);
+      expect(link).toBe('[Test Project](projects/Test Project.md)');
+    });
+
+    it('should generate markdown links with alias when provided', () => {
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md', '', 'Custom Alias', true);
+      expect(link).toBe('[Custom Alias](projects/Test Project.md)');
+    });
+
+    it('should generate markdown links with subpath when provided', () => {
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md', '#Section', '', true);
+      expect(link).toBe('[Test Project](projects/Test Project.md#Section)');
+    });
+
+    it('should generate wikilinks by default when useMarkdownLinks is false', () => {
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md', '', '', false);
+      expect(link).toBe('[[Test Project]]');
+    });
+
+    it('should generate wikilinks by default when useMarkdownLinks is undefined', () => {
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md');
+      expect(link).toBe('[[Test Project]]');
+    });
+  });
 });

--- a/tests/unit/utils/linkUtils.test.ts
+++ b/tests/unit/utils/linkUtils.test.ts
@@ -1,0 +1,65 @@
+import { generateLink, generateLinkWithBasename, generateLinkWithDisplay } from '../../../src/utils/linkUtils';
+import { MockObsidian } from '../../__mocks__/obsidian';
+import type { App, TFile } from 'obsidian';
+
+// @ts-ignore helper to cast the mock app
+const createMockApp = (mockApp: any): App => mockApp as unknown as App;
+
+jest.mock('obsidian');
+
+describe('linkUtils - frontmatter link format', () => {
+  let mockApp: App;
+  let mockFile: TFile;
+
+  beforeEach(() => {
+    MockObsidian.reset();
+    mockApp = createMockApp(MockObsidian.createMockApp());
+
+    // Create a test file
+    const vault = (mockApp as any).vault;
+    vault.create('projects/Test Project.md', '');
+    mockFile = vault.getAbstractFileByPath('projects/Test Project.md') as TFile;
+  });
+
+  describe('generateLink', () => {
+    it('should always generate wikilinks for frontmatter properties (regression test for #827)', () => {
+      // The bug: generateMarkdownLink respects user settings and might generate markdown links
+      // But markdown links don't work in frontmatter properties in Obsidian
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md');
+
+      // Expected: wikilink format [[Test Project]]
+      // Bug would produce: [Test Project](projects/Test%20Project.md)
+      expect(link).toMatch(/^\[\[.*\]\]$/); // Should be wikilink format
+      expect(link).not.toMatch(/^\[.*\]\(.*\)$/); // Should NOT be markdown format
+    });
+
+    it('should generate wikilink with basename only when no alias provided', () => {
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md');
+      expect(link).toBe('[[Test Project]]');
+    });
+
+    it('should generate wikilink with alias when provided', () => {
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md', '', 'Custom Alias');
+      expect(link).toBe('[[Test Project|Custom Alias]]');
+    });
+
+    it('should handle subpaths correctly', () => {
+      const link = generateLink(mockApp, mockFile, 'tasks/My Task.md', '#Section', '');
+      expect(link).toBe('[[Test Project#Section]]');
+    });
+  });
+
+  describe('generateLinkWithBasename', () => {
+    it('should generate wikilink with basename as alias', () => {
+      const link = generateLinkWithBasename(mockApp, mockFile, 'tasks/My Task.md');
+      expect(link).toBe('[[Test Project|Test Project]]');
+    });
+  });
+
+  describe('generateLinkWithDisplay', () => {
+    it('should generate wikilink with custom display name', () => {
+      const link = generateLinkWithDisplay(mockApp, mockFile, 'tasks/My Task.md', 'My Custom Display');
+      expect(link).toBe('[[Test Project|My Custom Display]]');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #827

Project links were generated as markdown links for users with markdown links enabled in Obsidian settings. Obsidian does not support markdown links in frontmatter properties, causing non-clickable text.

**Changes:**
- Default to wikilinks `[[link]]` for all frontmatter links
- Added optional setting to enable markdown links for users with `obsidian-frontmatter-markdown-links` plugin
- Setting only appears when user has markdown links enabled globally

Thanks to @nightroman for reporting.