### PR TITLE
fix: mock system date in issue #810 tests

### DIFF
--- a/tests/unit/issues/issue-810-overdue-tasks-disappear.test.ts
+++ b/tests/unit/issues/issue-810-overdue-tasks-disappear.test.ts
@@ -13,6 +13,10 @@ describe('Issue #810 - Overdue tasks disappear in agenda view when clicking "tod
     let mockPlugin: any;
 
     beforeEach(() => {
+        // Mock system date to Oct 6, 2025 for consistent testing
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date(Date.UTC(2025, 9, 6, 12, 0, 0))); // Oct 6, 2025 12:00 UTC
+
         // Setup mock services
         statusManager = new StatusManager([
             { id: 'open', value: ' ', label: 'Open', color: '#000000', isCompleted: false, order: 1 },
@@ -40,6 +44,10 @@ describe('Issue #810 - Overdue tasks disappear in agenda view when clicking "tod
             priorityManager,
             mockPlugin
         );
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     it('should show overdue tasks when showOverdueSection is enabled', async () => {


### PR DESCRIPTION
## Problem

The `issue-810-overdue-tasks-disappear.test.ts` tests were failing when run after October 6, 2025 because:

1. Tests use a fixed date: `new Date(Date.UTC(2025, 9, 6))` (Oct 6, 2025)
2. The `isOverdueTimeAware()` function calls `getTodayString()` which uses the **real system date**
3. When run on any date after Oct 6, 2025, tasks due on Oct 6 would appear overdue
4. This caused the assertions to fail: tasks due "today" were incorrectly appearing in the overdue section

## Solution

Mock the system date in the test suite using Jest's built-in time mocking:
- Added `jest.useFakeTimers()` and `jest.setSystemTime()` in `beforeEach()`
- Set system time to Oct 6, 2025 12:00 UTC (the test's "today")
- Added `jest.useRealTimers()` in `afterEach()` to clean up

This ensures consistent test behavior regardless of when the tests are run.

## Test Results

All 3 tests now pass:
- ✅ should show overdue tasks when showOverdueSection is enabled
- ✅ should include overdue tasks in overdue section after updating task due date to today
- ✅ should handle recurring tasks correctly - not show as overdue if current instance is today/future