### PR TITLE
fix: Prevent project filters from affecting custom field suggestions / Inconistent Project Suggestions (Bugs #905, #907)

### DIFF
--- a/src/modals/ProjectSelectModal.ts
+++ b/src/modals/ProjectSelectModal.ts
@@ -10,6 +10,7 @@ import type TaskNotesPlugin from "../main";
 import { ProjectMetadataResolver } from "../utils/projectMetadataResolver";
 import { parseDisplayFieldsRow } from "../utils/projectAutosuggestDisplayFieldsParser";
 import { getProjectPropertyFilter, matchesProjectProperty } from "../utils/projectFilterUtils";
+import { FilterUtils } from "../utils/FilterUtils";
 
 /**
  * Modal for selecting project notes using fuzzy search
@@ -56,7 +57,7 @@ export class ProjectSelectModal extends FuzzySuggestModal<TAbstractFile> {
 
 			const cache = this.app.metadataCache.getFileCache(file);
 
-			// Apply tag filtering - use native Obsidian API
+			// Apply tag filtering - use FilterUtils for consistent hierarchical tag matching
 			if (requiredTags.length > 0) {
 				// Get tags from both native tag detection and frontmatter
 				const nativeTags = cache?.tags?.map((t) => t.tag.replace("#", "")) || [];
@@ -68,9 +69,8 @@ export class ProjectSelectModal extends FuzzySuggestModal<TAbstractFile> {
 						: [frontmatterTags].filter(Boolean)),
 				];
 
-				// Check if file has ANY of the required tags
-				const hasRequiredTag = requiredTags.some((reqTag) => allTags.includes(reqTag));
-				if (!hasRequiredTag) {
+				// Use FilterUtils.matchesTagConditions for hierarchical matching and exclusion support
+				if (!FilterUtils.matchesTagConditions(allTags, requiredTags)) {
 					return false; // Skip this file
 				}
 			}

--- a/src/modals/TaskCreationModal.ts
+++ b/src/modals/TaskCreationModal.ts
@@ -186,8 +186,13 @@ class NLPSuggest extends AbstractInputSuggest<
 				.map((s) => s.trim())
 				.filter(Boolean);
 
-			// Get suggestions using FileSuggestHelper (with multi-word support)
-			const list = await FileSuggestHelper.suggest(this.plugin, queryAfterTrigger);
+			// Get suggestions using FileSuggestHelper with explicit project filter configuration
+			const list = await FileSuggestHelper.suggest(
+				this.plugin,
+				queryAfterTrigger,
+				20,
+				this.plugin.settings.projectAutosuggest
+			);
 
 			// Filter out excluded folders
 			const filteredList = list.filter((item) => {

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -1768,6 +1768,7 @@ class UserFieldSuggest extends AbstractInputSuggest<UserFieldSuggestion> {
 		if (wikiMatch) {
 			const partial = wikiMatch[1] || "";
 			const { FileSuggestHelper } = await import("../suggest/FileSuggestHelper");
+			// Custom fields show ALL files (no filterConfig = no filtering)
 			const list = await FileSuggestHelper.suggest(this.plugin, partial);
 			return list.map((item) => ({
 				value: item.insertText,

--- a/tests/unit/suggest/FileSuggestHelper.test.ts
+++ b/tests/unit/suggest/FileSuggestHelper.test.ts
@@ -1,0 +1,276 @@
+import { FileSuggestHelper, FileFilterConfig } from '../../../src/suggest/FileSuggestHelper';
+import { TFile } from 'obsidian';
+import type TaskNotesPlugin from '../../../src/main';
+
+// Mock parseFrontMatterAliases
+jest.mock('obsidian', () => ({
+  ...jest.requireActual('obsidian'),
+  parseFrontMatterAliases: jest.fn((frontmatter: any) => {
+    if (!frontmatter || !frontmatter.aliases) return [];
+    if (Array.isArray(frontmatter.aliases)) return frontmatter.aliases;
+    return [frontmatter.aliases];
+  }),
+}));
+
+describe('FileSuggestHelper', () => {
+  let mockPlugin: any;
+  let mockFiles: TFile[];
+  let projectFilterConfig: FileFilterConfig;
+
+  beforeEach(() => {
+    // Create mock files
+    mockFiles = [
+      {
+        basename: 'Project A',
+        path: 'projects/Project A.md',
+        extension: 'md',
+        parent: { path: 'projects' }
+      } as TFile,
+      {
+        basename: 'Project B',
+        path: 'projects/Project B.md',
+        extension: 'md',
+        parent: { path: 'projects' }
+      } as TFile,
+      {
+        basename: 'Note 1',
+        path: 'notes/Note 1.md',
+        extension: 'md',
+        parent: { path: 'notes' }
+      } as TFile,
+      {
+        basename: 'Note 2',
+        path: 'notes/Note 2.md',
+        extension: 'md',
+        parent: { path: 'notes' }
+      } as TFile,
+    ];
+
+    // Create project filter configuration
+    projectFilterConfig = {
+      requiredTags: ['project'],
+      includeFolders: [],
+      propertyKey: '',
+      propertyValue: ''
+    };
+
+    // Create mock plugin with settings
+    mockPlugin = {
+      app: {
+        vault: {
+          getMarkdownFiles: jest.fn(() => mockFiles),
+        },
+        metadataCache: {
+          getFileCache: jest.fn((file: TFile) => {
+            // Project files have #project tag
+            if (file.path.startsWith('projects/')) {
+              return {
+                frontmatter: {
+                  tags: ['project'],
+                  type: 'project'
+                },
+                tags: [{ tag: '#project', position: { start: { line: 0, col: 0, offset: 0 }, end: { line: 0, col: 8, offset: 8 } } }]
+              };
+            }
+            // Note files don't have #project tag
+            return {
+              frontmatter: {},
+              tags: []
+            };
+          }),
+        },
+      },
+      settings: {
+        suggestionDebounceMs: 0
+      },
+      fieldMapper: {
+        mapFromFrontmatter: jest.fn((fm: any) => ({
+          title: fm.title || ''
+        }))
+      }
+    } as unknown as TaskNotesPlugin;
+  });
+
+  describe('Filter Configuration', () => {
+    it('should return ALL files when no filterConfig is provided', async () => {
+      const results = await FileSuggestHelper.suggest(mockPlugin, '');
+
+      // Should return ALL files (4 total) - no filtering
+      expect(results.length).toBe(4);
+      const basenames = results.map(r => r.insertText);
+      expect(basenames).toContain('Project A');
+      expect(basenames).toContain('Project B');
+      expect(basenames).toContain('Note 1');
+      expect(basenames).toContain('Note 2');
+    });
+
+    it('should apply filters when filterConfig is provided', async () => {
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        'Project',
+        20,
+        projectFilterConfig
+      );
+
+      // Should only return files with #project tag
+      expect(results.length).toBe(2);
+      expect(results.every(r => r.insertText.startsWith('Project'))).toBe(true);
+    });
+
+    it('should return ALL files when filterConfig is undefined', async () => {
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20,
+        undefined
+      );
+
+      // Should return ALL files (4 total)
+      expect(results.length).toBe(4);
+      const basenames = results.map(r => r.insertText);
+      expect(basenames).toContain('Project A');
+      expect(basenames).toContain('Project B');
+      expect(basenames).toContain('Note 1');
+      expect(basenames).toContain('Note 2');
+    });
+  });
+
+  describe('Tag Filtering', () => {
+    it('should filter by required tags when configured', async () => {
+      const filterConfig: FileFilterConfig = {
+        requiredTags: ['project']
+      };
+
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20,
+        filterConfig
+      );
+
+      // Only files with #project tag
+      expect(results.length).toBe(2);
+      expect(results.every(r => r.insertText.startsWith('Project'))).toBe(true);
+    });
+
+    it('should NOT filter by tags when no filterConfig provided', async () => {
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20
+      );
+
+      // All files should be returned
+      expect(results.length).toBe(4);
+    });
+  });
+
+  describe('Folder Filtering', () => {
+    it('should filter by included folders when configured', async () => {
+      const filterConfig: FileFilterConfig = {
+        includeFolders: ['projects']
+      };
+
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20,
+        filterConfig
+      );
+
+      // Only files in projects/ folder
+      expect(results.length).toBe(2);
+      expect(results.every(r => r.insertText.startsWith('Project'))).toBe(true);
+    });
+
+    it('should NOT filter by folders when no filterConfig provided', async () => {
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20
+      );
+
+      // All files should be returned
+      expect(results.length).toBe(4);
+    });
+  });
+
+  describe('Property Filtering', () => {
+    it('should filter by property when configured', async () => {
+      const filterConfig: FileFilterConfig = {
+        propertyKey: 'type',
+        propertyValue: 'project'
+      };
+
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20,
+        filterConfig
+      );
+
+      // Only files with type: project
+      expect(results.length).toBe(2);
+      expect(results.every(r => r.insertText.startsWith('Project'))).toBe(true);
+    });
+
+    it('should NOT filter by property when no filterConfig provided', async () => {
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20
+      );
+
+      // All files should be returned
+      expect(results.length).toBe(4);
+    });
+  });
+
+  describe('Multiple Filters Combined', () => {
+    it('should apply all filters when configured', async () => {
+      const filterConfig: FileFilterConfig = {
+        requiredTags: ['project'],
+        includeFolders: ['projects'],
+        propertyKey: 'type',
+        propertyValue: 'project'
+      };
+
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20,
+        filterConfig
+      );
+
+      // Only files matching ALL criteria
+      expect(results.length).toBe(2);
+      expect(results.every(r => r.insertText.startsWith('Project'))).toBe(true);
+    });
+
+    it('should ignore all filters when no filterConfig provided', async () => {
+      const results = await FileSuggestHelper.suggest(
+        mockPlugin,
+        '',
+        20
+      );
+
+      // All files should be returned regardless of filters
+      expect(results.length).toBe(4);
+    });
+  });
+
+  describe('Query Matching', () => {
+    it('should match query regardless of filter settings', async () => {
+      const resultsWithoutFilters = await FileSuggestHelper.suggest(
+        mockPlugin,
+        'Note 1',
+        20
+      );
+
+      // Should match "Note 1" specifically
+      expect(resultsWithoutFilters.length).toBeGreaterThanOrEqual(1);
+      expect(resultsWithoutFilters.some(r => r.insertText === 'Note 1')).toBe(true);
+    });
+  });
+});
+


### PR DESCRIPTION
## Problem

**Bug**: Project autosuggestion filter settings (tags, folders, properties) were incorrectly applied to custom field file/link suggestions when users typed `[[` in custom fields.
Bug: https://github.com/callumalpass/tasknotes/issues/905


**Bug**: When I click on "Add to Project" button in the Task Edit modal, the project suggestions do not return the same results as the Task Creation modal.

While the Task Creation modal correctly returns results filtered by the plugin's "project auto-suggest" settings respecting hierarchical tags and exclusion settings, the "Task Edit" modal still filters based on simple tags.
Bug: https://github.com/callumalpass/tasknotes/issues/907

**Impact**: Users could not select files that didn't match their project filter criteria when using wikilink suggestions in custom fields, even though custom fields should show all vault files.

## Root Cause

1. **FileSuggestHelper** always applied project filters to ALL callers, regardless of context
2. **ProjectSelectModal** (used by Task Edit modal) used simple tag matching instead of hierarchical matching with exclusion support

This caused:
- Custom field wikilink suggestions to only show filtered project files instead of all vault files
- Task Edit modal to show fewer projects than Task Creation modal (missing files that matched via hierarchical tags)

## Solution

Made filtering **opt-in and generic**:
- Helper is now filter-agnostic
- Callers explicitly decide which filters to apply
- Both modals use consistent hierarchical tag matching
- Future-proof for custom field-specific filters

## Changes by File

### `src/suggest/FileSuggestHelper.ts`
**What changed**: Added generic `FileFilterConfig` interface and made filtering optional

**Why**: 
- Previously always read from `plugin.settings.projectAutosuggest` and applied filters to all callers
- Now accepts optional `filterConfig` parameter - `undefined` means no filtering
- Generic interface not tied to "project" concept, reusable for future custom field filters

**Key change**:
```typescript
// Before: Always applied project filters
const requiredTags = plugin.settings?.projectAutosuggest?.requiredTags ?? [];

// After: Only apply if filterConfig provided
const requiredTags = filterConfig?.requiredTags ?? [];
```

### `src/modals/TaskCreationModal.ts`
**What changed**: Explicitly passes project filter config to FileSuggestHelper

**Why**: 
- Project field (`+` trigger) should filter by project settings
- Makes intent explicit: "I want project filtering"
- No longer relies on helper's default behavior

**Key change**:
```typescript
// Explicitly pass project filter configuration
const list = await FileSuggestHelper.suggest(
    this.plugin,
    queryAfterTrigger,
    20,
    this.plugin.settings.projectAutosuggest  // Explicit filter config
);
```

### `src/modals/TaskModal.ts`
**What changed**: Calls FileSuggestHelper without filterConfig for custom fields

**Why**: 
- Custom fields (`[[` trigger) should show ALL vault files
- No filterConfig parameter = no filtering
- Clear intent: "Show me everything"

**Key change**:
```typescript
// No filterConfig = shows all files
const list = await FileSuggestHelper.suggest(this.plugin, partial);
```

### `src/modals/ProjectSelectModal.ts`
**What changed**: Updated tag filtering to use `FilterUtils.matchesTagConditions()`

**Why**: 
- Previously used simple `.some()` matching (exact matches only)
- Now uses same hierarchical tag matching as FileSuggestHelper
- Supports exclusion patterns (tags with `-` prefix)
- Consistent behavior across Task Creation and Task Edit modals

**Key change**:
```typescript
// Before: Simple exact matching
const hasRequiredTag = requiredTags.some((reqTag) => allTags.includes(reqTag));

// After: Hierarchical matching with exclusion support
if (!FilterUtils.matchesTagConditions(allTags, requiredTags)) {
    return false;
}
```

### `tests/unit/suggest/FileSuggestHelper.test.ts`
**What changed**: Added 12 unit tests covering filtering behavior

**Why**: 
- Verify no filterConfig returns all files
- Verify filterConfig applies filters correctly
- Test tag, folder, and property filtering independently and combined
- Ensure query matching works regardless of filter settings

**Test coverage**:
- Filter configuration (with/without filterConfig)
- Tag filtering (filtered vs unfiltered)
- Folder filtering (filtered vs unfiltered)
- Property filtering (filtered vs unfiltered)
- Multiple filters combined
- Query matching