### PR TITLE
fix: angle brackets

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,40 @@
+# fix-angle-brackets
+
+## Angle Bracket Links + Project Titles
+
+This change set improves angle‑bracket link handling, project title display, and dependency link normalization. The goal is to make internal link resolution consistent across filters, overlays, project links, and dependency displays.
+
+Examples (illustrative):
+
+- Angle‑bracket links: `[Spec](<Projects/Client X/Spec.md>)` and `<Projects/Client X/Spec.md>` now resolve like regular internal links.
+- Project title display: a project link like `[[Projects/Client X]]` shows frontmatter `title` (e.g., "Client X Roadmap") instead of the raw filename/path; if no `title` is set, the existing display text/alias/basename remains.
+- Dependency normalization: dependency values such as `[[Ops/Deploy Plan]]`, `[Deploy](<Ops/Deploy Plan.md>)`, or `Ops/Deploy Plan.md` normalize to the same target and render consistently.
+
+## Changelog
+
+### Links & Titles
+
+- Enhanced link parsing to support `<...>` autolinks and angle-bracket paths in markdown links, including URL decoding and `.md` handling.
+- Added `getProjectDisplayName` for consistent project display names across markdown links, wikilinks, and plain text.
+- Normalized internal link resolution in overlays and detection to handle angle-bracket markdown links.
+- Updated link rendering to:
+  - resolve relative links using `sourcePath`,
+  - normalize `data-href` with parsed paths,
+  - prefer frontmatter `title` when the display text is just the filename/path,
+  - support optional custom navigation hooks.
+- Group-by headers now:
+  - support markdown links,
+  - normalize paths via `parseLinkToPath`,
+  - prefer frontmatter `title` when applicable.
+- Filters, stats, and task services now use `getProjectDisplayName` for consistent project titles.
+- Updated call sites to pass `sourcePath` where needed (task cards, task modals, selector modals).
+
+### Dependencies
+
+- Dependency entries are normalized via `parseLinkToPath` to handle wikilinks, markdown links, and angle-bracket variants.
+- Dependency resolution now tries multiple candidates (with/without `.md`, `parseLinktext` variants) for more reliable linking.
+- Task modal normalizes dependencies before resolving them to improve display robustness.
+
+### Tests
+
+- Added unit coverage for angle-bracket link parsing and project display name resolution in `linkUtils`.

--- a/src/bases/groupTitleRenderer.ts
+++ b/src/bases/groupTitleRenderer.ts
@@ -1,5 +1,37 @@
 import { parseLinktext, TFile } from "obsidian";
 import { appendInternalLink, type LinkServices } from "../ui/renderers/linkRenderer";
