### PR TITLE
Add regex filter to .ics calendars

### DIFF
--- a/src/settings/tabs/integrationsTab.ts
+++ b/src/settings/tabs/integrationsTab.ts
@@ -1173,6 +1173,7 @@ export function renderIntegrationsTab(
 							enabled: false, // Start disabled until user fills in details
 							type: "remote" as const,
 							refreshInterval: 60,
+							filter: ""
 						};
 
 						if (!plugin.icsSubscriptionService) {
@@ -1589,6 +1590,7 @@ function renderICSSubscriptionsList(
 
 		const colorInput = createCardInput("color", "", subscription.color);
 		const refreshInput = createCardNumberInput(5, 1440, 5, subscription.refreshInterval || 60);
+		const filterInput = createCardInput("text", "", subscription.filter);
 
 		// Update handlers
 		const updateSubscription = async (updates: Partial<typeof subscription>) => {
@@ -1617,6 +1619,9 @@ function renderICSSubscriptionsList(
 			const minutes = parseInt(refreshInput.value) || 60;
 			updateSubscription({ refreshInterval: minutes });
 		});
+		filterInput.addEventListener("change", () =>
+			updateSubscription({ filter: filterInput.value })
+		);
 
 		// Type change handler - re-render the subscription list to update input type
 		typeSelect.addEventListener("change", async () => {
@@ -1750,6 +1755,7 @@ function renderICSSubscriptionsList(
 			},
 			{ label: "Color:", input: colorInput },
 			{ label: "Refresh (min):", input: refreshInput },
+			{ label: "Filter (regex):", input: filterInput }
 		];
 
 		createCard(container, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -761,6 +761,7 @@ export interface ICSSubscription {
 	color: string;
 	enabled: boolean;
 	refreshInterval: number; // minutes (for remote) or check interval (for local)
+	filter: string;
 }
 
 export interface ICSEvent {


### PR DESCRIPTION
Adds a regex filter to .ics calendars.

**Weird behavior:**
When updating the regex, the calendar view must be closed and then reopened to see the `ICSEntry` changes, I guess it's because of some caching (maybe `ICSCache`?)

-> Needs further investigation if wanted