### PR TITLE
fix: use theme color for advanced calendar list headers

### DIFF
--- a/styles/advanced-calendar-view.css
+++ b/styles/advanced-calendar-view.css
@@ -777,6 +777,10 @@
     background: transparent !important;
 }
 
+.advanced-calendar-view .fc-list-table th {
+    background: var(--background-secondary-alt) !important;
+}
+
 /* Clean event styling */
 .advanced-calendar-view .fc-event {
     border-radius: 6px;


### PR DESCRIPTION
fullcalendar defaults to `var(--fc-page-bg-color)` which doesn't account for the theme color (i.e dark theme has white table headers)