+import { parseLinkToPath } from "../utils/linkUtils";
+
+function resolveDisplayText(
+	filePath: string,
+	displayText: string,
+	linkServices: LinkServices
+): string {
+	const sourcePath = linkServices.sourcePath ?? "";
+	const normalizedPath = parseLinkToPath(filePath);
+	const file =
+		linkServices.metadataCache.getFirstLinkpathDest(normalizedPath, sourcePath) ||
+		linkServices.metadataCache.getFirstLinkpathDest(normalizedPath, "");
+	if (!(file instanceof TFile)) return displayText;
+	const cache = linkServices.metadataCache.getCache(file.path);
+	const frontmatterTitle = cache?.frontmatter?.title;
+	if (typeof frontmatterTitle !== "string" || frontmatterTitle.trim().length === 0) {
+		return displayText;
+	}
+
+	const normalizedDisplay = displayText?.trim() || "";
+	if (
+		normalizedDisplay === "" ||
+		normalizedDisplay === file.name ||
+		normalizedDisplay === file.basename ||
+		normalizedDisplay === file.path ||
+		normalizedDisplay === normalizedPath
+	) {
+		return frontmatterTitle;
+	}
+
+	return displayText;
+}
 
 /**
  * Render a group title, converting wiki-links and file paths to clickable links with hover preview.
@@ -15,17 +47,37 @@ export function renderGroupTitle(
 ): void {
 	// Check if the title looks like a wiki-link
 	const wikiLinkMatch = title.match(/^\[\[([^\]]+)\]\]$/);
+	const markdownLinkMatch = title.match(/^\[([^\]]*)\]\(([^)]+)\)$/);
 
 	if (wikiLinkMatch) {
 		// Parse wiki-link format: [[path|alias]] or [[path]]
 		const linkContent = wikiLinkMatch[1];
-		const parsedLink = parseLinktext(linkContent);
-		const filePath = parsedLink.path;
-		const displayText = parsedLink.subpath
-			? `${parsedLink.path}${parsedLink.subpath}`
-			: (linkContent.contains('|') ? linkContent.split('|')[1].trim() : parsedLink.path);
+		let filePath = linkContent;
+		let displayText = linkContent;
+		if (linkContent.includes("|")) {
+			const parts = linkContent.split("|");
+			filePath = parts[0].trim();
+			displayText = parts[1].trim();
+		} else {
+			const parsedLink = parseLinktext(linkContent);
+			filePath = parsedLink.path;
+			displayText = parsedLink.path;
+		}
+		const resolvedText = resolveDisplayText(filePath, displayText, linkServices);
 
-		appendInternalLink(container, filePath, displayText, linkServices, {
+		appendInternalLink(container, filePath, resolvedText, linkServices, {
+			cssClass: "internal-link task-group-link",
+			hoverSource: "tasknotes-bases-group",
+			showErrorNotices: false,
+		});
+		return;
+	}
+
+	if (markdownLinkMatch) {
+		const displayText = markdownLinkMatch[1].trim();
+		const filePath = markdownLinkMatch[2].trim();
+		const resolvedText = resolveDisplayText(filePath, displayText, linkServices);
+		appendInternalLink(container, filePath, resolvedText, linkServices, {
 			cssClass: "internal-link task-group-link",
 			hoverSource: "tasknotes-bases-group",
 			showErrorNotices: false,
@@ -35,12 +87,12 @@ export function renderGroupTitle(
 
 	// Check if title is a file path (with or without .md extension)
 	// Try to resolve it as a file
-	const filePathToTry = title.endsWith('.md') ? title.replace(/\.md$/, '') : title;
-	const file = linkServices.metadataCache.getFirstLinkpathDest(filePathToTry, '');
+	const filePathToTry = title.endsWith(".md") ? title.replace(/\.md$/, "") : title;
+	const file = linkServices.metadataCache.getFirstLinkpathDest(filePathToTry, "");
 
 	if (file instanceof TFile) {
 		// Render as clickable link with the file's basename as display text
-		const displayText = file.basename;
+		const displayText = resolveDisplayText(filePathToTry, file.basename, linkServices);
 		appendInternalLink(container, filePathToTry, displayText, linkServices, {
 			cssClass: "internal-link task-group-link",
 			hoverSource: "tasknotes-bases-group",

--- a/src/editor/TaskLinkOverlay.ts
+++ b/src/editor/TaskLinkOverlay.ts
@@ -423,6 +423,11 @@ function parseMarkdownLinkSync(
 	const displayText = match[1].trim();
 	let linkPath = match[2].trim();
 
+	// Strip angle brackets used to escape special characters or spaces
+	if (linkPath.startsWith("<") && linkPath.endsWith(">")) {
+		linkPath = linkPath.slice(1, -1).trim();
+	}
+
 	if (!linkPath || linkPath.length === 0) {
 		return null;
 	}

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -22,6 +22,7 @@ import { TaskDependency, TaskInfo, Reminder } from "../types";
 import {
 	DEFAULT_DEPENDENCY_RELTYPE,
 	formatDependencyLink,
+	normalizeDependencyEntry,
 	resolveDependencyEntry,
 } from "../utils/dependencyUtils";
 import {
@@ -74,24 +75,37 @@ export abstract class TaskModal extends Modal {
 		dependency: TaskDependency,
 		sourcePath?: string
 	): DependencyItem {
+		const normalized = normalizeDependencyEntry(dependency);
+		if (!normalized) {
+			const fallbackName =
+				(typeof dependency === "object" && dependency && "uid" in dependency && typeof dependency.uid === "string"
+					? dependency.uid
+					: String(dependency));
+			return {
+				dependency: { uid: fallbackName, reltype: DEFAULT_DEPENDENCY_RELTYPE },
+				name: fallbackName,
+				unresolved: true,
+			};
+		}
+
 		const resolution = resolveDependencyEntry(
 			this.plugin.app,
 			sourcePath ?? this.getDependencySourcePath(),
-			dependency
+			normalized
 		);
 		if (resolution) {
 			const name =
-				resolution.file?.basename || resolution.path.split("/").pop() || dependency.uid;
+				resolution.file?.basename || resolution.path.split("/").pop() || normalized.uid;
 			return {
-				dependency,
+				dependency: normalized,
 				path: resolution.path,
 				name,
 			};
 		}
 
-		const cleaned = dependency.uid.replace(/^\[\[/, "").replace(/\]\]$/, "");
+		const cleaned = normalized.uid.replace(/^\[\[/, "").replace(/\]\]$/, "");
 		return {
-			dependency,
+			dependency: normalized,
 			name: cleaned || dependency.uid,
 			unresolved: true,
 		};
@@ -151,6 +165,7 @@ export abstract class TaskModal extends Modal {
 		return {
 			metadataCache: this.plugin.app.metadataCache,
 			workspace: this.plugin.app.workspace,
+			sourcePath: this.getCurrentTaskPath() || this.plugin.app.workspace.getActiveFile()?.path || "",
 		};
 	}
 
@@ -205,7 +220,7 @@ export abstract class TaskModal extends Modal {
 				nameEl.addClass("clickable-dependency");
 				appendInternalLink(
 					nameEl,
-					item.path.replace(/\.md$/i, ""),
+					item.path,
 					item.name,
 					linkServices,
 					{

--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -11,6 +11,7 @@ import {
 	FilterOperator,
 } from "../types";
 import { parseLinktext } from "obsidian";
+import { getProjectDisplayName, parseLinkToPath } from "../utils/linkUtils";
 import { TaskManager } from "../utils/TaskManager";
 import { StatusManager } from "./StatusManager";
 import { PriorityManager } from "./PriorityManager";
@@ -996,17 +997,8 @@ export class FilterService extends EventEmitter {
 		if (!projectValue || typeof projectValue !== "string") {
 			return null;
 		}
-
-		// Handle [[Name]] format
-		if (projectValue.startsWith("[[") && projectValue.endsWith("]]")) {
-			const linkContent = projectValue.slice(2, -2);
-			// Extract just the name part if it's a path
-			const parts = linkContent.split("/");
-			return parts[parts.length - 1] || null;
-		}
-
-		// Handle plain name
-		return projectValue.trim() || null;
+		const displayName = getProjectDisplayName(projectValue, this.plugin?.app);
+		return displayName ? displayName : null;
 	}
 
 	/**
@@ -1091,44 +1083,7 @@ export class FilterService extends EventEmitter {
 	 * For non-link strings, returns the input as-is.
 	 */
 	private parseLinkToPath(linkText: string): string {
-		if (!linkText) return linkText;
-
-		const trimmed = linkText.trim();
-
-		// Handle wikilinks: [[path]] or [[path|alias]]
-		if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) {
-			const linkContent = trimmed.slice(2, -2);
-			const pipeIndex = linkContent.indexOf("|");
-			if (pipeIndex !== -1) {
-				return linkContent.substring(0, pipeIndex).trim();
-			}
-			return linkContent.trim();
-		}
-
-		// Handle markdown links: [text](path)
-		const markdownMatch = trimmed.match(/^\[([^\]]*)\]\(([^)]+)\)$/);
-		if (markdownMatch) {
-			let linkPath = markdownMatch[2].trim();
-
-			// URL decode the link path - crucial for paths with spaces like Car%20Maintenance.md
-			try {
-				linkPath = decodeURIComponent(linkPath);
-			} catch (error) {
-				// If decoding fails, use the original path
-				console.debug("Failed to decode URI component:", linkPath, error);
-			}
-
-			return linkPath;
-		}
-
-		// Handle legacy pipe syntax like "../projects/Genealogy|Genealogy"
-		if (trimmed.includes("|")) {
-			const parts = trimmed.split("|");
-			return parts[0].trim();
-		}
-
-		// Not a link format, return as-is
-		return trimmed;
+		return parseLinkToPath(linkText);
 	}
 
 	/**

--- a/src/services/TaskLinkDetectionService.ts
+++ b/src/services/TaskLinkDetectionService.ts
@@ -133,6 +133,11 @@ export class TaskLinkDetectionService {
 		const displayText = match[1].trim();
 		let linkPath = match[2].trim();
 
+		// Strip angle brackets used to escape spaces/special characters in markdown links
+		if (linkPath.startsWith("<") && linkPath.endsWith(">")) {
+			linkPath = linkPath.slice(1, -1).trim();
+		}
+
 		if (!linkPath) return null;
 
 		// URL decode the link path - this is crucial for markdown links

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -33,6 +33,7 @@ import {
 	normalizeDependencyEntry,
 	resolveDependencyEntry,
 } from "../utils/dependencyUtils";
+import { getProjectDisplayName } from "../utils/linkUtils";
 import {
 	formatDateForStorage,
 	getCurrentDateString,
@@ -2137,41 +2138,6 @@ export class TaskService {
 	 * - "simple string" -> "simple string"
 	 */
 	private extractProjectBasename(project: string): string {
-		if (!project) return "";
-
-		// Check if it's a wikilink format [[...]]
-		const linkMatch = project.match(/^\[\[([^\]]+)\]\]$/);
-		if (linkMatch) {
-			const linkContent = linkMatch[1];
-
-			// Handle pipe syntax: "path|display" -> use "display"
-			if (linkContent.includes("|")) {
-				return linkContent.split("|")[1].trim();
-			}
-
-			// Try to resolve the file using Obsidian's metadata cache
-			if (this.plugin.app?.metadataCache) {
-				try {
-					const file = this.plugin.app.metadataCache.getFirstLinkpathDest(
-						linkContent,
-						""
-					);
-					if (file) {
-						// Return the file's basename (name without extension)
-						return file.basename;
-					}
-				} catch (error) {
-					// File resolution failed, fall back to manual extraction
-					console.debug("Error resolving project file:", error);
-				}
-			}
-
-			// Fallback: extract basename manually from the path
-			const pathParts = linkContent.split("/");
-			return pathParts[pathParts.length - 1] || linkContent;
-		}
-
-		// For non-wikilink strings, return as-is
-		return project;
+		return getProjectDisplayName(project, this.plugin.app);
 	}
 }

