### PR TITLE
feat: add MCP server with shared controller logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tasknotes",
-	"version": "4.1.3",
+	"version": "4.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tasknotes",
-			"version": "4.1.3",
+			"version": "4.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/view": "^6.37.2",
@@ -16,13 +16,15 @@
 				"@fullcalendar/list": "^6.1.17",
 				"@fullcalendar/multimonth": "^6.1.17",
 				"@fullcalendar/timegrid": "^6.1.17",
+				"@modelcontextprotocol/sdk": "^1.12.1",
 				"chrono-node": "^2.7.5",
 				"date-fns": "^4.1.0",
 				"ical.js": "^2.2.1",
 				"obsidian-daily-notes-interface": "^0.9.4",
 				"reflect-metadata": "^0.2.2",
 				"rrule": "^2.8.1",
-				"yaml": "^2.3.1"
+				"yaml": "^2.3.1",
+				"zod": "^3.24.0"
 			},
 			"devDependencies": {
 				"@codemirror/autocomplete": "^6.19.1",
@@ -1549,6 +1551,18 @@
 				"@fullcalendar/core": "~6.1.20"
 			}
 		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.9",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+			"integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.14",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -2404,6 +2418,68 @@
 			"dependencies": {
 				"ret": "~0.1.10"
 			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.26.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+			"integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/@napi-rs/canvas": {
 			"version": "0.1.78",
@@ -4518,6 +4594,19 @@
 				"win32"
 			]
 		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4567,6 +4656,45 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ajv-formats/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
@@ -4924,6 +5052,46 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/boolean": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -5043,6 +5211,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/cacheable-lookup": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -5111,7 +5288,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -5125,7 +5301,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -5366,12 +5541,69 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/content-disposition": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+			"integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/cose-base": {
 			"version": "1.0.3",
@@ -5393,7 +5625,6 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -6044,10 +6275,9 @@
 			"license": "MIT"
 		},
 		"node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -6185,6 +6415,15 @@
 				"robust-predicates": "^3.0.2"
 			}
 		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -6243,7 +6482,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
@@ -6266,6 +6504,12 @@
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
 			"license": "MIT"
 		},
 		"node_modules/electron": {
@@ -6330,6 +6574,15 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
@@ -6447,7 +6700,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -6457,7 +6709,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -6467,7 +6718,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
 			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -6582,6 +6832,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -7439,12 +7695,42 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
 			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+			"integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/execa": {
 			"version": "5.1.1",
@@ -7498,6 +7784,67 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+			"integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "10.0.1"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
 		"node_modules/exsolve": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -7546,7 +7893,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-diff": {
@@ -7604,7 +7950,6 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
 			"integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -7671,6 +8016,27 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/find-up": {
@@ -7758,6 +8124,24 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/fs-extra": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -7799,7 +8183,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -7867,7 +8250,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -7902,7 +8284,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
@@ -8052,7 +8433,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -8186,7 +8566,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -8215,13 +8594,21 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+			"integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
@@ -8250,6 +8637,26 @@
 			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
 			"dev": true,
 			"license": "BSD-2-Clause"
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
@@ -8440,7 +8847,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/internal-slot": {
@@ -8466,6 +8872,24 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+			"integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -8758,6 +9182,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8927,7 +9357,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ismobilejs": {
@@ -9765,6 +10194,15 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/jose": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+			"integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9892,6 +10330,12 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -10223,10 +10667,30 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -10287,6 +10751,31 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -10394,7 +10883,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/napi-postinstall": {
@@ -10419,6 +10907,15 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -10488,7 +10985,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -10498,7 +10994,6 @@
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -10720,11 +11215,22 @@
 				"@types/tern": "*"
 			}
 		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
@@ -10893,6 +11399,15 @@
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/path-data-parser": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -10924,7 +11439,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -10960,6 +11474,16 @@
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -11069,6 +11593,15 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/pixijs"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -11333,6 +11866,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/pump": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -11372,10 +11918,9 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-			"dev": true,
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -11436,6 +11981,46 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/raw-body/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/react-is": {
@@ -11532,7 +12117,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -11697,6 +12281,22 @@
 				"points-on-path": "^0.2.1"
 			}
 		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/rrule": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
@@ -11834,7 +12434,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/saxes": {
@@ -11878,6 +12477,32 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/serialize-error": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -11907,6 +12532,25 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -11958,11 +12602,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -11975,7 +12624,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11985,7 +12633,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
 			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -12005,7 +12652,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
 			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -12022,7 +12668,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
 			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -12041,7 +12686,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
 			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -12123,6 +12767,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/stop-iteration-iterator": {
@@ -12476,6 +13129,15 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/toml-eslint-parser": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.9.3.tgz",
@@ -12719,6 +13381,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/type-is": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^1.0.5",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/typed-array-buffer": {
@@ -13120,6 +13796,15 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/unrs-resolver": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -13244,6 +13929,15 @@
 			},
 			"engines": {
 				"node": ">=10.12.0"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/vscode-jsonrpc": {
@@ -13381,7 +14075,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -13540,7 +14233,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/write-file-atomic": {
@@ -13706,6 +14398,24 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25 || ^4"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 	"dependencies": {
 		"@codemirror/view": "^6.37.2",
 		"@fullcalendar/core": "^6.1.17",
+		"@modelcontextprotocol/sdk": "^1.12.1",
 		"@fullcalendar/daygrid": "^6.1.17",
 		"@fullcalendar/interaction": "^6.1.17",
 		"@fullcalendar/list": "^6.1.17",
@@ -80,6 +81,7 @@
 		"obsidian-daily-notes-interface": "^0.9.4",
 		"reflect-metadata": "^0.2.2",
 		"rrule": "^2.8.1",
-		"yaml": "^2.3.1"
+		"yaml": "^2.3.1",
+		"zod": "^3.24.0"
 	}
 }

--- a/src/api/TimeTrackingController.ts
+++ b/src/api/TimeTrackingController.ts
@@ -8,6 +8,11 @@ import { StatusManager } from "../services/StatusManager";
 import TaskNotesPlugin from "../main";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Get, Post } from "../utils/OpenAPIDecorators";
