### PR TITLE
Added projectId, project, and projects templates for filenames.

### DIFF
--- a/docs/settings/task-defaults.md
+++ b/docs/settings/task-defaults.md
@@ -24,6 +24,7 @@ The **Default Tasks Folder** setting supports dynamic folder creation using temp
 - `{{contexts}}` - All contexts from the task's contexts array, joined by `/`
 - `{{project}}` - First project from the task's projects array  
 - `{{projects}}` - All projects from the task's projects array, joined by `/`
+- `{{projectId}}` - First project from the task's projects array abbreviated to 4 characters. (e.g., "TASK")
 - `{{priority}}` - Task priority (e.g., "high", "medium", "low")
 - `{{status}}` - Task status (e.g., "todo", "in-progress", "done")
 - `{{title}}` - Task title (sanitized for folder names)

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -259,6 +259,7 @@ export class TaskService {
 				title: title,
 				priority: priority,
 				status: status,
+				projects: projectsArray,
 				date: new Date(),
 				dueDate: taskData.due,
 				scheduledDate: taskData.scheduled,

--- a/src/utils/filenameGenerator.ts
+++ b/src/utils/filenameGenerator.ts
@@ -11,6 +11,7 @@ export interface FilenameContext {
 	scheduledDate?: string; // YYYY-MM-DD format
 	// Additional body template variables (optional for backwards compatibility)
 	contexts?: string[];
+	projects?: string[];
 	tags?: string[];
 	timeEstimate?: number;
 	details?: string;
@@ -209,6 +210,11 @@ function generateCustomFilename(
 	}
 
 	try {
+		// Process array values for contexts and tags
+		const contexts = Array.isArray(context.contexts) ? context.contexts : [];
+		const projects = Array.isArray(context.projects) ? context.projects : [];
+		const tags = Array.isArray(context.tags) ? context.tags : [];
+
 		// Validate and sanitize context values
 		const sanitizedTitle = sanitizeForFilename(context.title);
 		const sanitizedPriority =
@@ -218,10 +224,10 @@ function generateCustomFilename(
 		const sanitizedStatus = context.status
 			? sanitizeForFilename(context.status)
 			: "open";
-
-		// Process array values for contexts and tags
-		const contexts = Array.isArray(context.contexts) ? context.contexts : [];
-		const tags = Array.isArray(context.tags) ? context.tags : [];
+		const sanitizedProjectId =
+			projects
+				? sanitizeForFilename(projects[0]).trim().substring(0,4).toUpperCase()
+				: "TASK";
 
 		const variables: Record<string, string> = {
 			title: sanitizedTitle,
@@ -229,6 +235,7 @@ function generateCustomFilename(
 			time: format(date, "HHmmss"),
 			priority: sanitizedPriority,
 			status: sanitizedStatus,
+			projectId: sanitizedProjectId,
 			timestamp: format(date, "yyyy-MM-dd-HHmmss"),
 			dateTime: format(date, "yyyy-MM-dd-HHmm"),
 			year: format(date, "yyyy"),
@@ -242,6 +249,8 @@ function generateCustomFilename(
 			// Body template variables (contexts, tags, etc.)
 			context: contexts[0] ? sanitizeForFilename(contexts[0]) : "",
 			contexts: contexts.map((c) => sanitizeForFilename(c)).join("/"),
+			project: projects[0] ? sanitizeForFilename(projects[0]) : "",
+			projects: projects.map((c) => sanitizeForFilename(c)).join("/"),
 			tags: tags.map((t) => sanitizeForFilename(t)).join(", "),
 			hashtags: tags.map((t) => `#${sanitizeForFilename(t)}`).join(" "),
 			timeEstimate: context.timeEstimate?.toString() || "",


### PR DESCRIPTION
Following the discussion on #1178, I have made changes that are less intrusive.

In the time that's passed, the code around these file name formats has gotten a lot clearer, so I've only added these as custom templates (filename only).

The projectId template essentially only shortens the project name to four characters in caps, and the filename exists check just increments this. 
- {{projectId}}-0 >> TASK-0, TASK-01. 

This seems to be the best option without combining the generateCustomFilename and generateUniqueFilename functions. This naming depends on the taskdata in custom and the vault access for the increment. Since this is handled by the custom naming, it also allows different combinations with this projectId. Like my new setting below.
- {{shortYear}}Q{{q}}{{projectId}}-{{title_snake}} >> 26Q1TASK-my_task.

Would you be interested in unifying these replacements? IE: folderTemplateProcessor is essentially duplicated, but not as clear. I'd be willing to look into this. 