### PR TITLE
chore: 🔧 Enable maintainDueDateOffsetInRecurring by default

### DIFF
--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -336,7 +336,7 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 		'relationships': 'TaskNotes/Views/relationships.base',
 	},
 	// Recurring task behavior defaults
-	maintainDueDateOffsetInRecurring: false,
+	maintainDueDateOffsetInRecurring: true,
 	// Frontmatter link format defaults
 	useFrontmatterMarkdownLinks: false, // Default to wikilinks for compatibility
 	// OAuth Calendar Integration defaults


### PR DESCRIPTION
Related: [https://github.com/callumalpass/tasknotes/discussions/1081](https://github.com/callumalpass/tasknotes/discussions/1081)

maintainDueDateOffsetInRecurring is false by default, I think having the due dates on a task that is recurring not update is confusing to new users (it bamboozled me)

