### PR TITLE
fix: calendar base view support for embedded views

### DIFF
--- a/styles/advanced-calendar-view.css
+++ b/styles/advanced-calendar-view.css
@@ -546,7 +546,21 @@
 /* FullCalendar overrides - Minimalist & Clean */
 .advanced-calendar-view .fc {
     height: 100%;
+    width: 100%;
     font-family: var(--font-interface);
+}
+
+/* Ensure calendar table expands to fill container width */
+.advanced-calendar-view .fc-view-harness {
+    width: 100%;
+}
+
+.advanced-calendar-view .fc-scrollgrid {
+    width: 100% !important;
+}
+
+.advanced-calendar-view .fc-scrollgrid-sync-table {
+    width: 100% !important;
 }
 
 /* Remove outer borders only */


### PR DESCRIPTION
## Summary

Fixes calendar base view rendering and functionality in embedded Bases contexts.

## Changes

- **Property access**: Add fallback from `getAsPropertyId()` to `get()` for embedded views where property configuration may not work correctly
- **Initialization**: Improve DOM readiness detection with `offsetParent` checks and longer retry delays (100ms) for embedded contexts  
- **Dimensions**: Set minimum heights (800px root, 700px calendar) to ensure proper rendering
- **Width expansion**: Add CSS rules forcing FullCalendar tables to fill container width, fixing narrow day columns
- **Size recalculation**: Call `calendar.updateSize()` after render to recalculate dimensions once DOM settles
- **FullCalendar options**: Add `expandRows`, `handleWindowResize`, and `stickyHeaderDates` for better embedded behavior

## Testing

Tested with embedded calendar base view using property-based events (`startDateProperty`, `endDateProperty`, `titleProperty`). Calendar now renders with proper dimensions and functional property access in both standalone and embedded views.

## Related Issues

Addresses calendar initialization failures and layout issues specific to embedded Bases views.