### PR TITLE
fix: Bases Kanban columns appear in settings order

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "tasknotes",
 	"name": "TaskNotes",
-	"version": "3.25.3",
+	"version": "3.25.4",
 	"minAppVersion": "1.0.0",
 	"description": "Note-based task management with calendar, pomodoro and time-tracking integration.",
 	"author": "Callum Alpass",


### PR DESCRIPTION
## Summary
Fixes embedded Bases Kanban column ordering when no groupBy is configured.

## Problem
When using TaskNotes Kanban view embedded in Obsidian Bases without a `groupBy` configuration:
1. Bases returns grouped data with all keys as "none"
2. All tasks appeared in a single "None" column
3. When columns did appear, they were in wrong order (alphabetical instead of settings order)

## Solution
- Detect when Bases returns invalid grouping (all 'none' keys)
- Fall back to status-based grouping from plugin settings
- Use `getStatusesByOrder()` to respect user-defined status order
- Preserve Map insertion order instead of sorting alphabetically

## Changes
- `src/bases/kanban-view.ts`: Added validation for grouped data and proper fallback with order preservation
- `manifest.json`: Version bump to 3.25.4

## Testing
Tested with embedded Bases Kanban view (no groupBy configured):
- ✅ All status columns now appear
- ✅ Columns appear in order defined in TaskNotes settings
- ✅ Tasks properly distributed across status columns