### PR TITLE
fix: sync default status/priority when referenced value is deleted

### DIFF
--- a/src/settings/tabs/taskProperties/statusPropertyCard.ts
+++ b/src/settings/tabs/taskProperties/statusPropertyCard.ts
@@ -31,6 +31,13 @@ export function renderStatusPropertyCard(
 		plugin.settings.fieldMapping.status
 	);
 
+	// Validate defaultTaskStatus - if it doesn't exist in customStatuses, reset to first available
+	const validStatusValues = plugin.settings.customStatuses.map((s) => s.value);
+	if (!validStatusValues.includes(plugin.settings.defaultTaskStatus) && validStatusValues.length > 0) {
+		plugin.settings.defaultTaskStatus = validStatusValues[0];
+		save();
+	}
+
 	const defaultSelect = createCardSelect(
 		plugin.settings.customStatuses.map((status) => ({
 			value: status.value,
@@ -280,10 +287,19 @@ function renderStatusList(
 					(s) => s.id === status.id
 				);
 				if (statusIndex !== -1) {
+					// Check if we're deleting the default status
+					const wasDefault = plugin.settings.defaultTaskStatus === status.value;
+
 					plugin.settings.customStatuses.splice(statusIndex, 1);
 					plugin.settings.customStatuses.forEach((s, i) => {
 						s.order = i;
 					});
+
+					// If deleted status was the default, update to first available status
+					if (wasDefault && plugin.settings.customStatuses.length > 0) {
+						plugin.settings.defaultTaskStatus = plugin.settings.customStatuses[0].value;
+					}
+
 					save();
 					renderStatusList(container, plugin, save, translate, onStatusesChanged);
 					if (onStatusesChanged) onStatusesChanged();


### PR DESCRIPTION
When deleting the default value for a task status from the custom statuses, the `defaultTaskStatus` property would remain at the old value.

Since there's then no label associated with this value, the UI under Task Properties -> Status -> Default would show another label (the first one). So this looked as if it was "correct". Setting it explicitly to the intended default wouldn't update this either, since the UI filtered this as "no change".

The first time it was set to *another* value and then back would fix this.

This patch addresses this by ensuring that when the default status/priority is deleted, the default value is also updated. When the UI notices that it is set to a non-existing value, it is also updated.