+import {
+	computeActiveTimeSessions,
+	computeTimeSummary,
+	computeTaskTimeData,
+} from "../utils/timeTrackingUtils";
 
 export class TimeTrackingController extends BaseController {
 	constructor(
@@ -112,7 +117,7 @@ export class TimeTrackingController extends BaseController {
 			const description = body.description || "";
 
 			// Start time tracking using the existing service method
-			const updatedTask = await this.taskService.startTimeTracking(task);
+			let updatedTask = await this.taskService.startTimeTracking(task);
 
 			// If description was provided, update the latest time entry
 			if (description && updatedTask.timeEntries && updatedTask.timeEntries.length > 0) {
@@ -120,7 +125,7 @@ export class TimeTrackingController extends BaseController {
 				if (latestEntry && !latestEntry.endTime) {
 					latestEntry.description = description;
 					// Save the updated task
-					await this.taskService.updateTask(updatedTask, {
+					updatedTask = await this.taskService.updateTask(updatedTask, {
 						timeEntries: updatedTask.timeEntries,
 					});
 				}
@@ -151,51 +156,11 @@ export class TimeTrackingController extends BaseController {
 	async getActiveTimeSessions(req: IncomingMessage, res: ServerResponse): Promise<void> {
 		try {
 			const allTasks = await this.cacheManager.getAllTasks();
-			const activeSessions: Array<{
-				task: any;
-				session: any;
-				elapsedMinutes: number;
-			}> = [];
-
-			for (const task of allTasks) {
-				const activeEntry = this.plugin.getActiveTimeSession(task);
-				if (activeEntry) {
-					const startTime = new Date(activeEntry.startTime);
-					const elapsedMinutes = Math.floor(
-						(Date.now() - startTime.getTime()) / (1000 * 60)
-					);
-
-					activeSessions.push({
-						task: {
-							id: task.path,
-							title: task.title,
-							status: task.status,
-							priority: task.priority,
-							tags: task.tags || [],
-							projects: task.projects || [],
-						},
-						session: {
-							startTime: activeEntry.startTime,
-							description: activeEntry.description,
-							elapsedMinutes,
-						},
-						elapsedMinutes,
-					});
-				}
-			}
-
-			this.sendResponse(
-				res,
-				200,
-				this.successResponse({
-					activeSessions,
-					totalActiveSessions: activeSessions.length,
-					totalElapsedMinutes: activeSessions.reduce(
-						(sum, session) => sum + session.elapsedMinutes,
-						0
-					),
-				})
+			const result = computeActiveTimeSessions(
+				allTasks,
+				(task) => this.plugin.getActiveTimeSession(task)
 			);
+			this.sendResponse(res, 200, this.successResponse(result));
 		} catch (error: any) {
 			this.sendResponse(res, 500, this.errorResponse(error.message));
 		}
@@ -208,145 +173,17 @@ export class TimeTrackingController extends BaseController {
 			const query = parsedUrl.query;
 
 			const allTasks = await this.cacheManager.getAllTasks();
-			const period = query.period || "today"; // today, week, month, all
+			const period = (query.period as string) || "today";
 			const fromDate = query.from ? new Date(query.from as string) : null;
 			const toDate = query.to ? new Date(query.to as string) : null;
 
-			// Calculate date range based on period
-			let startDate: Date;
-			let endDate: Date = new Date();
-
-			switch (period) {
-				case "today":
-					startDate = new Date();
-					startDate.setHours(0, 0, 0, 0);
-					break;
-				case "week":
-					startDate = new Date();
-					startDate.setDate(startDate.getDate() - startDate.getDay()); // Start of week
-					startDate.setHours(0, 0, 0, 0);
-					break;
-				case "month":
-					startDate = new Date();
-					startDate.setDate(1); // Start of month
-					startDate.setHours(0, 0, 0, 0);
-					break;
-				case "all":
-					startDate = new Date(0); // Beginning of time
-					break;
-				default:
-					if (fromDate) {
-						startDate = fromDate;
-						if (toDate) endDate = toDate;
-					} else {
-						startDate = new Date();
-						startDate.setHours(0, 0, 0, 0);
-					}
-			}
-
-			let totalMinutes = 0;
-			let completedTasks = 0;
-			let activeTasks = 0;
-			const taskStats: Array<{ task: string; title: string; minutes: number }> = [];
-			const projectStats = new Map<string, number>();
-			const tagStats = new Map<string, number>();
-
-			for (const task of allTasks) {
-				if (!task.timeEntries || task.timeEntries.length === 0) continue;
-
-				let taskMinutes = 0;
-				let hasActiveSession = false;
-
-				for (const entry of task.timeEntries) {
-					const entryStart = new Date(entry.startTime);
-					const entryEnd = entry.endTime ? new Date(entry.endTime) : new Date();
-
-					// Check if entry is in date range
-					if (entryStart >= startDate && entryStart <= endDate) {
-						if (entry.duration) {
-							taskMinutes += entry.duration;
-						} else if (!entry.endTime) {
-							// Active session
-							const elapsedMinutes = Math.floor(
-								(Date.now() - entryStart.getTime()) / (1000 * 60)
-							);
-							taskMinutes += elapsedMinutes;
-							hasActiveSession = true;
-						} else {
-							// Calculate duration from start/end times
-							const durationMs = entryEnd.getTime() - entryStart.getTime();
-							taskMinutes += Math.floor(durationMs / (1000 * 60));
-						}
-					}
-				}
-
-				if (taskMinutes > 0) {
-					totalMinutes += taskMinutes;
-					taskStats.push({
-						task: task.path,
-						title: task.title,
-						minutes: taskMinutes,
-					});
-
-					if (hasActiveSession) {
-						activeTasks++;
-					} else if (this.statusManager.isCompletedStatus(task.status)) {
-						completedTasks++;
-					}
-
-					// Aggregate by projects
-					if (task.projects) {
-						for (const project of task.projects) {
-							const current = projectStats.get(project) || 0;
-							projectStats.set(project, current + taskMinutes);
-						}
-					}
-
-					// Aggregate by tags
-					if (task.tags) {
-						for (const tag of task.tags) {
-							const current = tagStats.get(tag) || 0;
-							tagStats.set(tag, current + taskMinutes);
-						}
-					}
-				}
-			}
-
-			// Sort and limit results
-			taskStats.sort((a, b) => b.minutes - a.minutes);
-			const topTasks = taskStats.slice(0, 10);
-
-			const topProjects = Array.from(projectStats.entries())
-				.sort((a, b) => b[1] - a[1])
-				.slice(0, 10)
-				.map(([project, minutes]) => ({ project, minutes }));
-
-			const topTags = Array.from(tagStats.entries())
-				.sort((a, b) => b[1] - a[1])
-				.slice(0, 10)
-				.map(([tag, minutes]) => ({ tag, minutes }));
-
-			this.sendResponse(
-				res,
-				200,
-				this.successResponse({
-					period,
-					dateRange: {
-						from: startDate.toISOString(),
-						to: endDate.toISOString(),
-					},
-					summary: {
-						totalMinutes,
-						totalHours: Math.round((totalMinutes / 60) * 100) / 100,
-						tasksWithTime: taskStats.length,
-						activeTasks,
-						completedTasks,
-					},
-					topTasks,
-					topProjects,
-					topTags,
-				})
+			const result = computeTimeSummary(
+				allTasks,
+				{ period, fromDate, toDate, includeTags: true },
+				(status) => this.statusManager.isCompletedStatus(status)
 			);
+
+			this.sendResponse(res, 200, this.successResponse(result));
 		} catch (error: any) {
 			this.sendResponse(res, 500, this.errorResponse(error.message));
 		}
@@ -372,96 +209,13 @@ export class TimeTrackingController extends BaseController {
 				return;
 			}
 
-			const timeEntries = task.timeEntries || [];
-			const activeSession = this.plugin.getActiveTimeSession(task);
-			const totalMinutes = this.calculateTotalTimeSpent(timeEntries);
-
-			// Calculate session statistics
-			const completedSessions = timeEntries.filter((entry) => entry.endTime).length;
-			const activeSessions = activeSession ? 1 : 0;
-
-			// Calculate average session length (completed sessions only)
-			const completedEntries = timeEntries.filter((entry) => entry.endTime && entry.duration);
-			const averageSessionMinutes =
-				completedEntries.length > 0
-					? Math.round(
-							(completedEntries.reduce(
-								(sum, entry) => sum + (entry.duration || 0),
-								0
-							) /
-								completedEntries.length) *
-								100
-						) / 100
-					: 0;
-
-			this.sendResponse(
-				res,
-				200,
-				this.successResponse({
-					task: {
-						id: task.path,
-						title: task.title,
-						status: task.status,
-						priority: task.priority,
-					},
-					summary: {
-						totalMinutes,
-						totalHours: Math.round((totalMinutes / 60) * 100) / 100,
-						totalSessions: timeEntries.length,
-						completedSessions,
-						activeSessions,
-						averageSessionMinutes,
-					},
-					activeSession: activeSession
-						? {
-								startTime: activeSession.startTime,
-								description: activeSession.description,
-								elapsedMinutes: Math.floor(
-									(Date.now() - new Date(activeSession.startTime).getTime()) /
-										(1000 * 60)
-								),
-							}
-						: null,
-					timeEntries: timeEntries.map((entry) => ({
-						startTime: entry.startTime,
-						endTime: entry.endTime || null,
-						description: entry.description || null,
-						duration:
-							entry.duration ||
-							(entry.endTime
-								? Math.floor(
-										(new Date(entry.endTime).getTime() -
-											new Date(entry.startTime).getTime()) /
-											(1000 * 60)
-									)
-								: Math.floor(
-										(Date.now() - new Date(entry.startTime).getTime()) /
-											(1000 * 60)
-									)),
-						isActive: !entry.endTime,
-					})),
-				})
+			const result = computeTaskTimeData(
+				task,
+				(t) => this.plugin.getActiveTimeSession(t)
 			);
+			this.sendResponse(res, 200, this.successResponse(result));
 		} catch (error: any) {
 			this.sendResponse(res, 500, this.errorResponse(error.message));
 		}
-	}
-
-	private calculateTotalTimeSpent(timeEntries: any[]): number {
-		if (!timeEntries || timeEntries.length === 0) return 0;
-
-		return timeEntries.reduce((total, entry) => {
-			if (entry.duration) {
-				return total + entry.duration;
-			} else if (entry.endTime) {
-				const durationMs =
-					new Date(entry.endTime).getTime() - new Date(entry.startTime).getTime();
-				return total + Math.floor(durationMs / (1000 * 60));
-			} else {
-				// Active session
-				const elapsedMs = Date.now() - new Date(entry.startTime).getTime();
-				return total + Math.floor(elapsedMs / (1000 * 60));
-			}
-		}, 0);
 	}
 }

--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -1856,6 +1856,12 @@ export const en: TranslationTree = {
 					description: "Token required for API authentication (leave empty for no auth)",
 					placeholder: "your-secret-token",
 				},
+				mcp: {
+					enable: {
+						name: "Enable MCP Server",
+						description: "Expose TaskNotes tools via Model Context Protocol at /mcp endpoint. Requires HTTP API to be enabled.",
+					},
+				},
 				endpoints: {
 					header: "Available API Endpoints",
 					expandIcon: "▶",

--- a/src/main.ts
+++ b/src/main.ts
@@ -352,7 +352,7 @@ export default class TaskNotesPlugin extends Plugin {
 			this.priorityManager,
 			this
 		);
-		this.taskStatsService = new TaskStatsService(this.cacheManager);
+		this.taskStatsService = new TaskStatsService(this.cacheManager, this.statusManager);
 		this.viewStateManager = new ViewStateManager(this.app, this);
 		this.projectSubtasksService = new ProjectSubtasksService(this);
 		this.expandedProjectsService = new ExpandedProjectsService(this);
@@ -1237,6 +1237,9 @@ export default class TaskNotesPlugin extends Plugin {
 		}
 		if (loadedData && typeof loadedData.apiAuthToken === "undefined") {
 			loadedData.apiAuthToken = "";
+		}
+		if (loadedData && typeof loadedData.enableMCP === "undefined") {
+			loadedData.enableMCP = false;
 		}
 
 		// Migration: Migrate statusSuggestionTrigger to nlpTriggers if needed

--- a/src/services/MCPService.ts
+++ b/src/services/MCPService.ts
@@ -1,0 +1,832 @@
+/* eslint-disable no-console */
+import { IncomingMessage, ServerResponse } from "http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { z } from "zod";
+
+import TaskNotesPlugin from "../main";
+import { TaskService } from "./TaskService";
+import { FilterService } from "./FilterService";
+import { TaskManager } from "../utils/TaskManager";
+import { StatusManager } from "./StatusManager";
+import { NaturalLanguageParser } from "./NaturalLanguageParser";
+import { TaskStatsService } from "./TaskStatsService";
+import {
+	TaskCreationData,
+	FilterQuery,
+	FilterCondition,
+	FilterGroup,
+	IWebhookNotifier,
+} from "../types";
+import {
+	computeActiveTimeSessions,
+	computeTimeSummary,
+	computeTaskTimeData,
+} from "../utils/timeTrackingUtils";
+import { collectCalendarEvents } from "../utils/calendarUtils";
+
+/**
+ * MCP (Model Context Protocol) server for TaskNotes.
+ *
+ * Exposes task management, time tracking, pomodoro, and calendar tools
+ * via the Streamable HTTP transport in stateless mode.
+ */
+export class MCPService {
+	constructor(
+		private plugin: TaskNotesPlugin,
+		private taskService: TaskService,
+		private filterService: FilterService,
+		private cacheManager: TaskManager,
+		private statusManager: StatusManager,
+		private nlParser: NaturalLanguageParser,
+		private taskStatsService: TaskStatsService,
+		private webhookNotifier: IWebhookNotifier
+	) {}
+
+	/** Handle an incoming MCP-over-HTTP request. */
+	async handleRequest(
+		req: IncomingMessage,
+		res: ServerResponse,
+		parsedBody: Record<string, unknown>
+	): Promise<void> {
+		if (req.method !== "POST") {
+			res.writeHead(405, { Allow: "POST" });
+			res.end(
+				JSON.stringify({
+					jsonrpc: "2.0",
+					error: { code: -32000, message: "Method not allowed" },
+					id: null,
+				})
+			);
+			return;
+		}
+
+		try {
+			const transport = new StreamableHTTPServerTransport({
+				sessionIdGenerator: undefined, // stateless mode
+			});
+			const server = new McpServer({
+				name: "tasknotes",
+				version: this.plugin.manifest.version,
+			});
+
+			this.registerTools(server);
+
+			await server.connect(transport);
+			await transport.handleRequest(req, res, parsedBody);
+
+			// Close transport after handling the request in stateless mode
+			await transport.close();
+			await server.close();
+		} catch (error: any) {
+			console.error("MCP request error:", error);
+			if (!res.headersSent) {
+				res.writeHead(500, { "Content-Type": "application/json" });
+				res.end(
+					JSON.stringify({
+						jsonrpc: "2.0",
+						error: { code: -32603, message: "Internal error" },
+						id: null,
+					})
+				);
+			}
+		}
+	}
+
+	private registerTools(server: McpServer): void {
+		this.registerTaskTools(server);
+		this.registerFilterTools(server);
+		this.registerTimeTrackingTools(server);
+		this.registerPomodoroTools(server);
+		this.registerCalendarTools(server);
+		this.registerSystemTools(server);
+	}
+
+	// Task Tools
+
+	private registerTaskTools(server: McpServer): void {
+		// @ts-expect-error TS2589 - McpServer.tool() type instantiation too deep with optional Zod params
+		server.tool(
+			"tasknotes_list_tasks",
+			"List all tasks with optional pagination",
+			{
+				limit: z.number().optional().describe("Max tasks to return"),
+				offset: z.number().optional().describe("Number of tasks to skip"),
+			},
+			async ({ limit, offset }) => {
+				try {
+					const allTasks = await this.cacheManager.getAllTasks();
+					const start = offset ?? 0;
+					const end = limit ? start + limit : undefined;
+					const tasks = allTasks.slice(start, end);
+
+					return {
+						content: [{
+							type: "text" as const,
+							text: JSON.stringify({
+								tasks,
+								total: allTasks.length,
+								offset: start,
+								returned: tasks.length,
+							}),
+						}],
+					};
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_get_task",
+			"Get a single task by its file path ID",
+			{ id: z.string().describe("Task file path (e.g. 'tasks/My Task.md')") },
+			async ({ id }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+					return this.jsonResult(task);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		// @ts-expect-error TS2589 - McpServer.tool() type instantiation too deep with optional Zod params
+		server.tool(
+			"tasknotes_create_task",
+			"Create a new task",
+			{
+				title: z.string().describe("Task title"),
+				status: z.string().optional().describe("Task status (e.g. 'open', 'in-progress', 'done')"),
+				priority: z.string().optional().describe("Task priority (e.g. 'low', 'normal', 'high', 'urgent')"),
+				due: z.string().optional().describe("Due date (YYYY-MM-DD)"),
+				scheduled: z.string().optional().describe("Scheduled date (YYYY-MM-DD)"),
+				tags: z.array(z.string()).optional().describe("Tags"),
+				contexts: z.array(z.string()).optional().describe("Contexts"),
+				projects: z.array(z.string()).optional().describe("Projects"),
+				recurrence: z.string().optional().describe("RFC 5545 recurrence rule"),
+				timeEstimate: z.number().optional().describe("Time estimate in minutes"),
+				details: z.string().optional().describe("Task body/description"),
+			},
+			async (args) => {
+				try {
+					const taskData: TaskCreationData = {
+						title: args.title,
+						path: "",
+						archived: false,
+						status: args.status || this.plugin.settings.defaultTaskStatus,
+						priority: args.priority || this.plugin.settings.defaultTaskPriority,
+						due: args.due,
+						scheduled: args.scheduled,
+						tags: args.tags,
+						contexts: args.contexts,
+						projects: args.projects,
+						recurrence: args.recurrence,
+						timeEstimate: args.timeEstimate,
+						details: args.details,
+						creationContext: "api",
+					};
+					const result = await this.taskService.createTask(taskData);
+
+					await this.webhookNotifier.triggerWebhook("task.created", {
+						task: result.taskInfo,
+					});
+
+					return this.jsonResult(result.taskInfo);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		// @ts-expect-error TS2589 - McpServer.tool() type instantiation too deep with optional Zod params
+		server.tool(
+			"tasknotes_update_task",
+			"Update an existing task's properties",
+			{
+				id: z.string().describe("Task file path"),
+				title: z.string().optional().describe("New title"),
+				status: z.string().optional().describe("New status"),
+				priority: z.string().optional().describe("New priority"),
+				due: z.string().nullable().optional().describe("New due date (YYYY-MM-DD) or null to clear"),
+				scheduled: z.string().nullable().optional().describe("New scheduled date (YYYY-MM-DD) or null to clear"),
+				tags: z.array(z.string()).optional().describe("New tags"),
+				contexts: z.array(z.string()).optional().describe("New contexts"),
+				projects: z.array(z.string()).optional().describe("New projects"),
+				recurrence: z.string().nullable().optional().describe("New recurrence rule or null to clear"),
+				timeEstimate: z.number().nullable().optional().describe("New time estimate in minutes or null to clear"),
+				details: z.string().optional().describe("New body/description"),
+			},
+			async ({ id, ...updates }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+
+					// Build updates object, filtering out undefined values
+					const cleanUpdates: Record<string, any> = {};
+					for (const [key, value] of Object.entries(updates)) {
+						if (value !== undefined) {
+							cleanUpdates[key] = value;
+						}
+					}
+
+					const updatedTask = await this.taskService.updateTask(task, cleanUpdates);
+
+					await this.webhookNotifier.triggerWebhook("task.updated", {
+						task: updatedTask,
+						previous: task,
+					});
+
+					return this.jsonResult(updatedTask);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_delete_task",
+			"Permanently delete a task file",
+			{ id: z.string().describe("Task file path") },
+			async ({ id }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+					await this.taskService.deleteTask(task);
+
+					await this.webhookNotifier.triggerWebhook("task.deleted", { task });
+
+					return this.jsonResult({ deleted: true, id });
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_toggle_status",
+			"Toggle a task's status through the status cycle",
+			{ id: z.string().describe("Task file path") },
+			async ({ id }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+					const updatedTask = await this.taskService.toggleStatus(task);
+
+					const wasCompleted = this.statusManager.isCompletedStatus(task.status);
+					const isCompleted = this.statusManager.isCompletedStatus(updatedTask.status);
+
+					if (!wasCompleted && isCompleted) {
+						await this.webhookNotifier.triggerWebhook("task.completed", {
+							task: updatedTask,
+						});
+					} else {
+						await this.webhookNotifier.triggerWebhook("task.updated", {
+							task: updatedTask,
+							previous: task,
+						});
+					}
+
+					return this.jsonResult(updatedTask);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_toggle_archive",
+			"Toggle a task's archived state",
+			{ id: z.string().describe("Task file path") },
+			async ({ id }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+					const updatedTask = await this.taskService.toggleArchive(task);
+
+					if (updatedTask.archived) {
+						await this.webhookNotifier.triggerWebhook("task.archived", {
+							task: updatedTask,
+						});
+					} else {
+						await this.webhookNotifier.triggerWebhook("task.unarchived", {
+							task: updatedTask,
+						});
+					}
+
+					return this.jsonResult(updatedTask);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_complete_recurring_instance",
+			"Mark a recurring task as completed for a specific date",
+			{
+				id: z.string().describe("Task file path"),
+				date: z.string().optional().describe("Date to mark complete (YYYY-MM-DD), defaults to today"),
+			},
+			async ({ id, date }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+					const targetDate = date ? new Date(date) : undefined;
+					const updatedTask = await this.taskService.toggleRecurringTaskComplete(
+						task,
+						targetDate
+					);
+
+					await this.webhookNotifier.triggerWebhook("task.updated", {
+						task: updatedTask,
+						previous: task,
+					});
+
+					return this.jsonResult(updatedTask);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_create_task_from_text",
+			"Create a task by parsing natural language text (e.g. 'Buy groceries tomorrow #shopping @home')",
+			{ text: z.string().describe("Natural language task description") },
+			async ({ text }) => {
+				try {
+					const parsed = this.nlParser.parseInput(text);
+					const taskData: TaskCreationData = {
+						title: parsed.title,
+						path: "",
+						archived: false,
+						status: parsed.status || this.plugin.settings.defaultTaskStatus,
+						priority: parsed.priority || this.plugin.settings.defaultTaskPriority,
+						due: parsed.dueDate,
+						scheduled: parsed.scheduledDate,
+						tags: parsed.tags,
+						contexts: parsed.contexts,
+						projects: parsed.projects,
+						recurrence: parsed.recurrence,
+						timeEstimate: parsed.estimate,
+						details: parsed.details,
+						creationContext: "api",
+					};
+					const result = await this.taskService.createTask(taskData);
+
+					await this.webhookNotifier.triggerWebhook("task.created", {
+						task: result.taskInfo,
+					});
+
+					return this.jsonResult({ parsed, task: result.taskInfo });
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+	}
+
+	// Filter Tools
+
+	private registerFilterTools(server: McpServer): void {
+		// Define the recursive filter schema
+		const filterConditionSchema: z.ZodType<FilterCondition> = z.object({
+			type: z.literal("condition"),
+			id: z.string(),
+			property: z.string().describe("Filter property (e.g. 'status', 'priority', 'due', 'tags', 'projects', 'contexts')"),
+			operator: z.string().describe("Filter operator (e.g. 'is', 'is_not', 'contains', 'before', 'after', 'is_empty')"),
+			value: z.union([z.string(), z.array(z.string()), z.number(), z.boolean(), z.null()]),
+		}) as any;
+
+		const filterGroupSchema: z.ZodType<FilterGroup> = z.lazy(() =>
+			z.object({
+				type: z.literal("group"),
+				id: z.string(),
+				conjunction: z.enum(["and", "or"]),
+				children: z.array(z.union([filterConditionSchema, filterGroupSchema])),
+			})
+		) as any;
+
+		server.tool(
+			"tasknotes_query_tasks",
+			"Query tasks using advanced filters with AND/OR logic, sorting, and grouping",
+			{
+				conjunction: z.enum(["and", "or"]).describe("How to combine filter conditions"),
+				children: z.array(z.union([
+					z.object({
+						type: z.literal("condition"),
+						id: z.string(),
+						property: z.string(),
+						operator: z.string(),
+						value: z.union([z.string(), z.array(z.string()), z.number(), z.boolean(), z.null()]),
+					}),
+					filterGroupSchema,
+				])).describe("Filter conditions or nested groups"),
+				sortKey: z.string().optional().describe("Sort by field (e.g. 'due', 'priority', 'title', 'status')"),
+				sortDirection: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+				groupKey: z.string().optional().describe("Group by field (e.g. 'priority', 'status', 'projects')"),
+			} as any,
+			async (args: any) => {
+				try {
+					const query: FilterQuery = {
+						type: "group",
+						id: "mcp-root",
+						conjunction: args.conjunction,
+						children: args.children as any,
+						sortKey: args.sortKey as any,
+						sortDirection: args.sortDirection,
+						groupKey: args.groupKey as any,
+					};
+
+					const grouped = await this.filterService.getGroupedTasks(query);
+					const result: Record<string, any[]> = {};
+					for (const [key, tasks] of grouped) {
+						result[key] = tasks;
+					}
+					return this.jsonResult(result);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_get_filter_options",
+			"Get available filter options (statuses, priorities, tags, contexts, projects)",
+			{},
+			async () => {
+				try {
+					const options = await this.filterService.getFilterOptions();
+					return this.jsonResult(options);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_get_stats",
+			"Get task statistics (counts by status, priority, overdue, etc.)",
+			{},
+			async () => {
+				try {
+					const allTasks = await this.cacheManager.getAllTasks();
+					const stats = this.taskStatsService.getStats(allTasks);
+					return this.jsonResult(stats);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+	}
+
+	// Time Tracking Tools
+
+	private registerTimeTrackingTools(server: McpServer): void {
+		server.tool(
+			"tasknotes_start_time_tracking",
+			"Start a time tracking session on a task",
+			{
+				id: z.string().describe("Task file path"),
+				description: z.string().optional().describe("Description for the time session"),
+			},
+			async ({ id, description }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+
+					let updatedTask = await this.taskService.startTimeTracking(task);
+
+					// If description was provided, update the latest time entry
+					if (description && updatedTask.timeEntries && updatedTask.timeEntries.length > 0) {
+						const latestEntry = updatedTask.timeEntries[updatedTask.timeEntries.length - 1];
+						if (latestEntry && !latestEntry.endTime) {
+							latestEntry.description = description;
+							updatedTask = await this.taskService.updateTask(updatedTask, {
+								timeEntries: updatedTask.timeEntries,
+							});
+						}
+					}
+
+					await this.webhookNotifier.triggerWebhook("time.started", {
+						task: updatedTask,
+						session: updatedTask.timeEntries?.[updatedTask.timeEntries.length - 1],
+					});
+
+					return this.jsonResult(updatedTask);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_stop_time_tracking",
+			"Stop the active time tracking session on a task",
+			{ id: z.string().describe("Task file path") },
+			async ({ id }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+					const updatedTask = await this.taskService.stopTimeTracking(task);
+
+					await this.webhookNotifier.triggerWebhook("time.stopped", {
+						task: updatedTask,
+						session: updatedTask.timeEntries?.[updatedTask.timeEntries.length - 1],
+					});
+
+					return this.jsonResult(updatedTask);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_get_active_time_sessions",
+			"Get all tasks with currently running time tracking sessions",
+			{},
+			async () => {
+				try {
+					const allTasks = await this.cacheManager.getAllTasks();
+					const result = computeActiveTimeSessions(
+						allTasks,
+						(task) => this.plugin.getActiveTimeSession(task)
+					);
+					return this.jsonResult(result);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		// @ts-expect-error TS2589 - McpServer.tool() type instantiation too deep with optional Zod params
+		server.tool(
+			"tasknotes_get_time_summary",
+			"Get time tracking summary for a period",
+			{
+				period: z.enum(["today", "week", "month", "all"]).optional().describe("Time period (default: today)"),
+				from: z.string().optional().describe("Start date (ISO string) for custom range"),
+				to: z.string().optional().describe("End date (ISO string) for custom range"),
+			},
+			async ({ period: periodArg, from, to }) => {
+				try {
+					const allTasks = await this.cacheManager.getAllTasks();
+					const period = periodArg || "today";
+					const fromDate = from ? new Date(from) : null;
+					const toDate = to ? new Date(to) : null;
+
+					const result = computeTimeSummary(
+						allTasks,
+						{ period, fromDate, toDate, includeTags: false },
+						(status) => this.statusManager.isCompletedStatus(status)
+					);
+
+					return this.jsonResult(result);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_get_task_time_data",
+			"Get detailed time tracking data for a specific task",
+			{ id: z.string().describe("Task file path") },
+			async ({ id }) => {
+				try {
+					const task = await this.cacheManager.getTaskInfo(id);
+					if (!task) {
+						return this.errorResult("Task not found");
+					}
+
+					const result = computeTaskTimeData(
+						task,
+						(t) => this.plugin.getActiveTimeSession(t)
+					);
+					return this.jsonResult(result);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+	}
+
+	// Pomodoro Tools
+
+	private registerPomodoroTools(server: McpServer): void {
+		server.tool(
+			"tasknotes_start_pomodoro",
+			"Start a pomodoro timer, optionally linked to a task",
+			{
+				taskId: z.string().optional().describe("Task file path to associate with this pomodoro"),
+				duration: z.number().optional().describe("Duration in minutes (default: work duration from settings)"),
+			},
+			async ({ taskId, duration }) => {
+				try {
+					let task;
+					if (taskId) {
+						task = await this.cacheManager.getTaskInfo(taskId);
+						if (!task) {
+							return this.errorResult("Task not found");
+						}
+					}
+
+					const currentState = this.plugin.pomodoroService.getState();
+					if (currentState.isRunning) {
+						return this.errorResult(
+							"Pomodoro session is already running. Stop or pause the current session first."
+						);
+					}
+
+					await this.plugin.pomodoroService.startPomodoro(task, duration);
+					const newState = this.plugin.pomodoroService.getState();
+
+					return this.jsonResult({
+						session: newState.currentSession,
+						task: task || null,
+						message: "Pomodoro session started",
+					});
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_stop_pomodoro",
+			"Stop and reset the current pomodoro session",
+			{},
+			async () => {
+				try {
+					const currentState = this.plugin.pomodoroService.getState();
+					if (!currentState.currentSession) {
+						return this.errorResult("No active pomodoro session to stop");
+					}
+					await this.plugin.pomodoroService.stopPomodoro();
+					return this.jsonResult({ message: "Pomodoro session stopped and reset" });
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_pause_pomodoro",
+			"Pause the running pomodoro timer",
+			{},
+			async () => {
+				try {
+					const currentState = this.plugin.pomodoroService.getState();
+					if (!currentState.isRunning || !currentState.currentSession) {
+						return this.errorResult("No running pomodoro session to pause");
+					}
+					await this.plugin.pomodoroService.pausePomodoro();
+					const newState = this.plugin.pomodoroService.getState();
+					return this.jsonResult({
+						timeRemaining: newState.timeRemaining,
+						message: "Pomodoro session paused",
+					});
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_resume_pomodoro",
+			"Resume a paused pomodoro timer",
+			{},
+			async () => {
+				try {
+					const currentState = this.plugin.pomodoroService.getState();
+					if (currentState.isRunning) {
+						return this.errorResult("Pomodoro session is already running");
+					}
+					if (!currentState.currentSession) {
+						return this.errorResult("No paused session to resume");
+					}
+					await this.plugin.pomodoroService.resumePomodoro();
+					const newState = this.plugin.pomodoroService.getState();
+					return this.jsonResult({
+						timeRemaining: newState.timeRemaining,
+						message: "Pomodoro session resumed",
+					});
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+
+		server.tool(
+			"tasknotes_get_pomodoro_status",
+			"Get the current pomodoro timer status including stats",
+			{},
+			async () => {
+				try {
+					const state = this.plugin.pomodoroService.getState();
+					const enhancedState = {
+						...state,
+						totalPomodoros: await this.plugin.pomodoroService.getPomodorosCompleted(),
+						currentStreak: await this.plugin.pomodoroService.getCurrentStreak(),
+						totalMinutesToday: await this.plugin.pomodoroService.getTotalMinutesToday(),
+					};
+					return this.jsonResult(enhancedState);
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+	}
+
+	// Calendar Tools
+
+	private registerCalendarTools(server: McpServer): void {
+		server.tool(
+			"tasknotes_get_calendar_events",
+			"Get calendar events from all connected providers (Google, Microsoft, ICS subscriptions)",
+			{
+				start: z.string().optional().describe("Start date filter (ISO string)"),
+				end: z.string().optional().describe("End date filter (ISO string)"),
+			},
+			async ({ start, end }) => {
+				try {
+					const startDate = start ? new Date(start) : null;
+					const endDate = end ? new Date(end) : null;
+
+					const result = collectCalendarEvents(
+						this.plugin.calendarProviderRegistry,
+						this.plugin.icsSubscriptionService ?? null,
+						{ start: startDate, end: endDate }
+					);
+
+					return this.jsonResult({
+						events: result.events,
+						total: result.total,
+					});
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+	}
+
+	// System Tools
+
+	private registerSystemTools(server: McpServer): void {
+		server.tool(
+			"tasknotes_health_check",
+			"Check if the TaskNotes MCP server is running and return vault info",
+			{},
+			async () => {
+				try {
+					const vaultName = this.plugin.app.vault.getName();
+					const vaultPath =
+						(this.plugin.app.vault.adapter as any).basePath || "unknown";
+					return this.jsonResult({
+						status: "ok",
+						vault: vaultName,
+						vaultPath,
+						version: this.plugin.manifest.version,
+						timestamp: new Date().toISOString(),
+					});
+				} catch (error: any) {
+					return this.errorResult(error.message);
+				}
+			}
+		);
+	}
+
+	// Helpers
+
+	private jsonResult(data: unknown) {
+		return {
+			content: [{ type: "text" as const, text: JSON.stringify(data) }],
+		};
+	}
+
+	private errorResult(message: string) {
+		return {
+			content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
+			isError: true,
+		};
+	}
+}

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -350,6 +350,7 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	enableAPI: false,
 	apiPort: 8080,
 	apiAuthToken: "",
+	enableMCP: false,
 	// Webhook defaults
 	webhooks: [],
 	// User Fields defaults (multiple)

--- a/src/settings/tabs/integrationsTab.ts
+++ b/src/settings/tabs/integrationsTab.ts
@@ -1402,6 +1402,18 @@ export function renderIntegrationsTab(
 							},
 						})
 					);
+
+					group.addSetting((setting) =>
+						configureToggleSetting(setting, {
+							name: translate("settings.integrations.httpApi.mcp.enable.name"),
+							desc: translate("settings.integrations.httpApi.mcp.enable.description"),
+							getValue: () => plugin.settings.enableMCP,
+							setValue: async (value: boolean) => {
+								plugin.settings.enableMCP = value;
+								save();
+							},
+						})
+					);
 				}
 			}
 		);

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -187,6 +187,7 @@ export interface TaskNotesSettings {
 	enableAPI: boolean;
 	apiPort: number;
 	apiAuthToken: string;
+	enableMCP: boolean;
 	// Webhook settings
 	webhooks: WebhookConfig[];
 	// User-defined field mappings (optional)

--- a/src/utils/calendarUtils.ts
+++ b/src/utils/calendarUtils.ts
@@ -1,0 +1,83 @@
+import { ICSEvent } from "../types";
+import { CalendarProviderRegistry } from "../services/CalendarProvider";
+import { ICSSubscriptionService } from "../services/ICSSubscriptionService";
+
+export interface CollectedCalendarEvents {
+	events: (ICSEvent & { provider: string })[];
+	total: number;
+	sources: Record<string, number>;
+}
+
+export function isEventInRange(
+	event: ICSEvent,
+	startDate: Date | null,
+	endDate: Date | null
+): boolean {
+	if (!startDate && !endDate) {
+		return true;
+	}
+
+	const eventStart = new Date(event.start);
+	const eventEnd = event.end ? new Date(event.end) : eventStart;
+
+	if (startDate && eventEnd < startDate) {
+		return false;
+	}
+	if (endDate && eventStart > endDate) {
+		return false;
+	}
+
+	return true;
+}
+
+export function getProviderFromSubscriptionId(subscriptionId: string): string {
+	if (subscriptionId.startsWith("google-")) {
+		return "google";
+	}
+	if (subscriptionId.startsWith("microsoft-")) {
+		return "microsoft";
+	}
+	return "unknown";
+}
+
+export function collectCalendarEvents(
+	providerRegistry: CalendarProviderRegistry,
+	icsService: ICSSubscriptionService | null,
+	options: { start?: Date | null; end?: Date | null }
+): CollectedCalendarEvents {
+	const startDate = options.start ?? null;
+	const endDate = options.end ?? null;
+
+	const allEvents: (ICSEvent & { provider: string })[] = [];
+	const sources: Record<string, number> = {};
+
+	// Events from OAuth providers (Google, Microsoft)
+	const providerEvents = providerRegistry.getAllEvents();
+	for (const event of providerEvents) {
+		const provider = getProviderFromSubscriptionId(event.subscriptionId);
+		if (isEventInRange(event, startDate, endDate)) {
+			allEvents.push({ ...event, provider });
+			sources[provider] = (sources[provider] || 0) + 1;
+		}
+	}
+
+	// Events from ICS subscriptions
+	if (icsService) {
+		const icsEvents = icsService.getAllEvents();
+		for (const event of icsEvents) {
+			if (isEventInRange(event, startDate, endDate)) {
+				allEvents.push({ ...event, provider: "ics" });
+				sources["ics"] = (sources["ics"] || 0) + 1;
+			}
+		}
+	}
+
+	// Sort events by start time
+	allEvents.sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+
+	return {
+		events: allEvents,
+		total: allEvents.length,
+		sources,
+	};
+}

--- a/src/utils/timeTrackingUtils.ts
+++ b/src/utils/timeTrackingUtils.ts
@@ -1,0 +1,341 @@
+import { TaskInfo, TimeEntry } from "../types";
+
+export interface ActiveSessionInfo {
+	task: {
+		id: string;
+		title: string;
+		status: string;
+		priority: string;
+		tags: string[];
+		projects: string[];
+	};
+	session: {
+		startTime: string;
+		description?: string;
+		elapsedMinutes: number;
+	};
+	elapsedMinutes: number;
+}
+
+export interface ActiveSessionsResult {
+	activeSessions: ActiveSessionInfo[];
+	totalActiveSessions: number;
+	totalElapsedMinutes: number;
+}
+
+export interface TimeSummaryOptions {
+	period: string;
+	fromDate: Date | null;
+	toDate: Date | null;
+	includeTags?: boolean;
+}
+
+export interface TimeSummaryResult {
+	period: string;
+	dateRange: { from: string; to: string };
+	summary: {
+		totalMinutes: number;
+		totalHours: number;
+		tasksWithTime: number;
+		activeTasks: number;
+		completedTasks: number;
+	};
+	topTasks: Array<{ task: string; title: string; minutes: number }>;
+	topProjects: Array<{ project: string; minutes: number }>;
+	topTags?: Array<{ tag: string; minutes: number }>;
+}
+
+export interface TaskTimeDataResult {
+	task: {
+		id: string;
+		title: string;
+		status: string;
+		priority: string;
+	};
+	summary: {
+		totalMinutes: number;
+		totalHours: number;
+		totalSessions: number;
+		completedSessions: number;
+		activeSessions: number;
+		averageSessionMinutes: number;
+	};
+	activeSession: {
+		startTime: string;
+		description?: string;
+		elapsedMinutes: number;
+	} | null;
+	timeEntries: Array<{
+		startTime: string;
+		endTime: string | null;
+		description: string | null;
+		duration: number;
+		isActive: boolean;
+	}>;
+}
+
+export function calculateTotalTimeSpent(timeEntries: TimeEntry[]): number {
+	if (!timeEntries || timeEntries.length === 0) return 0;
+
+	return timeEntries.reduce((total, entry) => {
+		if (entry.duration) {
+			return total + entry.duration;
+		} else if (entry.endTime) {
+			const durationMs =
+				new Date(entry.endTime).getTime() - new Date(entry.startTime).getTime();
+			return total + Math.floor(durationMs / (1000 * 60));
+		} else {
+			// Active session
+			const elapsedMs = Date.now() - new Date(entry.startTime).getTime();
+			return total + Math.floor(elapsedMs / (1000 * 60));
+		}
+	}, 0);
+}
+
+export function computeActiveTimeSessions(
+	tasks: TaskInfo[],
+	getActiveSession: (task: TaskInfo) => TimeEntry | null
+): ActiveSessionsResult {
+	const activeSessions: ActiveSessionInfo[] = [];
+
+	for (const task of tasks) {
+		const activeEntry = getActiveSession(task);
+		if (activeEntry) {
+			const startTime = new Date(activeEntry.startTime);
+			const elapsedMinutes = Math.floor(
+				(Date.now() - startTime.getTime()) / (1000 * 60)
+			);
+
+			activeSessions.push({
+				task: {
+					id: task.path,
+					title: task.title,
+					status: task.status,
+					priority: task.priority,
+					tags: task.tags || [],
+					projects: task.projects || [],
+				},
+				session: {
+					startTime: activeEntry.startTime,
+					description: activeEntry.description,
+					elapsedMinutes,
+				},
+				elapsedMinutes,
+			});
+		}
+	}
+
+	return {
+		activeSessions,
+		totalActiveSessions: activeSessions.length,
+		totalElapsedMinutes: activeSessions.reduce(
+			(sum, session) => sum + session.elapsedMinutes,
+			0
+		),
+	};
+}
+
+function computeDateRange(options: TimeSummaryOptions): { startDate: Date; endDate: Date } {
+	let startDate: Date;
+	let endDate: Date = new Date();
+
+	switch (options.period) {
+		case "today":
+			startDate = new Date();
+			startDate.setHours(0, 0, 0, 0);
+			break;
+		case "week":
+			startDate = new Date();
+			startDate.setDate(startDate.getDate() - startDate.getDay());
+			startDate.setHours(0, 0, 0, 0);
+			break;
+		case "month":
+			startDate = new Date();
+			startDate.setDate(1);
+			startDate.setHours(0, 0, 0, 0);
+			break;
+		case "all":
+			startDate = new Date(0);
+			break;
+		default:
+			if (options.fromDate) {
+				startDate = options.fromDate;
+				if (options.toDate) endDate = options.toDate;
+			} else {
+				startDate = new Date();
+				startDate.setHours(0, 0, 0, 0);
+			}
+	}
+
+	return { startDate, endDate };
+}
+
+export function computeTimeSummary(
+	tasks: TaskInfo[],
+	options: TimeSummaryOptions,
+	isCompletedStatus: (status: string) => boolean
+): TimeSummaryResult {
+	const { startDate, endDate } = computeDateRange(options);
+
+	let totalMinutes = 0;
+	let completedTasks = 0;
+	let activeTasks = 0;
+	const taskStats: Array<{ task: string; title: string; minutes: number }> = [];
+	const projectStats = new Map<string, number>();
+	const tagStats = options.includeTags ? new Map<string, number>() : null;
+
+	for (const task of tasks) {
+		if (!task.timeEntries || task.timeEntries.length === 0) continue;
+
+		let taskMinutes = 0;
+		let hasActiveSession = false;
+
+		for (const entry of task.timeEntries) {
+			const entryStart = new Date(entry.startTime);
+
+			if (entryStart >= startDate && entryStart <= endDate) {
+				if (entry.duration) {
+					taskMinutes += entry.duration;
+				} else if (!entry.endTime) {
+					taskMinutes += Math.floor(
+						(Date.now() - entryStart.getTime()) / (1000 * 60)
+					);
+					hasActiveSession = true;
+				} else {
+					const entryEnd = new Date(entry.endTime);
+					taskMinutes += Math.floor(
+						(entryEnd.getTime() - entryStart.getTime()) / (1000 * 60)
+					);
+				}
+			}
+		}
+
+		if (taskMinutes > 0) {
+			totalMinutes += taskMinutes;
+			taskStats.push({
+				task: task.path,
+				title: task.title,
+				minutes: taskMinutes,
+			});
+
+			if (hasActiveSession) {
+				activeTasks++;
+			} else if (isCompletedStatus(task.status)) {
+				completedTasks++;
+			}
+
+			if (task.projects) {
+				for (const project of task.projects) {
+					projectStats.set(project, (projectStats.get(project) || 0) + taskMinutes);
+				}
+			}
+
+			if (tagStats && task.tags) {
+				for (const tag of task.tags) {
+					tagStats.set(tag, (tagStats.get(tag) || 0) + taskMinutes);
+				}
+			}
+		}
+	}
+
+	taskStats.sort((a, b) => b.minutes - a.minutes);
+
+	const topProjects = Array.from(projectStats.entries())
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 10)
+		.map(([project, minutes]) => ({ project, minutes }));
+
+	const result: TimeSummaryResult = {
+		period: options.period,
+		dateRange: {
+			from: startDate.toISOString(),
+			to: endDate.toISOString(),
+		},
+		summary: {
+			totalMinutes,
+			totalHours: Math.round((totalMinutes / 60) * 100) / 100,
+			tasksWithTime: taskStats.length,
+			activeTasks,
+			completedTasks,
+		},
+		topTasks: taskStats.slice(0, 10),
+		topProjects,
+	};
+
+	if (tagStats) {
+		result.topTags = Array.from(tagStats.entries())
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, 10)
+			.map(([tag, minutes]) => ({ tag, minutes }));
+	}
+
+	return result;
+}
+
+export function computeTaskTimeData(
+	task: TaskInfo,
+	getActiveSession: (task: TaskInfo) => TimeEntry | null
+): TaskTimeDataResult {
+	const timeEntries = task.timeEntries || [];
+	const activeSession = getActiveSession(task);
+	const totalMinutes = calculateTotalTimeSpent(timeEntries);
+
+	const completedSessions = timeEntries.filter((entry) => entry.endTime).length;
+	const completedEntries = timeEntries.filter((entry) => entry.endTime && entry.duration);
+	const averageSessionMinutes =
+		completedEntries.length > 0
+			? Math.round(
+					(completedEntries.reduce(
+						(sum, entry) => sum + (entry.duration || 0),
+						0
+					) /
+						completedEntries.length) *
+						100
+				) / 100
+			: 0;
+
+	return {
+		task: {
+			id: task.path,
+			title: task.title,
+			status: task.status,
+			priority: task.priority,
+		},
+		summary: {
+			totalMinutes,
+			totalHours: Math.round((totalMinutes / 60) * 100) / 100,
+			totalSessions: timeEntries.length,
+			completedSessions,
+			activeSessions: activeSession ? 1 : 0,
+			averageSessionMinutes,
+		},
+		activeSession: activeSession
+			? {
+					startTime: activeSession.startTime,
+					description: activeSession.description,
+					elapsedMinutes: Math.floor(
+						(Date.now() - new Date(activeSession.startTime).getTime()) /
+							(1000 * 60)
+					),
+				}
+			: null,
+		timeEntries: timeEntries.map((entry) => ({
+			startTime: entry.startTime,
+			endTime: entry.endTime || null,
+			description: entry.description || null,
+			duration:
+				entry.duration ||
+				(entry.endTime
+					? Math.floor(
+							(new Date(entry.endTime).getTime() -
+								new Date(entry.startTime).getTime()) /
+								(1000 * 60)
+						)
+					: Math.floor(
+							(Date.now() - new Date(entry.startTime).getTime()) /
+								(1000 * 60)
+						)),
+			isActive: !entry.endTime,
+		})),
+	};
+}


### PR DESCRIPTION
## Summary

- Add Model Context Protocol (MCP) server exposing all TaskNotes tools at `/mcp` endpoint, gated behind an `enableMCP` setting
- Extract shared business logic from HTTP controllers into reusable utilities (`timeTrackingUtils`, `calendarUtils`, `TaskStatsService.getStats()`) so both HTTP controllers and MCPService call the same code — eliminating ~400 lines of duplication
- MCPService triggers webhooks for all mutations and reuses the shared utils
- Fixes a pre-existing bug where webhook payloads for start-with-description had stale data

## MCP Tools Exposed

Tasks (CRUD, query, toggle status/archive, parse from text), time tracking (start/stop sessions, summaries), pomodoro (start/stop/pause/resume, status), calendar events, filter options, task statistics, and health check.

## Note

For locally running AI agents, the [mdbase-skill](https://github.com/callumalpass/mdbase-skill) is likely a better fit. This in-plugin MCP endpoint is primarily useful for remote/hosted AI clients — such as Claude or ChatGPT on mobile, or other host apps that have no direct access to a vault via (bash) tool calls.

## Test plan

- [ ] Enable `enableMCP` in settings, verify `/mcp` endpoint responds to MCP protocol messages
- [ ] Verify existing HTTP API still works unchanged
- [ ] Test MCP tools for tasks, time tracking, pomodoro, and calendar
- [ ] Confirm webhooks fire for MCP mutations
- [ ] Verify the setting toggle enables/disables the MCP endpoint at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)