### PR TITLE
feat: migrate Bases integration to public API with grouped view support

### DIFF
--- a/build-css.mjs
+++ b/build-css.mjs
@@ -35,7 +35,8 @@ const CSS_FILES = [
     'styles/stats-view.css',         // StatsView component with proper BEM scoping
     'styles/settings-view.css',      // SettingsView component with proper BEM scoping
     'styles/webhook-settings.css',   // Webhook settings UI with proper BEM scoping
-    'styles/status-bar.css'          // StatusBar component with proper BEM scoping
+    'styles/status-bar.css',         // StatusBar component with proper BEM scoping
+    'styles/bases-views.css'         // Bases integration views (list and kanban)
 ];
 
 const MAIN_CSS_TEMPLATE = `/* TaskNotes Plugin Styles */

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -25,6 +25,17 @@ Example:
 
 -->
 
+## Added
+
+- Added grouped rendering support for Bases integration list and kanban views
+  - List view displays collapsible groups with toggle controls
+  - Kanban view renders grouped columns with drag-drop support
+  - Automatically detects ungrouped views and renders as flat list
+
+## Changed
+
+- Migrated Bases integration to use public API (Bases 1.10.0+) with graceful fallback to internal API for older versions
+
 ## Fixed
 
 - (#816) Fixed template variables not processing in ICS subscription note folder paths

--- a/src/bases/api.ts
+++ b/src/bases/api.ts
@@ -169,8 +169,7 @@ export function registerBasesView(
 		try {
 			const success = (plugin as any).registerBasesView(viewId, registration);
 			if (success) {
-				// eslint-disable-next-line no-console
-				console.log(
+				console.debug(
 					`[TaskNotes][Bases] Successfully registered view via public API: ${viewId}`
 				);
 				return true;
@@ -204,8 +203,7 @@ export function registerBasesView(
 		// Only register if it doesn't already exist
 		if (!api.registrations[viewId]) {
 			api.registrations[viewId] = registration;
-			// eslint-disable-next-line no-console
-			console.log(
+			console.debug(
 				`[TaskNotes][Bases] Successfully registered view via internal API: ${viewId}`
 			);
 		} else {
@@ -232,8 +230,7 @@ export function unregisterBasesView(plugin: Plugin, viewId: string): boolean {
 	try {
 		if (api.registrations[viewId]) {
 			delete api.registrations[viewId];
-			// eslint-disable-next-line no-console
-			console.log(`[TaskNotes][Bases] Successfully unregistered view: ${viewId}`);
+			console.debug(`[TaskNotes][Bases] Successfully unregistered view: ${viewId}`);
 		}
 		return true;
 	} catch (error) {

--- a/src/bases/api.ts
+++ b/src/bases/api.ts
@@ -178,7 +178,14 @@ export function registerBasesView(
 			console.debug(
 				`[TaskNotes][Bases] Public API returned false (Bases may be disabled), trying internal API`
 			);
-		} catch (error) {
+		} catch (error: any) {
+			// Check if error is because view already exists - treat as success
+			if (error?.message?.includes("already exists")) {
+				console.debug(
+					`[TaskNotes][Bases] View ${viewId} already registered via public API`
+				);
+				return true;
+			}
 			console.warn(
 				`[TaskNotes][Bases] Public API registration failed for ${viewId}, trying internal API:`,
 				error

--- a/src/bases/api.ts
+++ b/src/bases/api.ts
@@ -203,11 +203,6 @@ export function registerBasesView(
 		// Only register if it doesn't already exist
 		if (!api.registrations[viewId]) {
 			api.registrations[viewId] = registration;
-			console.debug(
-				`[TaskNotes][Bases] Successfully registered view via internal API: ${viewId}`
-			);
-		} else {
-			console.debug(`[TaskNotes][Bases] View ${viewId} already registered, skipping`);
 		}
 		return true;
 	} catch (error) {
@@ -230,7 +225,6 @@ export function unregisterBasesView(plugin: Plugin, viewId: string): boolean {
 	try {
 		if (api.registrations[viewId]) {
 			delete api.registrations[viewId];
-			console.debug(`[TaskNotes][Bases] Successfully unregistered view: ${viewId}`);
 		}
 		return true;
 	} catch (error) {

--- a/src/bases/base-view-factory.ts
+++ b/src/bases/base-view-factory.ts
@@ -14,6 +14,7 @@ import {
 	BasesDataItem,
 	identifyTaskNotesFromBasesData,
 	renderTaskNotesInBasesView,
+	renderGroupedTasksInBasesView,
 } from "./helpers";
 import { EVENT_TASK_UPDATED } from "../types";
 
@@ -32,13 +33,21 @@ export interface ViewConfig {
 }
 
 export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: ViewConfig) {
-	return function tasknotesBaseViewFactory(basesContainer: BasesContainerLike) {
+	return function tasknotesBaseViewFactory(basesContainer: BasesContainerLike, containerEl?: HTMLElement) {
 		let currentRoot: HTMLElement | null = null;
 		let eventListener: any = null;
 		let updateDebounceTimer: number | null = null;
 		let currentTaskElements = new Map<string, HTMLElement>();
 
-		const viewContainerEl = (basesContainer as any)?.viewContainerEl as HTMLElement | undefined;
+		// Detect which API is being used
+		// Public API (1.10.0+): (controller, containerEl)
+		// Legacy API: (container) where container.viewContainerEl exists
+		const viewContainerEl = containerEl || (basesContainer as any)?.viewContainerEl;
+
+		// For public API, basesContainer is actually the QueryController/BasesView instance
+		// For legacy API, basesContainer is the BasesContainer
+		const controller = basesContainer as any;
+
 		if (!viewContainerEl) {
 			console.error("[TaskNotes][BasesPOC] No viewContainerEl found");
 			return { destroy: () => {} } as any;
@@ -60,14 +69,14 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 
 		// Helper to extract items from Bases results
 		// Uses public API (1.10.0+) when available, falls back to internal API
-		const extractDataItems = (): BasesDataItem[] => {
+		const extractDataItems = (viewContext?: any): BasesDataItem[] => {
 			const dataItems: BasesDataItem[] = [];
+			const ctx = viewContext || controller;
 
-			// Try public API first (1.10.0+) - data is already filtered and sorted
-			const viewObject = (basesContainer as any);
-			if (viewObject.data?.data && Array.isArray(viewObject.data.data)) {
+			// Try public API first (1.10.0+) - viewContext.data.data contains BasesEntry[]
+			if (ctx.data?.data && Array.isArray(ctx.data.data)) {
 				// Use BasesEntry objects from public API
-				for (const entry of viewObject.data.data) {
+				for (const entry of ctx.data.data) {
 					const item = {
 						key: entry.file?.path || "",
 						data: entry,
@@ -82,7 +91,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 			}
 
 			// Fallback to internal API for older versions
-			const results = (basesContainer as any)?.results as Map<any, any> | undefined;
+			const results = ctx.results || (basesContainer as any)?.results as Map<any, any> | undefined;
 
 			if (results && results instanceof Map) {
 				for (const [key, value] of results.entries()) {
@@ -102,15 +111,33 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 			return dataItems;
 		};
 
-		const render = async () => {
+		const render = async function(this: any) {
 			if (!currentRoot) return;
 			try {
-				const dataItems = extractDataItems();
+				// For public API (1.10.0+), 'this' is the BasesView with data/config
+				// For legacy API, use controller/basesContainer
+				const viewContext = this?.data ? this : controller;
+
+				console.log("[TaskNotes][Bases] List view render context:", {
+					hasThisData: !!this?.data,
+					hasThisConfig: !!this?.config,
+					hasControllerData: !!controller?.data,
+					usingContext: viewContext === this ? 'this' : 'controller',
+					dataLength: viewContext?.data?.data?.length
+				});
+
+				// Skip rendering if we have no data yet (prevents flickering during data updates)
+				if (!viewContext.data?.data && !viewContext.results) {
+					console.log("[TaskNotes][Bases] List view: Skipping render - no data available");
+					return;
+				}
+
+				const dataItems = extractDataItems(viewContext);
 
 				// Compute Bases formulas for TaskNotes items
 				// This ensures formulas have access to TaskNote-specific properties
-				const ctxFormulas = (basesContainer as any)?.ctx?.formulas;
-				if (ctxFormulas && dataItems.length > 0) {
+				const ctxFormulas = viewContext?.ctx?.formulas || (basesContainer as any)?.ctx?.formulas;
+				if (ctxFormulas && typeof ctxFormulas === 'object' && dataItems.length > 0) {
 					for (let i = 0; i < dataItems.length; i++) {
 						const item = dataItems[i];
 						const itemFormulaResults = item.basesData?.formulaResults;
@@ -177,29 +204,38 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 							])
 					);
 
-					// Apply Bases sorting if configured (only needed for internal API)
-					// Public API (1.10.0+) already provides sorted data via this.data.data
-					const viewObject = (basesContainer as any);
-					const usingPublicAPI = viewObject.data?.data && Array.isArray(viewObject.data.data);
-
-					if (!usingPublicAPI) {
+					// Check if we have grouped data from Bases (public API)
+					if (viewContext.data?.groupedData && Array.isArray(viewContext.data.groupedData)) {
+						// Use grouped data from Bases
+						console.log("[TaskNotes][Bases] List view rendering with groups");
+						await renderGroupedTasksInBasesView(
+							itemsContainer,
+							taskNotes,
+							plugin,
+							viewContext,
+							pathToProps,
+							currentTaskElements
+						);
+					} else {
+						// Apply Bases sorting if configured
+						// Note: Public API data is not pre-sorted, so we always need to apply sorting
 						const { getBasesSortComparator } = await import("./sorting");
-						const sortComparator = getBasesSortComparator(basesContainer, pathToProps);
+						const sortComparator = getBasesSortComparator(viewContext, pathToProps);
 						if (sortComparator) {
 							taskNotes.sort(sortComparator);
 						}
-					}
 
-					// Render tasks using existing helper
-					// Clear existing task elements tracking before re-render
-					currentTaskElements.clear();
-					await renderTaskNotesInBasesView(
-						itemsContainer,
-						taskNotes,
-						plugin,
-						basesContainer,
-						currentTaskElements
-					);
+						// Render tasks using existing helper (flat list)
+						// Clear existing task elements tracking before re-render
+						currentTaskElements.clear();
+						await renderTaskNotesInBasesView(
+							itemsContainer,
+							taskNotes,
+							plugin,
+							viewContext,
+							currentTaskElements
+						);
+					}
 				}
 			} catch (error: any) {
 				console.error(
@@ -251,8 +287,9 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 				if (taskElement) {
 					// Update existing task element
 					const { updateTaskCard } = await import("../ui/TaskCard");
-					const basesProperties = (basesContainer as any)?.ctx?.formulas
-						? Object.keys((basesContainer as any).ctx.formulas)
+					// Note: In selective update, we don't have viewContext, use controller
+					const basesProperties = controller?.ctx?.formulas && typeof controller.ctx.formulas === 'object'
+						? Object.keys(controller.ctx.formulas)
 						: [];
 
 					updateTaskCard(taskElement, updatedTask, plugin, basesProperties, {
@@ -306,17 +343,19 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 		let queryListener: (() => void) | null = null;
 
 		const viewObject = {
-			refresh: render,
-			onResize: () => {
+			refresh() {
+				void render.call(this);
+			},
+			onResize() {
 				// Handle resize - no-op for now
 			},
-			onDataUpdated: () => {
-				void render();
+			onDataUpdated() {
+				void render.call(this);
 			},
-			getEphemeralState: () => {
+			getEphemeralState() {
 				return { scrollTop: currentRoot?.scrollTop || 0 };
 			},
-			setEphemeralState: (state: any) => {
+			setEphemeralState(state: any) {
 				if (!state) return;
 
 				try {
@@ -329,7 +368,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 					console.debug("[TaskNotes][Bases] Failed to restore ephemeral state:", e);
 				}
 			},
-			focus: () => {
+			focus() {
 				// Focus the root element if it exists and is connected
 				try {
 					if (currentRoot && currentRoot.isConnected && typeof currentRoot.focus === "function") {
@@ -340,7 +379,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 					console.debug("[TaskNotes][Bases] Failed to focus view:", e);
 				}
 			},
-			destroy: () => {
+			destroy() {
 				// Clean up task update listener
 				if (eventListener) {
 					plugin.emitter.offref(eventListener);
@@ -354,9 +393,10 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 				}
 
 				// Clean up query listener
-				if (queryListener && (basesContainer as any)?.query?.off) {
+				const query = controller.query || (basesContainer as any)?.query;
+				if (queryListener && query?.off) {
 					try {
-						(basesContainer as any).query.off("change", queryListener);
+						query.off("change", queryListener);
 					} catch (e) {
 						// Query listener removal may fail if already disposed
 					}
@@ -373,36 +413,26 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 				// eslint-disable-next-line no-console
 			console.log("[TaskNotes][Bases] Cleaned up view with real-time updates");
 			},
-			load: () => {
-				if ((basesContainer as any)?.query?.on && !queryListener) {
-					queryListener = () => void render();
+			load() {
+				const query = controller.query || (basesContainer as any)?.query;
+				if (query?.on && !queryListener) {
+					queryListener = () => void render.call(this);
 					try {
-						(basesContainer as any).query.on("change", queryListener);
+						query.on("change", queryListener);
 					} catch (e) {
 						// Query listener registration may fail for various reasons
 					}
 				}
 
-				// Trigger initial formula computation on load
-				const controller = (basesContainer as any)?.controller;
-				if (controller?.runQuery) {
-					controller
-						.runQuery()
-						.then(() => {
-							void render(); // Re-render with computed formulas
-						})
-						.catch((e: any) => {
-							console.warn(
-								"[TaskNotes][Bases] Initial formula computation failed:",
-								e
-							);
-						});
-				}
+				// Initial render - data will be available via this.data (public API) or controller (legacy)
+				// onDataUpdated() will be called by the framework when data changes
+				void render.call(this);
 			},
-			unload: () => {
-				if (queryListener && (basesContainer as any)?.query?.off) {
+			unload() {
+				const query = controller.query || (basesContainer as any)?.query;
+				if (queryListener && query?.off) {
 					try {
-						(basesContainer as any).query.off("change", queryListener);
+						query.off("change", queryListener);
 					} catch (e) {
 						// Query listener removal may fail if already disposed
 					}

--- a/src/bases/base-view-factory.ts
+++ b/src/bases/base-view-factory.ts
@@ -198,7 +198,6 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 					// Check if we have grouped data from Bases (public API)
 					if (viewContext.data?.groupedData && Array.isArray(viewContext.data.groupedData)) {
 						// Use grouped data from Bases
-						console.debug("[TaskNotes][Bases] List view rendering with groups");
 						await renderGroupedTasksInBasesView(
 							itemsContainer,
 							taskNotes,
@@ -298,8 +297,6 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 						taskElement.classList.remove("task-card--updated");
 					}, 1000);
 
-					// eslint-disable-next-line no-console
-			console.debug(`[TaskNotes][Bases] Selectively updated task: ${updatedTask.path}`);
 				} else {
 					// Task not currently visible, might need to be added - refresh to be safe
 					debouncedFullRefresh();
@@ -317,8 +314,6 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 			}
 
 			updateDebounceTimer = window.setTimeout(async () => {
-				// eslint-disable-next-line no-console
-			console.debug("[TaskNotes][Bases] Performing debounced full refresh");
 				await render();
 				updateDebounceTimer = null;
 			}, 150);
@@ -400,9 +395,6 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 				}
 				currentTaskElements.clear();
 				queryListener = null;
-
-				// eslint-disable-next-line no-console
-			console.debug("[TaskNotes][Bases] Cleaned up view with real-time updates");
 			},
 			load() {
 				const query = controller.query || (basesContainer as any)?.query;

--- a/src/bases/base-view-factory.ts
+++ b/src/bases/base-view-factory.ts
@@ -118,17 +118,8 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 				// For legacy API, use controller/basesContainer
 				const viewContext = this?.data ? this : controller;
 
-				console.log("[TaskNotes][Bases] List view render context:", {
-					hasThisData: !!this?.data,
-					hasThisConfig: !!this?.config,
-					hasControllerData: !!controller?.data,
-					usingContext: viewContext === this ? 'this' : 'controller',
-					dataLength: viewContext?.data?.data?.length
-				});
-
 				// Skip rendering if we have no data yet (prevents flickering during data updates)
 				if (!viewContext.data?.data && !viewContext.results) {
-					console.log("[TaskNotes][Bases] List view: Skipping render - no data available");
 					return;
 				}
 
@@ -207,7 +198,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 					// Check if we have grouped data from Bases (public API)
 					if (viewContext.data?.groupedData && Array.isArray(viewContext.data.groupedData)) {
 						// Use grouped data from Bases
-						console.log("[TaskNotes][Bases] List view rendering with groups");
+						console.debug("[TaskNotes][Bases] List view rendering with groups");
 						await renderGroupedTasksInBasesView(
 							itemsContainer,
 							taskNotes,
@@ -308,7 +299,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 					}, 1000);
 
 					// eslint-disable-next-line no-console
-			console.log(`[TaskNotes][Bases] Selectively updated task: ${updatedTask.path}`);
+			console.debug(`[TaskNotes][Bases] Selectively updated task: ${updatedTask.path}`);
 				} else {
 					// Task not currently visible, might need to be added - refresh to be safe
 					debouncedFullRefresh();
@@ -327,7 +318,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 
 			updateDebounceTimer = window.setTimeout(async () => {
 				// eslint-disable-next-line no-console
-			console.log("[TaskNotes][Bases] Performing debounced full refresh");
+			console.debug("[TaskNotes][Bases] Performing debounced full refresh");
 				await render();
 				updateDebounceTimer = null;
 			}, 150);
@@ -411,7 +402,7 @@ export function buildTasknotesBaseViewFactory(plugin: TaskNotesPlugin, config: V
 				queryListener = null;
 
 				// eslint-disable-next-line no-console
-			console.log("[TaskNotes][Bases] Cleaned up view with real-time updates");
+			console.debug("[TaskNotes][Bases] Cleaned up view with real-time updates");
 			},
 			load() {
 				const query = controller.query || (basesContainer as any)?.query;

--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -489,6 +489,14 @@ export async function renderGroupedTasksInBasesView(
 				svg.classList.add("chevron");
 				svg.setAttribute("width", "16");
 				svg.setAttribute("height", "16");
+
+				console.debug("[TaskNotes][Bases] SVG setup:", {
+					tagName: svg.tagName,
+					className: svg.className,
+					classList: Array.from(svg.classList),
+					parent: toggleBtn.className,
+					innerHTML: svg.outerHTML.substring(0, 100)
+				});
 			}
 		} catch (error) {
 			// Fallback to text chevron
@@ -523,10 +531,13 @@ export async function renderGroupedTasksInBasesView(
 			const isCollapsed = groupSection.classList.toggle("is-collapsed");
 			toggleBtn.setAttribute("aria-expanded", String(!isCollapsed));
 
+			const svg = toggleBtn.querySelector("svg");
 			console.debug("[TaskNotes][Bases] Group toggled:", {
 				group: groupName,
 				isCollapsed,
-				classes: groupSection.className
+				classes: groupSection.className,
+				svgTransform: svg ? window.getComputedStyle(svg).transform : "no svg",
+				svgStyle: svg ? svg.getAttribute("style") : "no svg"
 			});
 
 			// Toggle task cards visibility

--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -446,6 +446,29 @@ export async function renderGroupedTasksInBasesView(
 		headerElement.className = "task-group-header task-list-view__group-header";
 		groupSection.appendChild(headerElement);
 
+		// Add toggle button (chevron)
+		const toggleBtn = document.createElement("button");
+		toggleBtn.className = "task-group-toggle";
+		toggleBtn.setAttribute("aria-label", "Toggle group");
+		toggleBtn.setAttribute("aria-expanded", "true");
+		headerElement.appendChild(toggleBtn);
+
+		// Try to add chevron icon
+		try {
+			const { setIcon } = await import("obsidian");
+			setIcon(toggleBtn, "chevron-right");
+			const svg = toggleBtn.querySelector("svg");
+			if (svg) {
+				svg.classList.add("chevron");
+				svg.setAttribute("width", "16");
+				svg.setAttribute("height", "16");
+			}
+		} catch (error) {
+			// Fallback to text chevron
+			toggleBtn.textContent = "▸";
+			toggleBtn.classList.add("chevron-text");
+		}
+
 		// Format group name and add count
 		const displayName = groupName === "null" || groupName === "undefined" ? "None" : groupName;
 		headerElement.createSpan({ text: displayName });
@@ -454,6 +477,23 @@ export async function renderGroupedTasksInBasesView(
 		headerElement.createSpan({
 			text: ` (${groupEntries.length})`,
 			cls: "agenda-view__item-count",
+		});
+
+		// Add click handler for toggle
+		headerElement.addEventListener("click", (e: MouseEvent) => {
+			const target = e.target as HTMLElement;
+			// Don't toggle if clicking on a link
+			if (target.closest("a")) return;
+
+			const isCollapsed = groupSection.classList.toggle("is-collapsed");
+			toggleBtn.setAttribute("aria-expanded", String(!isCollapsed));
+
+			// Toggle task cards visibility
+			if (isCollapsed) {
+				taskCardsContainer.style.display = "none";
+			} else {
+				taskCardsContainer.style.display = "";
+			}
 		});
 
 		// Create task cards container

--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -364,6 +364,11 @@ export async function renderGroupedTasksInBasesView(
 		return;
 	}
 
+	// Create wrapper with proper class for CSS styling
+	const listWrapper = document.createElement("div");
+	listWrapper.className = "tn-bases-tasknotes-list";
+	container.appendChild(listWrapper);
+
 	// Get visible properties from Bases
 	const basesVisibleProperties = getBasesVisibleProperties(viewContext);
 	let visibleProperties: string[] | undefined;
@@ -439,7 +444,7 @@ export async function renderGroupedTasksInBasesView(
 		const groupSection = document.createElement("div");
 		groupSection.className = "task-section task-group";
 		groupSection.setAttribute("data-group", groupName);
-		container.appendChild(groupSection);
+		listWrapper.appendChild(groupSection);
 
 		// Create group header
 		const headerElement = document.createElement("h3");

--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -364,6 +364,18 @@ export async function renderGroupedTasksInBasesView(
 		return;
 	}
 
+	// Check if this is actually ungrouped (single group with null/undefined/empty key)
+	if (groupedData.length === 1) {
+		const singleGroup = groupedData[0];
+		const groupKey = singleGroup.key?.data;
+		// If the key is null, undefined, empty string, or "Unknown", treat as ungrouped
+		if (groupKey === null || groupKey === undefined || groupKey === "" || String(groupKey) === "Unknown") {
+			// Render as flat list without group headers
+			await renderTaskNotesInBasesView(container, taskNotes, plugin, viewContext, taskElementsMap);
+			return;
+		}
+	}
+
 	// Create wrapper with proper class for CSS styling
 	const listWrapper = document.createElement("div");
 	listWrapper.className = "tn-bases-tasknotes-list";

--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -1,5 +1,6 @@
 import TaskNotesPlugin from "../main";
 import { TaskInfo } from "../types";
+import { setIcon } from "obsidian";
 
 export interface BasesDataItem {
 	key?: string;
@@ -369,17 +370,8 @@ export async function renderGroupedTasksInBasesView(
 		const singleGroup = groupedData[0];
 		const groupKey = singleGroup.key?.data;
 		const groupKeyStr = String(groupKey);
-		console.debug("[TaskNotes][Bases] Single group detected:", {
-			groupKey,
-			groupKeyStr,
-			keyType: typeof groupKey,
-			isNull: groupKey === null,
-			isUndefined: groupKey === undefined,
-			isEmpty: groupKey === "",
-		});
 		// If the key is null, undefined, empty string, or "Unknown", treat as ungrouped
 		if (groupKey === null || groupKey === undefined || groupKey === "" || groupKeyStr === "null" || groupKeyStr === "undefined" || groupKeyStr === "Unknown") {
-			console.debug("[TaskNotes][Bases] Rendering as flat list (no grouping)");
 			// Render as flat list without group headers
 			await renderTaskNotesInBasesView(container, taskNotes, plugin, viewContext, taskElementsMap);
 			return;
@@ -480,28 +472,14 @@ export async function renderGroupedTasksInBasesView(
 		toggleBtn.setAttribute("aria-expanded", "true");
 		headerElement.appendChild(toggleBtn);
 
-		// Try to add chevron icon
-		try {
-			const { setIcon } = await import("obsidian");
-			setIcon(toggleBtn, "chevron-right");
-			const svg = toggleBtn.querySelector("svg");
-			if (svg) {
-				svg.classList.add("chevron");
-				svg.setAttribute("width", "16");
-				svg.setAttribute("height", "16");
+		// Add chevron icon
+		setIcon(toggleBtn, "chevron-right");
 
-				console.debug("[TaskNotes][Bases] SVG setup:", {
-					tagName: svg.tagName,
-					className: svg.className,
-					classList: Array.from(svg.classList),
-					parent: toggleBtn.className,
-					innerHTML: svg.outerHTML.substring(0, 100)
-				});
-			}
-		} catch (error) {
-			// Fallback to text chevron
-			toggleBtn.textContent = "▸";
-			toggleBtn.classList.add("chevron-text");
+		const svg = toggleBtn.querySelector("svg");
+		if (svg) {
+			svg.classList.add("chevron");
+			svg.setAttribute("width", "16");
+			svg.setAttribute("height", "16");
 		}
 
 		// Format group name and add count
@@ -530,15 +508,6 @@ export async function renderGroupedTasksInBasesView(
 
 			const isCollapsed = groupSection.classList.toggle("is-collapsed");
 			toggleBtn.setAttribute("aria-expanded", String(!isCollapsed));
-
-			const svg = toggleBtn.querySelector("svg");
-			console.debug("[TaskNotes][Bases] Group toggled:", {
-				group: groupName,
-				isCollapsed,
-				classes: groupSection.className,
-				svgTransform: svg ? window.getComputedStyle(svg).transform : "no svg",
-				svgStyle: svg ? svg.getAttribute("style") : "no svg"
-			});
 
 			// Toggle task cards visibility
 			if (isCollapsed) {

--- a/src/bases/kanban-view.ts
+++ b/src/bases/kanban-view.ts
@@ -486,14 +486,15 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
 							}
 						}
 
-						// Refresh the view
-						await render();
+						// Don't manually render - let Bases detect the property change
+						// and trigger onDataUpdated() with proper context
+						// This prevents flickering from renders without proper 'this' context
 					} else if (task && !groupByPropertyId) {
 						// Fallback to status update when no groupBy config
 						await plugin.updateTaskProperty(task, "status", targetColumnId, {
 							silent: true,
 						});
-						await render();
+						// Don't manually render - let Bases detect the change
 					}
 				} catch (e) {
 					console.error("[TaskNotes][Bases] Move failed:", e);

--- a/src/bases/kanban-view.ts
+++ b/src/bases/kanban-view.ts
@@ -121,13 +121,6 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
 					return; // Skip render silently - no data available
 				}
 
-				console.log("[TaskNotes][Bases] Kanban render context:", {
-					hasThisData: !!this?.data,
-					hasThisConfig: !!this?.config,
-					hasControllerData: !!controller?.data,
-					usingContext: viewContext === this ? 'this' : 'controller',
-					groupedDataLength: viewContext?.data?.groupedData?.length
-				});
 
 				const dataItems = extractDataItems(viewContext);
 				const taskNotes = await identifyTaskNotesFromBasesData(dataItems, plugin);
@@ -156,7 +149,7 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
 
 				// Try to use public API (1.10.0+) data.groupedData
 				if (viewContext.data?.groupedData && Array.isArray(viewContext.data.groupedData)) {
-					console.log("[TaskNotes][Bases] Using public API groupedData", {
+					console.debug("[TaskNotes][Bases] Using public API groupedData", {
 						groupCount: viewContext.data.groupedData.length,
 						hasConfig: !!viewContext.config
 					});
@@ -217,7 +210,7 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
 						const keyValue = group.key?.data ?? "none";
 						const keyString = String(keyValue);
 
-						console.log("[TaskNotes][Bases] Processing group:", {
+						console.debug("[TaskNotes][Bases] Processing group:", {
 							keyString,
 							entryCount: group.entries?.length
 						});
@@ -233,9 +226,9 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
 							groups.set(keyString, groupTasks);
 						}
 					}
-					console.log("[TaskNotes][Bases] Final groups:", Array.from(groups.keys()));
+					console.debug("[TaskNotes][Bases] Final groups:", Array.from(groups.keys()));
 				} else {
-					console.log("[TaskNotes][Bases] No groupedData available, using fallback grouping", {
+					console.debug("[TaskNotes][Bases] No groupedData available, using fallback grouping", {
 						hasData: !!viewContext.data,
 						hasGroupedData: !!viewContext.data?.groupedData,
 						isArray: Array.isArray(viewContext.data?.groupedData)

--- a/src/bases/kanban-view.ts
+++ b/src/bases/kanban-view.ts
@@ -109,6 +109,16 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
 				// For legacy API, use controller/basesContainer
 				const viewContext = this?.data ? this : controller;
 
+				// Skip rendering if we have no data yet (prevents flickering during data updates)
+				// Check BEFORE any logging or processing
+				const hasGroupedData = !!(viewContext.data?.groupedData && Array.isArray(viewContext.data.groupedData) && viewContext.data.groupedData.length > 0);
+				const hasFlatData = !!(viewContext.data?.data && Array.isArray(viewContext.data.data) && viewContext.data.data.length > 0);
+				const hasLegacyResults = !!(viewContext.results && viewContext.results instanceof Map && viewContext.results.size > 0);
+
+				if (!hasGroupedData && !hasFlatData && !hasLegacyResults) {
+					return; // Skip render silently - no data available
+				}
+
 				console.log("[TaskNotes][Bases] Kanban render context:", {
 					hasThisData: !!this?.data,
 					hasThisConfig: !!this?.config,
@@ -116,12 +126,6 @@ export function buildTasknotesKanbanViewFactory(plugin: TaskNotesPlugin) {
 					usingContext: viewContext === this ? 'this' : 'controller',
 					groupedDataLength: viewContext?.data?.groupedData?.length
 				});
-
-				// Skip rendering if we have no data yet (prevents flickering during data updates)
-				if (!viewContext.data?.data && !viewContext.data?.groupedData && !viewContext.results) {
-					console.log("[TaskNotes][Bases] Skipping render - no data available");
-					return;
-				}
 
 				const dataItems = extractDataItems(viewContext);
 				const taskNotes = await identifyTaskNotesFromBasesData(dataItems, plugin);

--- a/src/bases/registration.ts
+++ b/src/bases/registration.ts
@@ -61,7 +61,7 @@ export async function registerBasesTaskList(plugin: TaskNotesPlugin): Promise<vo
 
 	// Try immediate registration
 	if (await attemptRegistration()) {
-		console.log("[TaskNotes][Bases] Successfully registered views");
+		console.debug("[TaskNotes][Bases] Successfully registered views");
 		return;
 	}
 
@@ -69,7 +69,7 @@ export async function registerBasesTaskList(plugin: TaskNotesPlugin): Promise<vo
 	for (let i = 0; i < 5; i++) {
 		await new Promise((r) => setTimeout(r, 200));
 		if (await attemptRegistration()) {
-			console.log("[TaskNotes][Bases] Successfully registered views on retry");
+			console.debug("[TaskNotes][Bases] Successfully registered views on retry");
 			return;
 		}
 	}

--- a/src/bases/registration.ts
+++ b/src/bases/registration.ts
@@ -29,6 +29,7 @@ export async function registerBasesTaskList(plugin: TaskNotesPlugin): Promise<vo
 				factory: buildTasknotesKanbanViewFactory(plugin),
 			});
 
+			// Consider it successful if either view registered successfully
 			if (!taskListSuccess && !kanbanSuccess) {
 				console.debug("[TaskNotes][Bases] Bases plugin not available for registration");
 				return false;

--- a/src/bases/registration.ts
+++ b/src/bases/registration.ts
@@ -61,7 +61,6 @@ export async function registerBasesTaskList(plugin: TaskNotesPlugin): Promise<vo
 
 	// Try immediate registration
 	if (await attemptRegistration()) {
-		console.debug("[TaskNotes][Bases] Successfully registered views");
 		return;
 	}
 
@@ -69,7 +68,6 @@ export async function registerBasesTaskList(plugin: TaskNotesPlugin): Promise<vo
 	for (let i = 0; i < 5; i++) {
 		await new Promise((r) => setTimeout(r, 200));
 		if (await attemptRegistration()) {
-			console.debug("[TaskNotes][Bases] Successfully registered views on retry");
 			return;
 		}
 	}

--- a/styles/bases-views.css
+++ b/styles/bases-views.css
@@ -1,0 +1,192 @@
+/* ================================================
+   BASES VIEWS - TaskNotes Integration Styles
+   ================================================ */
+
+/* Bases TaskNotes List View Container */
+.tn-bases-tasknotes-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--tn-spacing-xs);
+    width: 100%;
+}
+
+/* Task Group Section (matches TaskListView structure) */
+.tn-bases-tasknotes-list .task-section.task-group {
+    margin-bottom: var(--tn-spacing-md);
+}
+
+/* Group Header */
+.tn-bases-tasknotes-list .task-group-header {
+    display: flex;
+    align-items: center;
+    gap: var(--tn-spacing-sm);
+    justify-content: flex-start;
+    padding: var(--tn-spacing-md) 0 var(--tn-spacing-sm);
+    margin-bottom: var(--tn-spacing-sm);
+    border-bottom: 1px solid var(--tn-border-color);
+    position: relative;
+    font-size: var(--tn-font-size-lg);
+    font-weight: var(--tn-font-weight-medium);
+    color: var(--tn-text-normal);
+    letter-spacing: 0.01em;
+    line-height: 1.4;
+    cursor: pointer;
+}
+
+/* Count element within group headers */
+.tn-bases-tasknotes-list .task-group-header .agenda-view__item-count {
+    margin-left: auto;
+    margin-right: 0;
+}
+
+/* Toggle button for groups */
+.tn-bases-tasknotes-list .task-group-toggle {
+    display: contents;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    margin-right: var(--tn-spacing-xs);
+    border: none;
+    background: transparent;
+    color: var(--tn-text-normal);
+    font-size: 14px;
+    line-height: 1;
+}
+
+.tn-bases-tasknotes-list .task-group-toggle svg,
+.tn-bases-tasknotes-list .task-group-toggle .chevron,
+.tn-bases-tasknotes-list .task-group-toggle .chevron path {
+    color: var(--tn-text-normal);
+}
+
+.tn-bases-tasknotes-list .task-group-toggle svg,
+.tn-bases-tasknotes-list .task-group-toggle .chevron path {
+    stroke: currentColor;
+}
+
+.tn-bases-tasknotes-list .task-group-toggle .chevron {
+    transition: transform var(--tn-transition-fast);
+}
+
+/* Expanded state - chevron rotated */
+.tn-bases-tasknotes-list .task-group .task-group-toggle .chevron,
+.tn-bases-tasknotes-list .task-group .task-group-toggle svg {
+    transform: rotate(90deg);
+}
+
+/* Collapsed state - chevron normal */
+.tn-bases-tasknotes-list .task-group.is-collapsed .task-group-toggle svg,
+.tn-bases-tasknotes-list .task-group.is-collapsed .task-group-toggle .chevron {
+    transform: rotate(0deg);
+}
+
+/* Hide task cards when collapsed */
+.tn-bases-tasknotes-list .task-group.is-collapsed .task-cards {
+    display: none;
+}
+
+/* Task cards container */
+.tn-bases-tasknotes-list .tasks-container.task-cards {
+    display: flex;
+    flex-direction: column;
+    gap: var(--tn-spacing-xs);
+}
+
+/* Empty state */
+.tn-bases-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: var(--tn-spacing-xl);
+    text-align: center;
+    color: var(--tn-text-muted);
+    background: var(--tn-bg-secondary);
+    border: 1px solid var(--tn-border-color);
+    border-radius: var(--tn-radius-md);
+    margin: var(--tn-spacing-lg) 0;
+}
+
+/* Kanban Board Styles */
+.tn-bases-kanban-board {
+    display: flex;
+    gap: var(--tn-spacing-md);
+    overflow-x: auto;
+    padding: var(--tn-spacing-sm);
+    min-height: 400px;
+}
+
+.tn-bases-kanban-column {
+    flex: 0 0 280px;
+    min-width: 280px;
+    display: flex;
+    flex-direction: column;
+    background: var(--tn-bg-secondary);
+    border: 1px solid var(--tn-border-color);
+    border-radius: var(--tn-radius-md);
+    overflow: hidden;
+}
+
+.tn-bases-kanban-column-header {
+    padding: var(--tn-spacing-md);
+    background: var(--tn-bg-primary);
+    border-bottom: 1px solid var(--tn-border-color);
+    font-weight: var(--tn-font-weight-medium);
+    color: var(--tn-text-normal);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.tn-bases-kanban-column-name {
+    font-size: var(--tn-font-size-md);
+}
+
+.tn-bases-kanban-column-count {
+    font-size: var(--tn-font-size-sm);
+    color: var(--tn-text-muted);
+    background: var(--tn-bg-secondary);
+    padding: 2px 8px;
+    border-radius: var(--tn-radius-sm);
+}
+
+.tn-bases-kanban-tasks {
+    flex: 1;
+    padding: var(--tn-spacing-sm);
+    display: flex;
+    flex-direction: column;
+    gap: var(--tn-spacing-xs);
+    overflow-y: auto;
+}
+
+/* Drag and drop styles */
+.tn-bases-kanban-tasks.drag-over {
+    background: var(--tn-interactive-hover);
+    border: 2px dashed var(--tn-interactive-accent);
+    border-radius: var(--tn-radius-sm);
+}
+
+/* Responsive design for Bases views */
+@media (max-width: 768px) {
+    .tn-bases-kanban-board {
+        gap: var(--tn-spacing-sm);
+    }
+
+    .tn-bases-kanban-column {
+        flex: 0 0 240px;
+        min-width: 240px;
+    }
+}
+
+@media (max-width: 480px) {
+    .tn-bases-tasknotes-list .task-group-header {
+        font-size: var(--tn-font-size-md);
+        padding: var(--tn-spacing-sm) 0 var(--tn-spacing-xs);
+    }
+
+    .tn-bases-kanban-column {
+        flex: 0 0 200px;
+        min-width: 200px;
+    }
+}

--- a/styles/bases-views.css
+++ b/styles/bases-views.css
@@ -22,7 +22,7 @@
     align-items: center;
     gap: var(--tn-spacing-xs);
     justify-content: flex-start;
-    padding: var(--tn-spacing-md) var(--tn-spacing-md) var(--tn-spacing-sm) var(--tn-spacing-sm);
+    padding: var(--tn-spacing-xs) var(--tn-spacing-md) var(--tn-spacing-xs) var(--tn-spacing-sm);
     margin-bottom: var(--tn-spacing-sm);
     border-bottom: 1px solid var(--tn-border-color);
     position: relative;
@@ -57,19 +57,11 @@
     padding: 0;
 }
 
-.tn-bases-tasknotes-list .task-group-toggle svg {
+.tn-bases-tasknotes-list .task-group-toggle svg,
+.tn-bases-tasknotes-list .task-group-toggle .chevron {
     color: var(--tn-text-normal);
     transition: transform 0.2s ease;
-}
-
-.tn-bases-tasknotes-list .task-group-toggle .chevron {
-    transition: transform 0.2s ease;
-}
-
-/* Expanded state - chevron rotated 90deg */
-.tn-bases-tasknotes-list .task-group:not(.is-collapsed) .task-group-toggle svg,
-.tn-bases-tasknotes-list .task-group:not(.is-collapsed) .task-group-toggle .chevron {
-    transform: rotate(90deg);
+    transform: rotate(90deg); /* Default expanded state */
 }
 
 /* Collapsed state - chevron at 0deg */

--- a/styles/bases-views.css
+++ b/styles/bases-views.css
@@ -57,17 +57,16 @@
     padding: 0;
 }
 
-.tn-bases-tasknotes-list .task-group-toggle svg,
-.tn-bases-tasknotes-list .task-group-toggle .chevron {
+/* Default expanded state - chevron pointing down */
+.tn-bases-tasknotes-list .task-group .task-group-toggle svg {
     color: var(--tn-text-normal);
     transition: transform 0.2s ease;
-    transform: rotate(90deg); /* Default expanded state */
+    transform: rotate(90deg) !important;
 }
 
-/* Collapsed state - chevron at 0deg */
-.tn-bases-tasknotes-list .task-group.is-collapsed .task-group-toggle svg,
-.tn-bases-tasknotes-list .task-group.is-collapsed .task-group-toggle .chevron {
-    transform: rotate(0deg);
+/* Collapsed state - chevron pointing right */
+.tn-bases-tasknotes-list .task-group.is-collapsed .task-group-toggle svg {
+    transform: rotate(0deg) !important;
 }
 
 /* Hide task cards when collapsed */

--- a/styles/bases-views.css
+++ b/styles/bases-views.css
@@ -8,6 +8,7 @@
     flex-direction: column;
     gap: var(--tn-spacing-xs);
     width: 100%;
+    padding: var(--tn-spacing-sm);
 }
 
 /* Task Group Section (matches TaskListView structure) */
@@ -19,9 +20,9 @@
 .tn-bases-tasknotes-list .task-group-header {
     display: flex;
     align-items: center;
-    gap: var(--tn-spacing-sm);
+    gap: var(--tn-spacing-xs);
     justify-content: flex-start;
-    padding: var(--tn-spacing-md) 0 var(--tn-spacing-sm);
+    padding: var(--tn-spacing-md) var(--tn-spacing-md) var(--tn-spacing-sm) var(--tn-spacing-sm);
     margin-bottom: var(--tn-spacing-sm);
     border-bottom: 1px solid var(--tn-border-color);
     position: relative;
@@ -41,41 +42,37 @@
 
 /* Toggle button for groups */
 .tn-bases-tasknotes-list .task-group-toggle {
-    display: contents;
+    display: flex;
     align-items: center;
     justify-content: center;
     width: 20px;
     height: 20px;
-    margin-right: var(--tn-spacing-xs);
+    flex-shrink: 0;
     border: none;
     background: transparent;
     color: var(--tn-text-normal);
     font-size: 14px;
     line-height: 1;
+    cursor: pointer;
+    padding: 0;
 }
 
-.tn-bases-tasknotes-list .task-group-toggle svg,
-.tn-bases-tasknotes-list .task-group-toggle .chevron,
-.tn-bases-tasknotes-list .task-group-toggle .chevron path {
+.tn-bases-tasknotes-list .task-group-toggle svg {
     color: var(--tn-text-normal);
-}
-
-.tn-bases-tasknotes-list .task-group-toggle svg,
-.tn-bases-tasknotes-list .task-group-toggle .chevron path {
-    stroke: currentColor;
+    transition: transform 0.2s ease;
 }
 
 .tn-bases-tasknotes-list .task-group-toggle .chevron {
-    transition: transform var(--tn-transition-fast);
+    transition: transform 0.2s ease;
 }
 
-/* Expanded state - chevron rotated */
-.tn-bases-tasknotes-list .task-group .task-group-toggle .chevron,
-.tn-bases-tasknotes-list .task-group .task-group-toggle svg {
+/* Expanded state - chevron rotated 90deg */
+.tn-bases-tasknotes-list .task-group:not(.is-collapsed) .task-group-toggle svg,
+.tn-bases-tasknotes-list .task-group:not(.is-collapsed) .task-group-toggle .chevron {
     transform: rotate(90deg);
 }
 
-/* Collapsed state - chevron normal */
+/* Collapsed state - chevron at 0deg */
 .tn-bases-tasknotes-list .task-group.is-collapsed .task-group-toggle svg,
 .tn-bases-tasknotes-list .task-group.is-collapsed .task-group-toggle .chevron {
     transform: rotate(0deg);
@@ -91,6 +88,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--tn-spacing-xs);
+    padding-left: var(--tn-spacing-md);
 }
 
 /* Empty state */


### PR DESCRIPTION
## Summary
- Migrates Bases integration to use the public API (Bases 1.10.0+) with graceful fallback to internal API for older versions
- Adds grouped rendering support for both list and kanban views
- Fixes multiple UI issues including chevron rotation, drag-drop reliability, and view flickering
- Reduces console logging verbosity

## Test plan
- [x] List view renders correctly with and without grouping
- [x] Kanban view renders correctly with proper column grouping
- [x] Drag-drop operations work reliably
- [x] Views work with both public API (1.10.0+) and legacy internal API
- [x] No console spam from debug logging