### PR TITLE
feat: add rich metadata display to NLP project autosuggestion

### DIFF
--- a/styles/task-modal.css
+++ b/styles/task-modal.css
@@ -870,6 +870,61 @@
     color: var(--text-normal);
 }
 
+/* NLP Project Suggestion Styles - Rich Metadata Display (Legacy textarea-based) */
+.tasknotes-plugin .nlp-suggest-project__filename {
+    font-weight: var(--font-weight-medium);
+    color: var(--text-normal);
+    font-size: var(--font-ui-small);
+    margin-bottom: 2px;
+}
+
+.tasknotes-plugin .nlp-suggest-project__meta {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+    margin-top: 2px;
+    line-height: 1.4;
+}
+
+.tasknotes-plugin .nlp-suggest-project__meta-label {
+    color: var(--text-muted);
+    font-weight: 500;
+    margin-right: 4px;
+}
+
+.tasknotes-plugin .nlp-suggest-project__meta-value {
+    color: var(--text-normal);
+}
+
+/* CodeMirror Project Suggestion Styles - Rich Metadata Display */
+.tasknotes-plugin .cm-tooltip-autocomplete .cm-project-suggestion {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--size-4-1) 0;
+}
+
+.tasknotes-plugin .cm-tooltip-autocomplete .cm-project-suggestion__name {
+    font-weight: var(--font-weight-medium);
+    color: var(--text-normal);
+    font-size: var(--font-ui-small);
+}
+
+.tasknotes-plugin .cm-tooltip-autocomplete .cm-project-suggestion__meta {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+    line-height: 1.4;
+}
+
+.tasknotes-plugin .cm-tooltip-autocomplete .cm-project-suggestion__meta-label {
+    color: var(--text-muted);
+    font-weight: 500;
+    margin-right: 4px;
+}
+
+.tasknotes-plugin .cm-tooltip-autocomplete .cm-project-suggestion__meta-value {
+    color: var(--text-normal);
+}
+
 /* =====================================================================
    PROJECT SELECTION UI
    ===================================================================== */


### PR DESCRIPTION
Enhance the CodeMirror-based NLP autocomplete to display user-defined project metadata as context when users type the project trigger, bringing feature parity with the manual "Add to Project" button dropdown.

Changes:
- Use CodeMirror 6's addToOptions API for custom rendering
- Display up to 3 configurable metadata rows based on projectAutosuggest.rows settings
- Add ProjectMetadataResolver integration for consistent metadata resolution
- Add CSS styles for metadata display in autocomplete tooltip


Note (future improvements):
This is a "quick win"  solution. A most definitive solution would involve more refactoring but would unify code that could be utilized by "Add to Projects"  and the NLP triggers.

![Screenshot_2025-11-23-21-52-57-11_2665fb67b16260a8d818298cef8dc107](https://github.com/user-attachments/assets/3bdb265c-1f34-42a2-af37-385b44ce6167)


This improves UX consistency by ensuring both project selection methods (NLP-triggered and manual) display the same rich context to help users identify the correct project.