### PR TITLE
fix: Add Portuguese language to list of translations for general tab settings

### DIFF
--- a/src/i18n/I18nService.ts
+++ b/src/i18n/I18nService.ts
@@ -66,6 +66,7 @@ export class I18nService extends Events {
 			fr: "Français",
 			de: "Deutsch",
 			es: "Español",
+			pt: "Português",
 			ru: "Русский",
 			zh: "中文",
 			ja: "日本語",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -8,6 +8,7 @@ import { zh } from "./resources/zh";
 import { de } from "./resources/de";
 import { es } from "./resources/es";
 import { ja } from "./resources/ja";
+import { pt } from "./resources/pt";
 
 export const translationResources = {
 	en,
@@ -17,6 +18,7 @@ export const translationResources = {
 	de,
 	es,
 	ja,
+	pt,
 } satisfies TranslationResources;
 
 export type TranslationKey = string;


### PR DESCRIPTION
This configs is necessary for the portuguese transalation to be able for use 