### PR TITLE
fix: keep title in frontmatter when storeTitleInFilename is true

### DIFF
--- a/src/services/FieldMapper.ts
+++ b/src/services/FieldMapper.ts
@@ -201,9 +201,8 @@ export class FieldMapper {
 			frontmatter[this.mapping.title] = taskData.title;
 		}
 
-		if (storeTitleInFilename) {
-			delete frontmatter[this.mapping.title];
-		}
+		// Note: title is always kept in frontmatter for CLI/API compatibility,
+		// even when storeTitleInFilename is true (filename is derived from title)
 
 		if (taskData.status !== undefined) {
 			// Coerce boolean-like status strings to actual booleans for compatibility with Obsidian checkbox properties


### PR DESCRIPTION
## Summary

When `storeTitleInFilename` is enabled, `FieldMapper.mapToFrontmatter()` deletes the title from frontmatter. This breaks external CLI tools (e.g. `mdbase-tasknotes`) that locate tasks by the frontmatter `title` field.

## Root cause

`src/services/FieldMapper.ts` line 204-206:

```typescript
if (storeTitleInFilename) {
    delete frontmatter[this.mapping.title];
}
```

This removes the title from frontmatter entirely when `storeTitleInFilename` is true, making the task invisible to tools that search by frontmatter title.

## Fix

Remove the deletion. The title is always kept in frontmatter for CLI/API compatibility. The filename continues to be derived from the title as before.

## Reproduction

```bash
# With storeTitleInFilename: true (the default)

# Create a task via tn (uses plugin HTTP API)
tn create "Test task today @admin #planning 10m"

# Check frontmatter -- no title field
obsidian read path="TaskNotes/Tasks/Test task.md"
# ---
# status: open
# tags: [task, planning]
# ...
# ---
# (no title field)

# mtn can't find it
mtn show "Test task"
# No task found matching "Test task"
```

After fix:

```bash
obsidian read path="TaskNotes/Tasks/Test task.md"
# ---
# title: Test task      <-- now present
# status: open
# tags: [task, planning]
# ...
# ---

mtn show "Test task"
# Shows full task details
```

## Test plan

- [x] tn-created tasks now have `title` in frontmatter
- [x] mtn can find, show, and update tn-created tasks by title
- [x] Cross-tool workflow: mtn adds tags/contexts to tn-created tasks, tn sees the changes
- [x] Full test suite passes with no regressions (same 9 pre-existing failures on main)