### PR TITLE
fix: render hierarchical tags with slashes in link text

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,21 @@
+# fix/render-hierarchical-tags
+
+Fixes: https://github.com/callumalpass/tasknotes/issues/1428
+
+## Fix hierarchical tags in Agenda
+
+Render hierarchical tags with slashes (e.g., #g/tog) as a single tag token in Agenda/Task list views. This prevents the slash suffix from being rendered as plain text.
+
+Examples (illustrative):
+
+- #g/tog renders as one tag
+- #project/sub-project renders as one tag
+
+## Changelog
+
+- expand tag regex in link text rendering to include slashes
+- enable regression test for hierarchical tag rendering in link text
+
+## Tests
+
+- npm run test:unit -- --runTestsByPath tests/unit/issues/issue-1428-hashtags-with-slashes.test.ts

--- a/src/ui/renderers/linkRenderer.ts
+++ b/src/ui/renderers/linkRenderer.ts
@@ -198,7 +198,7 @@ export function renderTextWithLinks(
 	const remainingText = text.slice(lastIndex);
 	if (remainingText && options?.onTagClick) {
 		// Look for tags in the remaining text
-		const tagRegex = /(^|\s)(#\w+)/g;
+		const tagRegex = /(^|\s)(#[\p{L}\p{N}\p{M}_/-]+)/gu;
 		let tagLastIndex = 0;
 		let tagMatch: RegExpExecArray | null;
 

--- a/tests/unit/issues/issue-1428-hashtags-with-slashes.test.ts
+++ b/tests/unit/issues/issue-1428-hashtags-with-slashes.test.ts
@@ -24,7 +24,7 @@
 import { renderTextWithLinks, LinkServices } from '../../../src/ui/renderers/linkRenderer';
 import { makeContainer } from '../../helpers/dom-helpers';
 
-describe.skip('Issue #1428: Hashtags with slashes not rendered correctly', () => {
+describe('Issue #1428: Hashtags with slashes not rendered correctly', () => {
   // Mock LinkServices for rendering
   const mockLinkServices: LinkServices = {
     metadataCache: {


### PR DESCRIPTION
Fixes #1428. Cf. [PR.md](PR.md).