### PR TITLE
Fix word wrapping in "nl-preview-item" div

### DIFF
--- a/styles/task-modal.css
+++ b/styles/task-modal.css
@@ -643,6 +643,7 @@
 .tasknotes-plugin .nl-preview-item {
     display: flex;
     align-items: center;
+	word-break: break-all;
     margin-bottom: var(--size-4-1);
     font-size: var(--font-ui-small);
 }


### PR DESCRIPTION
Hi ☺️
Small CSS fix in the creation modal – fixed word-wrap for `nl-preview-item` div.

![fix-word-wrap-div](https://github.com/user-attachments/assets/a376e841-f2aa-4029-ac05-3cee683e8f8b)
