### PR TITLE
fix: Show inlineTaskConvertFolder setting independent of enableInstantTaskConvert

### DIFF
--- a/src/settings/tabs/featuresTab.ts
+++ b/src/settings/tabs/featuresTab.ts
@@ -52,18 +52,16 @@ export function renderFeaturesTab(
 		},
 	});
 
-	if (plugin.settings.enableInstantTaskConvert) {
-		createTextSetting(container, {
-			name: translate("settings.features.instantConvert.folder.name"),
-			desc: translate("settings.features.instantConvert.folder.description"),
-			placeholder: "TaskNotes",
-			getValue: () => plugin.settings.inlineTaskConvertFolder,
-			setValue: async (value: string) => {
-				plugin.settings.inlineTaskConvertFolder = value;
-				save();
-			},
-		});
-	}
+	createTextSetting(container, {
+		name: translate("settings.features.instantConvert.folder.name"),
+		desc: translate("settings.features.instantConvert.folder.description"),
+		placeholder: "TaskNotes",
+		getValue: () => plugin.settings.inlineTaskConvertFolder,
+		setValue: async (value: string) => {
+			plugin.settings.inlineTaskConvertFolder = value;
+			save();
+		},
+	});
 
 	// Natural Language Processing Section
 	createSectionHeader(container, translate("settings.features.nlp.header"));


### PR DESCRIPTION
Within the "Features" settings, in the "Inline Tasks" section: When "Show convert button next to checkboxes" is turned off, the "Folder for converted tasks" setting is hidden. However, it is still possible to convert checkboxes to tasknotes through Obsidian's command palette, and when this is done, the converted tasknote obeys the "Folder for converted tasks" setting, despite it being hidden in the UI.

The change in this pull request keeps the "Folder for converted tasks" setting visible at all times. Because its behaviour is independent of whether the convert button is shown, the setting's availability in the UI should also be independent.

As a side note, I ran into this after initially disabling the convert button because I prefer to do as much as possible via the command palette rather than with mouse clicks. Hoping this may prevent similar confusion for folks in the future.

Thank you for this fantastic plugin!