--- a/src/ui/TaskCard.ts
+++ b/src/ui/TaskCard.ts
@@ -670,11 +670,12 @@ const PROPERTY_RENDERERS: Record<string, PropertyRenderer> = {
 			renderScheduledDateProperty(element, value, task, plugin);
 		}
 	},
-	projects: (element, value, _, plugin) => {
+	projects: (element, value, task, plugin) => {
 		if (Array.isArray(value)) {
 			const linkServices: LinkServices = {
 				metadataCache: plugin.app.metadataCache,
 				workspace: plugin.app.workspace,
+				sourcePath: task.path,
 			};
 			renderProjectLinks(element, value as string[], linkServices);
 		}

--- a/src/views/StatsView.ts
+++ b/src/views/StatsView.ts
@@ -14,6 +14,7 @@ import { calculateTotalTimeSpent, filterEmptyProjects } from "../utils/helpers";
 import { getTodayLocal, createUTCDateFromLocalCalendarDate } from "../utils/dateUtils";
 import { createTaskCard } from "../ui/TaskCard";
 import { convertInternalToUserProperties } from "../utils/propertyMapping";
+import { getProjectDisplayName } from "../utils/linkUtils";
 
 interface ProjectStats {
 	projectName: string;
@@ -472,30 +473,8 @@ export class StatsView extends ItemView {
 	 */
 	private extractProjectName(projectValue: string): string | null {
 		if (!projectValue) return null;
-
-		// For wikilinks, extract the link content
-		if (projectValue.startsWith("[[") && projectValue.endsWith("]]")) {
-			const linkPath = this.extractWikilinkPath(projectValue);
-			if (!linkPath) return null;
-
-			// Extract basename from path
-			const parts = linkPath.split("/");
-			return parts[parts.length - 1] || linkPath;
-		}
-
-		// For pipe syntax, get the display name
-		if (projectValue.includes("|")) {
-			const parts = projectValue.split("|");
-			return parts[parts.length - 1] || projectValue;
-		}
-
-		// For paths, get the final segment
-		if (projectValue.includes("/")) {
-			const parts = projectValue.split("/");
-			return parts[parts.length - 1] || projectValue;
-		}
-
-		return projectValue;
+		const displayName = getProjectDisplayName(projectValue, this.plugin?.app);
+		return displayName || null;
 	}
 
 	private calculateOverallStats(tasks: TaskInfo[]): OverallStats {


### PR DESCRIPTION
# fix-angle-brackets

## Angle Bracket Links + Project Titles

This change set improves angle‑bracket link handling, project title display, and dependency link normalization. The goal is to make internal link resolution consistent across filters, overlays, project links, and dependency displays.

Examples (illustrative):

- Angle‑bracket links: `[Spec](<Projects/Client X/Spec.md>)` and `<Projects/Client X/Spec.md>` now resolve like regular internal links.
- Project title display: a project link like `[[Projects/Client X]]` shows frontmatter `title` (e.g., "Client X Roadmap") instead of the raw filename/path; if no `title` is set, the existing display text/alias/basename remains.
- Dependency normalization: dependency values such as `[[Ops/Deploy Plan]]`, `[Deploy](<Ops/Deploy Plan.md>)`, or `Ops/Deploy Plan.md` normalize to the same target and render consistently.

## Changelog

### Links & Titles

- Enhanced link parsing to support `<...>` autolinks and angle-bracket paths in markdown links, including URL decoding and `.md` handling.
- Added `getProjectDisplayName` for consistent project display names across markdown links, wikilinks, and plain text.
- Normalized internal link resolution in overlays and detection to handle angle-bracket markdown links.
- Updated link rendering to:
  - resolve relative links using `sourcePath`,
  - normalize `data-href` with parsed paths,
  - prefer frontmatter `title` when the display text is just the filename/path,
  - support optional custom navigation hooks.
- Group-by headers now:
  - support markdown links,
  - normalize paths via `parseLinkToPath`,
  - prefer frontmatter `title` when applicable.
- Filters, stats, and task services now use `getProjectDisplayName` for consistent project titles.
- Updated call sites to pass `sourcePath` where needed (task cards, task modals, selector modals).

### Dependencies

- Dependency entries are normalized via `parseLinkToPath` to handle wikilinks, markdown links, and angle-bracket variants.
- Dependency resolution now tries multiple candidates (with/without `.md`, `parseLinktext` variants) for more reliable linking.
- Task modal normalizes dependencies before resolving them to improve display robustness.

### Tests

- Added unit coverage for angle-bracket link parsing and project display name resolution in `linkUtils`.

Cf. [Pull Request](<Pull Request.md>)