### PR TITLE
Add resume state storage location (avoid sync noise)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -24,6 +24,11 @@ Example:
 
 -->
 
+## Added
+
+- Added `Resume state storage` setting to control where resume state is persisted (plugin data, separate `state.json`, or device-only `localStorage`)
+  - Helps Git users avoid sync conflicts/noise by allowing `state.json` to be gitignored
+
 ## Fixed
 
 - Fixed documentation deployment CI failures caused by `docs-builder/src/js/main.js` being excluded by a broad `.gitignore` `main.js` rule

--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -549,6 +549,24 @@ export const en: TranslationTree = {
 					locationChanged: "Pomodoro storage location changed to {location}",
 				},
 			},
+				sessionStateStorage: {
+					name: "Resume state storage",
+					description:
+						"Choose where TaskNotes stores resume state (in-progress Pomodoro, last selected task).",
+					pluginData: "Plugin data (syncs)",
+					stateFile: "Separate file (state.json)",
+					localStorage: "Device storage (localStorage)",
+					notices: {
+						locationChanged: "Resume state storage changed to {location}",
+					},
+					modal: {
+						title: "Change resume state storage",
+						message:
+							"This will move your current resume state to the new storage location. If you use Git, the separate file option lets you ignore state changes to avoid conflicts.",
+						confirm: "Change storage",
+						cancel: "Cancel",
+					},
+				},
 			notifications: {
 				header: "Notifications",
 				description: "Configure task reminder notifications and alerts.",

--- a/src/services/PomodoroService.ts
+++ b/src/services/PomodoroService.ts
@@ -91,7 +91,7 @@ export class PomodoroService {
 
 	async loadState() {
 		try {
-			const data = await this.plugin.loadData();
+			const data = await this.plugin.sessionStateStorage.load();
 
 			if (data?.pomodoroState) {
 				this.state = data.pomodoroState;
@@ -144,10 +144,10 @@ export class PomodoroService {
 
 	async saveState() {
 		try {
-			const data = (await this.plugin.loadData()) || {};
-			data.pomodoroState = this.state;
-			data.lastPomodoroDate = formatDateForStorage(getTodayLocal());
-			await this.plugin.saveData(data);
+			await this.plugin.sessionStateStorage.save({
+				pomodoroState: this.state,
+				lastPomodoroDate: formatDateForStorage(getTodayLocal()),
+			});
 		} catch (error) {
 			console.error("Failed to save pomodoro state:", error);
 		}
@@ -157,9 +157,7 @@ export class PomodoroService {
 		this.lastSelectedTaskPath = taskPath;
 		this.lastSelectedTaskPathLoaded = true;
 		try {
-			const data = (await this.plugin.loadData()) || {};
-			data.lastSelectedTaskPath = taskPath;
-			await this.plugin.saveData(data);
+			await this.plugin.sessionStateStorage.save({ lastSelectedTaskPath: taskPath });
 		} catch (error) {
 			console.error("Failed to save last selected task:", error);
 		}
@@ -170,7 +168,7 @@ export class PomodoroService {
 			return this.lastSelectedTaskPath;
 		}
 		try {
-			const data = await this.plugin.loadData();
+			const data = await this.plugin.sessionStateStorage.load();
 			const path = data?.lastSelectedTaskPath;
 			if (typeof path === "string" && path.trim().length > 0) {
 				this.lastSelectedTaskPath = path;

--- a/src/services/SessionStateStorage.ts
+++ b/src/services/SessionStateStorage.ts
@@ -1,0 +1,257 @@
+import { normalizePath } from "obsidian";
+import type TaskNotesPlugin from "../main";
+import type { PomodoroState } from "../types";
+import type { TaskNotesSettings } from "../types/settings";
+
+export type SessionStateStorageLocation = "plugin" | "state-file" | "localStorage";
+
+export interface SessionStateData {
+	pomodoroState?: PomodoroState;
+	lastPomodoroDate?: string;
+	lastSelectedTaskPath?: string;
+}
+
+const SESSION_STATE_KEYS: (keyof SessionStateData)[] = [
+	"pomodoroState",
+	"lastPomodoroDate",
+	"lastSelectedTaskPath",
+];
+
+function hasAnySessionState(data: SessionStateData | undefined | null): boolean {
+	if (!data) return false;
+	return SESSION_STATE_KEYS.some((key) => typeof data[key] !== "undefined");
+}
+
+export class SessionStateStorage {
+	constructor(private plugin: TaskNotesPlugin) {}
+
+	getLocation(): SessionStateStorageLocation {
+		return this.plugin.settings.sessionStateStorageLocation;
+	}
+
+	getStateFilePath(): string {
+		const dir = (this.plugin.manifest as any)?.dir as string | undefined;
+		const base = dir && dir.trim().length > 0 ? dir : ".obsidian/plugins/tasknotes";
+		return normalizePath(`${base}/state.json`);
+	}
+
+	private getVaultName(): string {
+		try {
+			const vault = this.plugin.app?.vault;
+			if (vault && typeof vault.getName === "function") {
+				return vault.getName() || "default";
+			}
+		} catch {
+			// ignore
+		}
+		return "default";
+	}
+
+	private getLocalStorageKey(): string {
+		return `tasknotes:${this.getVaultName()}:session-state`;
+	}
+
+	private async loadFromPluginData(): Promise<SessionStateData> {
+		const data = (await this.plugin.loadData()) || {};
+		const out: SessionStateData = {};
+		for (const key of SESSION_STATE_KEYS) {
+			if (typeof (data as any)[key] !== "undefined") {
+				(out as any)[key] = (data as any)[key];
+			}
+		}
+		return out;
+	}
+
+	private async saveToPluginData(partial: SessionStateData): Promise<void> {
+		const data = (await this.plugin.loadData()) || {};
+		for (const key of SESSION_STATE_KEYS) {
+			if (typeof (partial as any)[key] !== "undefined") {
+				(data as any)[key] = (partial as any)[key];
+			}
+		}
+		await this.plugin.saveData(data);
+	}
+
+	async stripSessionStateFromPluginData(force = false): Promise<void> {
+		const location = this.getLocation();
+		if (!force && location === "plugin") return;
+
+		try {
+			const data = (await this.plugin.loadData()) || {};
+			let changed = false;
+			for (const key of SESSION_STATE_KEYS) {
+				if (key in (data as any)) {
+					delete (data as any)[key];
+					changed = true;
+				}
+			}
+			if (changed) {
+				await this.plugin.saveData(data);
+			}
+		} catch {
+			// ignore
+		}
+	}
+
+	private async loadFromStateFile(): Promise<SessionStateData> {
+		const adapter = this.plugin.app.vault.adapter;
+		const path = this.getStateFilePath();
+		if (!(await adapter.exists(path))) return {};
+		try {
+			const raw = await adapter.read(path);
+			const parsed = JSON.parse(raw);
+			return parsed && typeof parsed === "object" ? (parsed as SessionStateData) : {};
+		} catch {
+			return {};
+		}
+	}
+
+	private async saveToStateFile(partial: SessionStateData): Promise<void> {
+		const adapter = this.plugin.app.vault.adapter;
+		const path = this.getStateFilePath();
+		const existing = await this.loadFromStateFile();
+		const merged = { ...existing, ...partial };
+		await adapter.write(path, JSON.stringify(merged, null, 2));
+	}
+
+	private loadFromLocalStorage(): SessionStateData {
+		try {
+			if (typeof window === "undefined") return {};
+			const storage = window.localStorage;
+			if (!storage) return {};
+			const raw = storage.getItem(this.getLocalStorageKey());
+			if (!raw) return {};
+			const parsed = JSON.parse(raw);
+			return parsed && typeof parsed === "object" ? (parsed as SessionStateData) : {};
+		} catch {
+			return {};
+		}
+	}
+
+	private saveToLocalStorage(partial: SessionStateData): void {
+		try {
+			if (typeof window === "undefined") return;
+			const storage = window.localStorage;
+			if (!storage) return;
+			const existing = this.loadFromLocalStorage();
+			const merged = { ...existing, ...partial };
+			storage.setItem(this.getLocalStorageKey(), JSON.stringify(merged));
+		} catch {
+			// ignore
+		}
+	}
+
+	private removeFromLocalStorage(): void {
+		try {
+			if (typeof window === "undefined") return;
+			const storage = window.localStorage;
+			if (!storage) return;
+			storage.removeItem(this.getLocalStorageKey());
+		} catch {
+			// ignore
+		}
+	}
+
+	async load(): Promise<SessionStateData> {
+		const location = this.getLocation();
+		if (location === "plugin") return this.loadFromPluginData();
+		if (location === "state-file") return this.loadFromStateFile();
+		return this.loadFromLocalStorage();
+	}
+
+	async save(partial: SessionStateData): Promise<void> {
+		const location = this.getLocation();
+		if (location === "plugin") {
+			await this.saveToPluginData(partial);
+			return;
+		}
+
+		if (location === "state-file") {
+			await this.saveToStateFile(partial);
+		} else {
+			this.saveToLocalStorage(partial);
+		}
+
+		await this.stripSessionStateFromPluginData();
+	}
+
+	/**
+	 * One-time migration: if the chosen location is not plugin data, and plugin data
+	 * still contains session state, copy it into the chosen location and strip it
+	 * from plugin data.
+	 */
+	async migrateFromPluginDataIfNeeded(): Promise<void> {
+		const location = this.getLocation();
+		if (location === "plugin") return;
+
+		const legacy = await this.loadFromPluginData();
+		if (!hasAnySessionState(legacy)) return;
+
+		const current = await this.load();
+		if (!hasAnySessionState(current)) {
+			await this.save(legacy);
+		} else {
+			// Still strip to avoid sync noise
+			await this.stripSessionStateFromPluginData();
+		}
+	}
+
+	async migrateLocation(
+		from: TaskNotesSettings["sessionStateStorageLocation"],
+		to: TaskNotesSettings["sessionStateStorageLocation"]
+	): Promise<void> {
+		if (from === to) return;
+
+		const readFrom = async (loc: SessionStateStorageLocation) => {
+			if (loc === "plugin") return this.loadFromPluginData();
+			if (loc === "state-file") return this.loadFromStateFile();
+			return this.loadFromLocalStorage();
+		};
+
+		const writeTo = async (loc: SessionStateStorageLocation, data: SessionStateData) => {
+			if (loc === "plugin") return this.saveToPluginData(data);
+			if (loc === "state-file") return this.saveToStateFile(data);
+			return this.saveToLocalStorage(data);
+		};
+
+		const clearFrom = async (loc: SessionStateStorageLocation) => {
+			if (loc === "plugin") {
+				// Delete keys from plugin data
+				try {
+					const data = (await this.plugin.loadData()) || {};
+					let changed = false;
+					for (const key of SESSION_STATE_KEYS) {
+						if (key in (data as any)) {
+							delete (data as any)[key];
+							changed = true;
+						}
+					}
+					if (changed) await this.plugin.saveData(data);
+				} catch {
+					// ignore
+				}
+				return;
+			}
+
+			if (loc === "state-file") {
+				try {
+					const adapter = this.plugin.app.vault.adapter;
+					const path = this.getStateFilePath();
+					if (await adapter.exists(path)) await adapter.remove(path);
+				} catch {
+					// ignore
+				}
+				return;
+			}
+
+			this.removeFromLocalStorage();
+		};
+
+		const data = await readFrom(from);
+		await writeTo(to, data);
+		await clearFrom(from);
+		if (to !== "plugin") {
+			await this.stripSessionStateFromPluginData(true);
+		}
+	}
+}

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -287,6 +287,7 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	pomodoroSoundEnabled: true,
 	pomodoroSoundVolume: 50,
 	pomodoroStorageLocation: "plugin",
+	sessionStateStorageLocation: "plugin",
 	pomodoroMobileSidebar: "tab",
 	// Editor defaults
 	enableTaskLinkOverlay: true,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -121,6 +121,13 @@ export interface TaskNotesSettings {
 	pomodoroSoundEnabled: boolean;
 	pomodoroSoundVolume: number; // 0-100
 	pomodoroStorageLocation: "plugin" | "daily-notes"; // where to store pomodoro history data
+		/**
+		 * Where to store resume state (e.g., pomodoroState/currentSession, lastSelectedTaskPath).
+		 * - "plugin": stored in plugin `data.json` (will sync with `.obsidian`).
+		 * - "state-file": stored in `.obsidian/plugins/tasknotes/state.json` (can be gitignored).
+		 * - "localStorage": stored in WebView/Electron localStorage (device-only).
+		 */
+		sessionStateStorageLocation: "plugin" | "state-file" | "localStorage";
 	pomodoroMobileSidebar: "tab" | "left" | "right"; // where to open pomodoro view on mobile
 	// Editor settings
 	enableTaskLinkOverlay: boolean;


### PR DESCRIPTION
Adds a new setting to control where TaskNotes stores resume state (in-progress Pomodoro + last selected task):

- Plugin data (current behavior; syncs)
- Separate state file: `.obsidian/plugins/tasknotes/state.json` (can be gitignored to avoid Git conflicts/noise)
- Device storage (localStorage; device-only)

Includes migration of existing state out of `data.json` when configured, and a confirmation modal when changing locations.