### PR TITLE
Preserve Time When Setting Recurrence and Clear Recurrence from Google Calendar

### DIFF
--- a/src/bases/KanbanView.ts
+++ b/src/bases/KanbanView.ts
@@ -2302,6 +2302,7 @@ export class KanbanView extends BasesViewBase {
 		const menu = new RecurrenceContextMenu({
 			currentValue: typeof task.recurrence === "string" ? task.recurrence : undefined,
 			currentAnchor: task.recurrence_anchor || "scheduled",
+			scheduledDate: task.scheduled,
 			onSelect: async (newRecurrence: string | null, anchor?: "scheduled" | "completion") => {
 				try {
 					await this.plugin.updateTaskProperty(

--- a/src/bases/TaskListView.ts
+++ b/src/bases/TaskListView.ts
@@ -1101,6 +1101,7 @@ export class TaskListView extends BasesViewBase {
 		const menu = new RecurrenceContextMenu({
 			currentValue: typeof task.recurrence === "string" ? task.recurrence : undefined,
 			currentAnchor: task.recurrence_anchor || 'scheduled',
+			scheduledDate: task.scheduled,
 			onSelect: async (newRecurrence: string | null, anchor?: 'scheduled' | 'completion') => {
 				try {
 					await this.plugin.updateTaskProperty(

--- a/src/components/RecurrenceContextMenu.ts
+++ b/src/components/RecurrenceContextMenu.ts
@@ -13,6 +13,7 @@ export interface RecurrenceOption {
 export interface RecurrenceContextMenuOptions {
 	currentValue?: string;
 	currentAnchor?: 'scheduled' | 'completion';
+	scheduledDate?: string; // Task's scheduled date to extract time from
 	onSelect: (value: string | null, anchor?: 'scheduled' | 'completion') => void;
 	app: App;
 	plugin: TaskNotesPlugin;
@@ -115,7 +116,7 @@ export class RecurrenceContextMenu {
 		// Format today as DTSTART, preserving existing time if available
 		let todayDTSTART = this.formatDateForDTSTART(today);
 
-		// If there's an existing recurrence with time, preserve the time component
+		// Priority 1: Preserve time from existing recurrence
 		if (this.options.currentValue) {
 			const existingDtstartMatch = this.options.currentValue.match(
 				/DTSTART:(\d{8}(?:T\d{6}Z?)?)/
@@ -124,6 +125,16 @@ export class RecurrenceContextMenu {
 				// Extract time part from existing DTSTART
 				const existingTime = existingDtstartMatch[1].split("T")[1];
 				todayDTSTART = `${todayDTSTART}T${existingTime}`;
+			}
+		}
+		// Priority 2: If no existing recurrence time, check task's scheduled date
+		else if (this.options.scheduledDate && this.options.scheduledDate.includes("T")) {
+			// Extract time from scheduled date (format: YYYY-MM-DDTHH:mm or similar)
+			const timeMatch = this.options.scheduledDate.match(/T(\d{2}):(\d{2})/);
+			if (timeMatch) {
+				const hours = timeMatch[1];
+				const minutes = timeMatch[2];
+				todayDTSTART = `${todayDTSTART}T${hours}${minutes}00Z`;
 			}
 		}
 
@@ -242,6 +253,7 @@ export class RecurrenceContextMenu {
 			this.options.app,
 			this.options.currentValue || "",
 			this.options.currentAnchor || 'scheduled',
+			this.options.scheduledDate,
 			(result, anchor) => {
 				if (result) {
 					this.options.onSelect(result, anchor);
@@ -257,6 +269,7 @@ export class RecurrenceContextMenu {
 
 class CustomRecurrenceModal extends Modal {
 	private currentValue: string;
+	private scheduledDate?: string;
 	private onSubmit: (result: string | null, anchor?: 'scheduled' | 'completion') => void;
 	private frequency = "DAILY";
 	private interval = 1;
@@ -271,10 +284,11 @@ class CustomRecurrenceModal extends Modal {
 	private dtstartTime = "";
 	private recurrenceAnchor: 'scheduled' | 'completion' = 'scheduled'; // NEW: Recurrence anchor
 
-	constructor(app: App, currentValue: string, currentAnchor: 'scheduled' | 'completion', onSubmit: (result: string | null, anchor?: 'scheduled' | 'completion') => void) {
+	constructor(app: App, currentValue: string, currentAnchor: 'scheduled' | 'completion', scheduledDate: string | undefined, onSubmit: (result: string | null, anchor?: 'scheduled' | 'completion') => void) {
 		super(app);
 		this.currentValue = currentValue;
 		this.recurrenceAnchor = currentAnchor;
+		this.scheduledDate = scheduledDate;
 		this.onSubmit = onSubmit;
 		this.parseCurrentValue();
 	}
@@ -283,6 +297,14 @@ class CustomRecurrenceModal extends Modal {
 		if (!this.currentValue) {
 			// Set default DTSTART to today
 			this.dtstart = this.formatTodayForInput();
+			
+			// Check if we should preserve time from scheduled date
+			if (this.scheduledDate && this.scheduledDate.includes("T")) {
+				const timeMatch = this.scheduledDate.match(/T(\d{2}):(\d{2})/);
+				if (timeMatch) {
+					this.dtstartTime = `${timeMatch[1]}:${timeMatch[2]}`;
+				}
+			}
 			return;
 		}
 

--- a/src/components/TaskContextMenu.ts
+++ b/src/components/TaskContextMenu.ts
@@ -1365,6 +1365,7 @@ export class TaskContextMenu {
 				const recurrenceMenu = new RecurrenceContextMenu({
 					currentValue: typeof currentValue === "string" ? currentValue : undefined,
 					currentAnchor: this.options.task.recurrence_anchor || 'scheduled',
+					scheduledDate: this.options.task.scheduled,
 					onSelect: onSelect,
 					app: plugin.app,
 					plugin: plugin,

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -1350,6 +1350,7 @@ export abstract class TaskModal extends Modal {
 		const menu = new RecurrenceContextMenu({
 			currentValue: this.recurrenceRule,
 			currentAnchor: this.recurrenceAnchor,
+			scheduledDate: this.scheduledDate,
 			onSelect: (value, anchor) => {
 				this.recurrenceRule = value || "";
 				if (anchor !== undefined) {

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -25,6 +25,9 @@ export class TaskCalendarSyncService {
 	/** In-flight sync operations to prevent concurrent syncs for the same task */
 	private inFlightSyncs: Map<string, Promise<void>> = new Map();
 
+	/** Track previous task state for detecting recurrence removal */
+	private previousTaskState: Map<string, TaskInfo> = new Map();
+
 	constructor(plugin: TaskNotesPlugin, googleCalendarService: GoogleCalendarService) {
 		this.plugin = plugin;
 		this.googleCalendarService = googleCalendarService;
@@ -38,6 +41,7 @@ export class TaskCalendarSyncService {
 			clearTimeout(timer);
 		}
 		this.pendingSyncs.clear();
+		this.previousTaskState.clear();
 	}
 
 	/**
@@ -335,7 +339,7 @@ export class TaskCalendarSyncService {
 	/**
 	 * Convert a task to a Google Calendar event payload
 	 */
-	private taskToCalendarEvent(task: TaskInfo): {
+	private taskToCalendarEvent(task: TaskInfo, clearRecurrence?: boolean): {
 		summary: string;
 		description?: string;
 		start: { date?: string; dateTime?: string; timeZone?: string };
@@ -445,6 +449,10 @@ export class TaskCalendarSyncService {
 					}
 				}
 			}
+		} else if (clearRecurrence) {
+			// Explicitly clear recurrence when it was removed from the task
+			// Google Calendar API requires an empty array to remove recurrence
+			event.recurrence = [];
 		}
 
 		return event;
@@ -453,7 +461,7 @@ export class TaskCalendarSyncService {
 	/**
 	 * Sync a task to Google Calendar (create or update)
 	 */
-	async syncTaskToCalendar(task: TaskInfo): Promise<void> {
+	async syncTaskToCalendar(task: TaskInfo, previous?: TaskInfo): Promise<void> {
 		if (!this.shouldSyncTask(task)) {
 			return;
 		}
@@ -462,7 +470,10 @@ export class TaskCalendarSyncService {
 		const existingEventId = this.getTaskEventId(task);
 
 		try {
-			const eventData = this.taskToCalendarEvent(task);
+			// Check if recurrence was removed (previous had recurrence, current doesn't)
+			const clearRecurrence = !!(previous?.recurrence && !task.recurrence);
+			
+			const eventData = this.taskToCalendarEvent(task, clearRecurrence);
 			if (!eventData) {
 				console.warn("[TaskCalendarSync] Could not convert task to event:", task.path);
 				return;
@@ -503,7 +514,7 @@ export class TaskCalendarSyncService {
 				// Retry without the link - refetch task to get updated version
 				const updatedTask = await this.plugin.cacheManager.getTaskInfo(task.path);
 				if (updatedTask) {
-					return this.syncTaskToCalendar(updatedTask);
+					return this.syncTaskToCalendar(updatedTask, previous);
 				}
 			}
 
@@ -522,6 +533,11 @@ export class TaskCalendarSyncService {
 		}
 
 		const taskPath = task.path;
+
+		// Store previous state for recurrence change detection
+		if (previous) {
+			this.previousTaskState.set(taskPath, previous);
+		}
 
 		// Cancel any pending debounced sync for this task
 		const existingTimer = this.pendingSyncs.get(taskPath);
@@ -575,11 +591,19 @@ export class TaskCalendarSyncService {
 			if (existingEventId) {
 				await this.deleteTaskFromCalendar(task);
 			}
+			// Clean up previous state
+			this.previousTaskState.delete(task.path);
 			return;
 		}
 
+		// Get previous state for recurrence change detection
+		const previousState = this.previousTaskState.get(task.path);
+
 		// Sync the updated task
-		await this.syncTaskToCalendar(task);
+		await this.syncTaskToCalendar(task, previousState);
+		
+		// Update previous state with current task
+		this.previousTaskState.set(task.path, task);
 	}
 
 	/**

--- a/src/ui/TaskCard.ts
+++ b/src/ui/TaskCard.ts
@@ -248,6 +248,7 @@ function createRecurrenceClickHandler(
 		const menu = new RecurrenceContextMenu({
 			currentValue: typeof task.recurrence === "string" ? task.recurrence : undefined,
 			currentAnchor: task.recurrence_anchor || "scheduled",
+			scheduledDate: task.scheduled,
 			onSelect: async (newRecurrence, anchor) => {
 				try {
 					await plugin.updateTaskProperty(task, "recurrence", newRecurrence || undefined);


### PR DESCRIPTION
## Summary

This PR fixes two related issues with recurrence handling and Google Calendar sync:

1. **Time preservation**: When setting a new recurrence on a task with a scheduled time, the time component was lost, causing Google Calendar events to appear as all-day instead of at the specified time.

2. **Recurrence clearing**: When clearing recurrence from a task synced to Google Calendar, the recurrence rule wasn't properly removed from the calendar event.

## Problem

### Issue 1: Time Loss in Recurrence

**Before:**
- Task has `scheduled: 2026-01-27T18:39` (with time)
- User sets weekly recurrence
- Recurrence created: `DTSTART:20260127;FREQ=WEEKLY` (date-only)
- Google Calendar shows event as all-day ❌

**After:**
- Task has `scheduled: 2026-01-27T18:39` (with time)
- User sets weekly recurrence
- Recurrence created: `DTSTART:20260127T183900Z;FREQ=WEEKLY` (with time)
- Google Calendar shows event at 18:39 ✓

### Issue 2: Recurrence Not Cleared from Google Calendar

**Before:**
- Task has recurrence synced to Google Calendar
- User clears recurrence from task
- Google Calendar event still shows as recurring ❌

**After:**
- Task has recurrence synced to Google Calendar
- User clears recurrence from task
- Google Calendar event updated with `recurrence: []` to remove recurrence ✓

## Root Causes

### Issue 1: Time Preservation
`RecurrenceContextMenu.getRecurrenceOptions()` only checked for time in existing recurrence rules (`currentValue`). When setting a new recurrence on a task with scheduled time but no existing recurrence, it didn't check the task's scheduled date for time information.

### Issue 2: Recurrence Clearing
`TaskCalendarSyncService.taskToCalendarEvent()` omitted the `recurrence` property entirely when a task had no recurrence. Google Calendar API requires an explicit empty array (`recurrence: []`) to remove existing recurrence rules.

## Solution

### Fix 1: Preserve Time from Scheduled Date

1. **Enhanced `RecurrenceContextMenuOptions` interface** to include `scheduledDate?: string`
2. **Updated `getRecurrenceOptions()`** to check scheduled date for time when no existing recurrence time exists:
   - Priority 1: Preserve time from existing recurrence (if present)
   - Priority 2: Extract time from task's scheduled date (if present)
3. **Updated `CustomRecurrenceModal`** to accept and use scheduled date, pre-filling time field
4. **Updated all call sites** (5 files) to pass `task.scheduled` when creating `RecurrenceContextMenu`

### Fix 2: Explicitly Clear Recurrence

1. **Added `previousTaskState` map** to track previous task state for detecting recurrence removal
2. **Modified `taskToCalendarEvent()`** to accept `clearRecurrence` parameter
3. **Updated `syncTaskToCalendar()`** to detect when recurrence was removed and pass `clearRecurrence: true`
4. **Set `recurrence: []`** explicitly when clearing recurrence to tell Google Calendar API to remove it

## Changes Made

### Files Modified

1. **`src/components/RecurrenceContextMenu.ts`**
   - Added `scheduledDate` to `RecurrenceContextMenuOptions` interface
   - Updated `getRecurrenceOptions()` to check scheduled date for time
   - Updated `CustomRecurrenceModal` constructor and `parseCurrentValue()`
   - Updated `showCustomRecurrenceModal()` to pass scheduled date

2. **`src/services/TaskCalendarSyncService.ts`**
   - Added `previousTaskState` map for tracking previous task state
   - Modified `taskToCalendarEvent()` to accept `clearRecurrence` parameter
   - Updated `syncTaskToCalendar()` to detect recurrence removal
   - Updated `updateTaskInCalendar()` and `executeTaskUpdate()` to track and pass previous state

3. **`src/ui/TaskCard.ts`**
   - Added `scheduledDate: task.scheduled` when creating `RecurrenceContextMenu`

4. **`src/bases/TaskListView.ts`**
   - Added `scheduledDate: task.scheduled` when creating `RecurrenceContextMenu`

5. **`src/bases/KanbanView.ts`**
   - Added `scheduledDate: task.scheduled` when creating `RecurrenceContextMenu`

6. **`src/components/TaskContextMenu.ts`**
   - Added `scheduledDate: this.options.task.scheduled` when creating `RecurrenceContextMenu`

7. **`src/modals/TaskModal.ts`**
   - Added `scheduledDate: this.scheduledDate` when creating `RecurrenceContextMenu`

### Test Files Created

- `e2e/issues/issue-clear-recurrence-google-calendar.spec.ts` - Tests for recurrence clearing
- `e2e/issues/issue-preserve-time-in-recurrence.spec.ts` - Tests for time preservation

## Testing

**Time Preservation:**
1. Create task with `scheduled: 2026-01-27T18:39`
2. Set recurrence via quick option (e.g., "Weekly on Monday")
3. Verify DTSTART includes time: `DTSTART:20260127T183900Z`
4. Check Google Calendar shows event at 18:39, not all-day

**Recurrence Clearing:**
1. Create recurring task synced to Google Calendar
2. Clear recurrence from task
3. Verify Google Calendar event is updated (no longer recurring)
4. Verify event ID remains in task (event updated, not deleted)

**Custom Recurrence Modal:**
1. Open custom recurrence modal for task with scheduled time
2. Verify time field is pre-filled from scheduled date
3. Set recurrence and verify time is preserved

## Impact

### User Experience
- ✅ Recurring events maintain correct times in Google Calendar
- ✅ Clearing recurrence properly updates Google Calendar events
- ✅ Custom recurrence modal pre-fills time from scheduled date
- ✅ Consistent behavior across all views (TaskCard, TaskListView, KanbanView, TaskModal)

### Technical
- ✅ Proper DTSTART format with time component (`YYYYMMDDTHHMMSSZ`)
- ✅ Explicit recurrence clearing via empty array (`recurrence: []`)
- ✅ State tracking for detecting recurrence changes
- ✅ Backward compatible (existing recurrences continue to work)

## Related Issues

Fixes issues where:
- Setting recurrence on tasks with scheduled times loses time information
- Clearing recurrence doesn't update Google Calendar events properly
- Google Calendar shows all-day events instead of timed events

## Checklist

- [x] Code compiles without errors
- [x] No linter errors
- [x] All call sites updated to pass scheduled date
- [x] Time preservation logic implemented
- [x] Recurrence clearing logic implemented
