### PR TITLE
fix: persist project removals

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,20 @@
+# fix/projects-removal
+
+## Ensure project removals persist from the edit dialog
+
+When removing project assignments in the task edit modal, the frontmatter now updates correctly (including fully removing the property when the list is emptied). We also normalize link comparisons so different link syntaxes (e.g., angle‑bracket markdown links) do not cause false change detection.
+
+Examples (illustrative):
+
+- Removing the last project now deletes the `projects` property from frontmatter.
+- `[Project](<path/to/Project.md>)` and `[[path/to/Project]]` compare as the same target for change detection.
+
+## Changelog
+
+- Normalize project link comparisons in the edit modal to handle angle‑bracket markdown links.
+- Persist empty project lists by explicitly removing the `projects` field from frontmatter.
+- Add a unit test to ensure empty project updates remove the property.
+
+## Tests
+
+- `./node_modules/.bin/jest tests/unit/services/TaskService.test.ts --runInBand`

--- a/src/modals/TaskEditModal.ts
+++ b/src/modals/TaskEditModal.ts
@@ -25,7 +25,7 @@ import {
 } from "../utils/helpers";
 import { splitListPreservingLinksAndQuotes } from "../utils/stringSplit";
 import { ReminderContextMenu } from "../components/ReminderContextMenu";
-import { generateLinkWithDisplay } from "../utils/linkUtils";
+import { generateLinkWithDisplay, parseLinkToPath } from "../utils/linkUtils";
 import { EmbeddableMarkdownEditor } from "../editor/EmbeddableMarkdownEditor";
 import { ConfirmationModal } from "./ConfirmationModal";
 
@@ -761,8 +761,23 @@ export class TaskEditModal extends TaskModal {
 		const newProjects = splitListPreservingLinksAndQuotes(this.projects);
 		const oldProjects = this.task.projects || [];
 
-		if (JSON.stringify(newProjects.sort()) !== JSON.stringify(oldProjects.sort())) {
-			changes.projects = newProjects.length > 0 ? newProjects : undefined;
+		const normalizeProjectList = (projects: string[]): string[] =>
+			projects
+				.map((project) => {
+					if (!project || typeof project !== "string") return "";
+					const trimmed = project.trim();
+					if (!trimmed) return "";
+					return parseLinkToPath(trimmed).trim();
+				})
+				.filter((project) => project.length > 0);
+
+		const normalizedNewProjects = normalizeProjectList(newProjects).sort();
+		const normalizedOldProjects = normalizeProjectList(oldProjects).sort();
+
+		if (
+			JSON.stringify(normalizedNewProjects) !== JSON.stringify(normalizedOldProjects)
+		) {
+			changes.projects = newProjects.length > 0 ? newProjects : [];
 		}
 
 		// Parse and compare tags

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -1414,6 +1414,15 @@ export class TaskService {
 					delete frontmatter[this.plugin.fieldMapper.toUserField("scheduled")];
 				if (updates.hasOwnProperty("contexts") && updates.contexts === undefined)
 					delete frontmatter[this.plugin.fieldMapper.toUserField("contexts")];
+				if (updates.hasOwnProperty("projects")) {
+					const projectsField = this.plugin.fieldMapper.toUserField("projects");
+					const projectsToSet = Array.isArray(updates.projects) ? updates.projects : [];
+					if (projectsToSet.length > 0) {
+						frontmatter[projectsField] = projectsToSet;
+					} else {
+						delete frontmatter[projectsField];
+					}
+				}
 				if (updates.hasOwnProperty("timeEstimate") && updates.timeEstimate === undefined)
 					delete frontmatter[this.plugin.fieldMapper.toUserField("timeEstimate")];
 				if (updates.hasOwnProperty("completedDate") && updates.completedDate === undefined)

--- a/tests/unit/services/TaskService.test.ts
+++ b/tests/unit/services/TaskService.test.ts
@@ -987,6 +987,24 @@ describe('TaskService', () => {
       expect(mockPlugin.app.fileManager.processFrontMatter).toHaveBeenCalled();
     });
 
+    it('should remove projects when set to an empty array', async () => {
+      const taskWithProjects = TaskFactory.createTask({
+        projects: ['[[Project Alpha]]']
+      });
+      mockFile = new TFile(taskWithProjects.path);
+      mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      let capturedFrontmatter: any = {};
+      mockPlugin.app.fileManager.processFrontMatter.mockImplementation(async (_file, fn) => {
+        capturedFrontmatter = { projects: ['[[Project Alpha]]'] };
+        fn(capturedFrontmatter);
+      });
+
+      await taskService.updateTask(taskWithProjects, { projects: [] });
+
+      expect(capturedFrontmatter.projects).toBeUndefined();
+    });
+
     it('should preserve tags when not being updated', async () => {
       const taskWithTags = TaskFactory.createTask({ tags: ['task', 'important'] });
       const updates = { priority: 'high' };


### PR DESCRIPTION
# fix/projects-removal

## Ensure project removals persist from the edit dialog

When removing project assignments in the task edit modal, the frontmatter now updates correctly (including fully removing the property when the list is emptied). We also normalize link comparisons so different link syntaxes (e.g., angle‑bracket markdown links) do not cause false change detection.

Examples (illustrative):

- Removing the last project now deletes the `projects` property from frontmatter.
- `[Project](<path/to/Project.md>)` and `[[path/to/Project]]` compare as the same target for change detection.

## Changelog

- Normalize project link comparisons in the edit modal to handle angle‑bracket markdown links.
- Persist empty project lists by explicitly removing the `projects` field from frontmatter.
- Add a unit test to ensure empty project updates remove the property.

## Tests

- `./node_modules/.bin/jest tests/unit/services/TaskService.test.ts --runInBand`
