### PR TITLE
feat: Disable task overlay when wikilink has an alias (display text)

### DIFF
--- a/src/editor/ReadingModeTaskLinkProcessor.ts
+++ b/src/editor/ReadingModeTaskLinkProcessor.ts
@@ -170,6 +170,11 @@ export class ReadingModeTaskLinkProcessor {
 				displayText = linkContent;
 			}
 
+			if (displayText) {
+				// If there's a display text (alias), do not replace the link
+				return;
+			}
+
 			// Create a task widget instance
 			const widget = new TaskLinkWidget(taskInfo, this.plugin, originalText, displayText);
 

--- a/src/editor/TaskLinkOverlay.ts
+++ b/src/editor/TaskLinkOverlay.ts
@@ -280,10 +280,14 @@ export function buildTaskLinkDecorations(
 						: parseMarkdownLinkSync(link.match);
 				if (!parsed) continue;
 
-				const { linkPath } = parsed;
-
+				const { linkPath, displayText } = parsed;
 				// Validate link path
 				if (!linkPath || typeof linkPath !== "string" || linkPath.trim().length === 0) {
+					continue;
+				}
+
+				// Disable overlay if there's a display text (alias)
+				if (displayText) {
 					continue;
 				}
 


### PR DESCRIPTION
Hello! Thanks for this amazing plugin. I'm proposing a small change to improve its flexibility.

## 🎯 The Problem

The automatic task overlay/widget is a great feature. However, it currently activates on *all* wikilinks to a task note.

This is a problem when I want to link to a specific **section or block** inside the task note (which is common, since tasks *are* notes), for example:
`The documentation is located in [[My Task#Documentation]]`

In this context, the overlay is not helpful and actually prevents me from using the link to navigate. The only way to avoid this is to disable overlays globally, which is too drastic.

## ✅ The Solution

My solution is simple and non-intrusive: **If the wikilink has a display text (alias), do not render the overlay.**

This allows users to "opt-out" of the overlay on a per-link basis.

* `[[My Task]]` -> Renders the overlay (current behavior).
* `[[My Task|see task]]` -> Renders as a normal link (new behavior).
* `[[My Task#Section|see notes]]` -> Renders as a normal link (solves the problem).

## 🛠️ Implementation

The plugin already parses the `displayText` but doesn't seem to use it in the overlay logic.

I have added two simple checks to skip the rendering if `displayText` is present:
1.  A `if (displayText) { continue }` for Live Edit mode.
2.  A `if (displayText) { return }` for Reading View mode.

This is a very minimal change and should have no side effects.

---

**Note on `package-lock.json`:**
You will also see changes in `package-lock.json`. These are **not** new dependencies. This is just a metadata update from running `npm install` with a modern npm version (v7+), which automatically adds the `"peer": true` flag to relevant packages. It's a safe and standard lockfile migration.

Thanks for your consideration!