### PR TITLE
docs: update documentation for 3.25.x changes

### DIFF
--- a/docs/features/ics-integration.md
+++ b/docs/features/ics-integration.md
@@ -164,6 +164,18 @@ Configure template files for consistent content creation from events. Templates 
 
 Set destination folders for content created from events. This helps organize ICS-generated content separately from other vault content if desired.
 
+Folder paths support template variables for dynamic organization:
+
+- Date variables: `{{year}}`, `{{month}}`, `{{day}}`, `{{monthName}}`, etc.
+- ICS event variables: `{{icsEventTitle}}`, `{{icsEventLocation}}`, `{{icsEventDescription}}`
+- Other variables: See template variables section below
+
+Example folder paths:
+
+- `Daily/{{year}}/{{month}}/{{day}}` creates date-based hierarchy
+- `Events/{{year}}/{{icsEventTitle}}` organizes by year and event title
+- `Meetings/{{monthName}}` groups by month name
+
 ### Filename Formats
 
 The system uses the standard TaskNotes filename generation with event-specific context, ensuring unique and descriptive filenames for created content.

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -11,15 +11,75 @@ TaskNotes integrates with the [Bases plugin](https://github.com/obsidian-communi
 
 ### Features
 
-- **Task Views**: TaskNotes provides two views for Bases: "Task List" and "Kanban".
+- **Task Views**: TaskNotes provides three views for Bases: "Task List", "Kanban", and "Calendar".
 - **Task Properties**: Task properties are displayed on the task cards in the Bases views.
 - **Formula Computation**: Use Bases formulas to perform calculations on your task data.
 
 ### Getting Started
 
-To use the Bases integration, you need to have both the TaskNotes and Bases plugins installed and enabled.
+To use the Bases integration, you need to have both the TaskNotes and Bases plugins installed and enabled. Bases 1.10.0 or higher is required for Calendar view support.
 
-1.  **Enable the Integration**: Open **Settings → TaskNotes → Integrations** and enable the "Bases integration" toggle (restart Obsidian after changing this setting).
-2.  **Create a View**: In Bases, create a new view and select either the "TaskNotes Task List" or "TaskNotes Kanban" view.
+1. **Enable the Integration**: Open **Settings → TaskNotes → Integrations** and enable the "Bases integration" toggle (restart Obsidian after changing this setting).
+2. **Create a View**: In Bases, create a new view and select either the "TaskNotes Task List", "TaskNotes Kanban", or "TaskNotes Calendar" view.
 
 Your tasks will now be available in the Bases view.
+
+### Calendar View
+
+The Calendar view (requires Bases 1.10.0+) provides multiple viewing modes and supports both task-based and property-based events:
+
+#### View Modes
+
+- Month view
+- Week view
+- Day view
+- Year view
+- List view
+
+#### Event Types
+
+The Calendar view can display multiple types of events:
+
+- Tasks with scheduled dates
+- Tasks with due dates
+- Recurring task instances
+- Time tracking entries
+- Timeblocks from daily notes
+- Property-based events from any notes in the Bases source
+
+#### Property-Based Events
+
+Property-based events allow you to display any notes from your Bases source on the calendar by specifying which date properties to use:
+
+- Configure start date property, end date property, and title property in settings
+- Date values can be stored as date properties or text properties containing ISO dates
+- Notes with invalid date values are handled gracefully
+- Drag-and-drop support updates the date properties in frontmatter
+
+#### Layout and Display Options
+
+- Time format (12-hour or 24-hour)
+- Weekend visibility toggle
+- All-day event slot display
+- Today button and highlight
+- Configurable scroll time
+- Adjustable event height
+- Individual visibility toggles for each event type
+
+#### Date Navigation
+
+Configure how the calendar determines its initial display date:
+
+- Hardcoded date option: Set a specific date (YYYY-MM-DD format) for the calendar to display on load
+- Property-based navigation: Automatically navigate to dates from filtered note properties
+- Three navigation strategies: First result, Earliest date, or Latest date
+- Supports both static views and dynamic filtered views
+
+#### List View
+
+The list view displays events in a chronological format with custom card rendering for different event types:
+
+- Task cards show status, priority, and other task properties
+- Timeblock cards display duration and associated tasks
+- ICS event cards show event details from subscribed calendars
+- Property-based event cards display the note title and date range

--- a/docs/releases/2.0.0.md
+++ b/docs/releases/2.0.0.md
@@ -2,25 +2,29 @@ TaskNotes 2.0.0 - Major Feature Release
 
 Major New Features:
 
-Kanban Board View
+**Kanban Board View**
+
 - Visual task management with drag-and-drop functionality
 - Dynamic grouping by status, priority, or context
 - Search filtering across all columns
 - Real-time updates and collapsible columns
 
-Enhanced Pomodoro System 
+**Enhanced Pomodoro System**
+
 - SVG progress circle with refined visual timer
 - Persistent session history and statistics tracking
 - Dedicated Pomodoro Statistics view with completion metrics
 - Enhanced UI with improved controls and display
 
-Advanced Task Filtering & Grouping
+**Advanced Task Filtering & Grouping**
+
 - Unified filtering system with search, status, context, priority filters
-- Date range filtering with overdue task support  
+- Date range filtering with overdue task support
 - Flexible grouping options (status, priority, context, due date)
 - Performance-optimized filtering using cache indexes
 
-Enhanced Recurring Tasks
+**Enhanced Recurring Tasks**
+
 - Visual distinction with special styling and indicators
 - Per-date completion tracking with smart UI controls
 - Context menus filtered to prevent status conflicts
@@ -28,25 +32,29 @@ Enhanced Recurring Tasks
 
 UI/UX Improvements:
 
-Task Management
+**Task Management**
+
 - Enhanced task edit modal with improved form layout
 - Context menu (right-click) for quick property changes
 - Autocomplete for contexts and tags in task forms
 - Optimistic UI updates for better responsiveness
 
-View Enhancements
+**View Enhancements**
+
 - Agenda view with improved layout and timeline organization
 - Enhanced note cards with consistent styling across views
 - Improved calendar integration with better visual indicators
 - Unified card styling system across all views
 
-Performance & Reliability
+**Performance & Reliability**
+
 - Migrated to unified CacheManager from legacy FileIndexer
-- DOM reconciliation system for efficient UI updates  
+- DOM reconciliation system for efficient UI updates
 - Enhanced async handling and error management
 - Improved cache update handling and race condition prevention
 
 Additional Improvements:
+
 - Enhanced due date modal with better styling
 - Improved time tracking UX with visual feedback
 - Better task archival feedback and UI consistency
@@ -54,6 +62,7 @@ Additional Improvements:
 - Updated README with comprehensive feature documentation
 
 Bug Fixes:
+
 - Fixed 'No due date' group positioning in task list
 - Resolved various UI spacing and alignment issues
 - Improved handling of edge cases in recurring task logic

--- a/docs/releases/3.10.0.md
+++ b/docs/releases/3.10.0.md
@@ -6,26 +6,26 @@
 
 ### Option to Store Task Title in Filename
 
-
 A new setting, storeTitleInFilename, is available under "Task Filenames" in the settings tab. This feature changes how task titles are stored.
 
+**Implementation Details:**
 
-  * Implementation Details:
-      * When this setting is enabled, creating a new task will use its title to generate the filename (e.g., My New Task.md). The title field will be omitted from the task's frontmatter.
-      * For reading tasks, the application will first look for a title field in the frontmatter. If it is not found, the system will use the filename as the task's title. This ensures backward compatibility with existing tasks.
-      * When a task's title is updated, and this setting is active, the file itself is automatically renamed to match the new title. The file's frontmatter is updated before the rename operation occurs to ensure data integrity.
-      * Enabling this setting disables and hides the other filename format options (Zettelkasten, timestamp, custom).
-      * This setting is disabled by default.
+- When this setting is enabled, creating a new task will use its title to generate the filename (e.g., My New Task.md). The title field will be omitted from the task's frontmatter.
+- For reading tasks, the application will first look for a title field in the frontmatter. If it is not found, the system will use the filename as the task's title. This ensures backward compatibility with existing tasks.
+- When a task's title is updated, and this setting is active, the file itself is automatically renamed to match the new title. The file's frontmatter is updated before the rename operation occurs to ensure data integrity.
+- Enabling this setting disables and hides the other filename format options (Zettelkasten, timestamp, custom).
+- This setting is disabled by default.
 
 ### Status Bar Component for Tracked Tasks
 
- A new UI component has been added to the app's status bar to display tasks with active time-tracking sessions.
+A new UI component has been added to the app's status bar to display tasks with active time-tracking sessions.
 
-  * Functionality:
-      * When a single task is being tracked, its title (truncated if necessary) is displayed in the status bar. The full title is visible in a tooltip.
-      * When multiple tasks are being tracked, a count of these tasks is displayed. The tooltip lists the titles of the tracked tasks.
-      * The status bar item is hidden when no tasks are being tracked.
-      * This feature is controlled by the "Show tracked tasks in status bar" setting and is disabled by default.
+**Functionality:**
+
+- When a single task is being tracked, its title (truncated if necessary) is displayed in the status bar. The full title is visible in a tooltip.
+- When multiple tasks are being tracked, a count of these tasks is displayed. The tooltip lists the titles of the tracked tasks.
+- The status bar item is hidden when no tasks are being tracked.
+- This feature is controlled by the "Show tracked tasks in status bar" setting and is disabled by default.
 
 ### Customizable First Day of Week for Mini Calendar
 
@@ -33,12 +33,12 @@ The mini calendar view now respects the "First day of the week" setting in Obsid
 
 ## Bug Fixes
 
-  * Search Functionality: Resolved a type error in the search filter that occurred when a task's title or context field was null. The code now handles null values gracefully during search operations.
-  * File Renaming: Corrected the order of operations when storeTitleInFilename is enabled. The previous implementation could rename the file before its frontmatter was updated, which has now been fixed.
+- Search Functionality: Resolved a type error in the search filter that occurred when a task's title or context field was null. The code now handles null values gracefully during search operations.
+- File Renaming: Corrected the order of operations when storeTitleInFilename is enabled. The previous implementation could rename the file before its frontmatter was updated, which has now been fixed.
 
- Internal Improvements & Documentation
+## Internal Improvements & Documentation
 
-  * Service Refactoring: The TaskService, FieldMapper, and MinimalNativeCache have been updated to handle the new logic for storing and retrieving task titles from filenames.
-  * `StatusBarService`: A new StatusBarService was implemented to encapsulate the logic for the new status bar component, including its creation, updates, and event handling.
-  * Issue Templates: The GitHub issue templates for bug reports and questions have been updated to be more structured and improve the quality of submitted reports.
-  * Documentation: Added a new section to the documentation explaining the storeTitleInFilename feature in detail.
+- Service Refactoring: The TaskService, FieldMapper, and MinimalNativeCache have been updated to handle the new logic for storing and retrieving task titles from filenames.
+- `StatusBarService`: A new StatusBarService was implemented to encapsulate the logic for the new status bar component, including its creation, updates, and event handling.
+- Issue Templates: The GitHub issue templates for bug reports and questions have been updated to be more structured and improve the quality of submitted reports.
+- Documentation: Added a new section to the documentation explaining the storeTitleInFilename feature in detail.

--- a/docs/settings/general.md
+++ b/docs/settings/general.md
@@ -21,7 +21,17 @@ These settings control the foundational aspects of the plugin, such as task iden
 
 - **Excluded folders**: A comma-separated list of folders to exclude from the Notes tab.
 
+## Frontmatter
+
+This section only appears when you have markdown links enabled globally in Obsidian settings.
+
+- **Use markdown links in frontmatter**: Enable markdown link format `[text](path)` for project and dependency links in frontmatter. Requires the `obsidian-frontmatter-markdown-links` plugin. When disabled (default), frontmatter uses wikilink format `[[path]]` which is natively supported by Obsidian.
+
 ## Task Interaction
 
 - **Single-click action**: The action to perform when single-clicking a task card. Can be either "Edit task" or "Open note".
 - **Double-click action**: The action to perform when double-clicking a task card. Can be "Edit task", "Open note", or "No action".
+
+## Release Notes
+
+- **View release notes**: Opens a dedicated tab showing release notes for the current version. Release notes are displayed automatically after updating to a new version, and can also be accessed anytime via command palette or this settings button.

--- a/docs/settings/integrations.md
+++ b/docs/settings/integrations.md
@@ -12,7 +12,7 @@ These settings control the integration with other plugins and services, such as 
 ## Calendar subscriptions
 
 - **Default note template**: Path to template file for notes created from ICS events.
-- **Default note folder**: Folder for notes created from ICS events.
+- **Default note folder**: Folder for notes created from ICS events. Supports template variables (e.g., `Daily/{{year}}/{{month}}/{{day}}`, `Events/{{icsEventTitle}}`). See ICS Integration documentation for full list of supported variables.
 - **ICS note filename format**: How filenames are generated for notes created from ICS events.
 - **Custom ICS filename template**: Template for custom ICS event filenames.
 - **Add Calendar Subscription**: Add a new calendar subscription from ICS/iCal URL or local file.


### PR DESCRIPTION
## Summary

- Document Bases Calendar view with view modes, event types, property-based events, layout options, date navigation, and list view
- Document folder template variables for ICS integration
- Document frontmatter markdown links setting
- Document release notes viewer
- Fix markdown list formatting in 2.0.0 and 3.10.0 release notes

## Changes

### New Documentation

**docs/features/integrations.md**
- Added Calendar view to list of Bases views
- Added Calendar view section with view modes, event types, property-based events configuration, layout options, date navigation strategies, and list view details
- Added Bases 1.10.0+ requirement

**docs/features/ics-integration.md**
- Added folder template variables documentation with date and event-specific variables
- Added example folder path patterns

**docs/settings/general.md**
- Added Frontmatter section for markdown links in frontmatter setting
- Added Release Notes section

**docs/settings/integrations.md**
- Updated ICS note folder setting to document template variable support

### Formatting Fixes

**docs/releases/2.0.0.md**
- Fixed list formatting by adding bold section headers before lists
- Ensured proper blank line separation for markdown rendering

**docs/releases/3.10.0.md**
- Fixed list formatting by converting indented lists to standard markdown
- Added section headers and proper blank line separation