### PR TITLE
Open the timeblock modal with the task title prefilled from the task context menu

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -28,7 +28,7 @@ Example:
 
 - Added a task context-menu action to create a timeblock with the task title prefilled, and default times derived from the task schedule or a planning slot
 - Timeblocks created from a task now automatically include that task note as a prefilled attachment
-- In Edit Timeblock, adding an attachment now auto-fills the title when the title is empty
+- In Create Timeblock and Edit Timeblock, adding an attachment now auto-fills the title when the title is empty
 - Added a setting to control the ordering of results in the timeblock Add Attachment search window
 - Fixed documentation deployment CI failures caused by `docs-builder/src/js/main.js` being excluded by a broad `.gitignore` `main.js` rule
   - Added a specific unignore rule so the docs site client script is tracked and available in GitHub Actions builds

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -29,6 +29,7 @@ Example:
 - Added a task context-menu action to create a timeblock with the task title prefilled, and default times derived from the task schedule or a planning slot
 - Timeblocks created from a task now automatically include that task note as a prefilled attachment
 - In Edit Timeblock, adding an attachment now auto-fills the title when the title is empty
+- Added a setting to control the ordering of results in the timeblock Add Attachment search window
 - Fixed documentation deployment CI failures caused by `docs-builder/src/js/main.js` being excluded by a broad `.gitignore` `main.js` rule
   - Added a specific unignore rule so the docs site client script is tracked and available in GitHub Actions builds
 - Reduced long-running performance risk from calendar sync token persistence by avoiding full runtime settings side-effects during background sync writes

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -26,6 +26,8 @@ Example:
 
 ## Fixed
 
+- Added a task context-menu action to create a timeblock with the task title prefilled, and default times derived from the task schedule or a planning slot
+- Timeblocks created from a task now automatically include that task note as a prefilled attachment
 - Fixed documentation deployment CI failures caused by `docs-builder/src/js/main.js` being excluded by a broad `.gitignore` `main.js` rule
   - Added a specific unignore rule so the docs site client script is tracked and available in GitHub Actions builds
 - Reduced long-running performance risk from calendar sync token persistence by avoiding full runtime settings side-effects during background sync writes

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -28,6 +28,7 @@ Example:
 
 - Added a task context-menu action to create a timeblock with the task title prefilled, and default times derived from the task schedule or a planning slot
 - Timeblocks created from a task now automatically include that task note as a prefilled attachment
+- In Edit Timeblock, adding an attachment now auto-fills the title when the title is empty
 - Fixed documentation deployment CI failures caused by `docs-builder/src/js/main.js` being excluded by a broad `.gitignore` `main.js` rule
   - Added a specific unignore rule so the docs site client script is tracked and available in GitHub Actions builds
 - Reduced long-running performance risk from calendar sync token persistence by avoiding full runtime settings side-effects during background sync writes

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -29,6 +29,7 @@ Example:
 - Added a task context-menu action to create a timeblock with the task title prefilled, and default times derived from the task schedule or a planning slot
 - Timeblocks created from a task now automatically include that task note as a prefilled attachment
 - In Create Timeblock and Edit Timeblock, adding an attachment now auto-fills the title when the title is empty
+- Added an "Add task" action to Create Timeblock and Edit Timeblock to select a task and prefill the title
 - Added a setting to control the ordering of results in the timeblock Add Attachment search window
 - Fixed documentation deployment CI failures caused by `docs-builder/src/js/main.js` being excluded by a broad `.gitignore` `main.js` rule
   - Added a specific unignore rule so the docs site client script is tracked and available in GitHub Actions builds

--- a/src/components/TaskContextMenu.ts
+++ b/src/components/TaskContextMenu.ts
@@ -1,7 +1,7 @@
 import { Menu, Notice, TFile } from "obsidian";
 import TaskNotesPlugin from "../main";
 import { TaskDependency, TaskInfo } from "../types";
-import { formatDateForStorage } from "../utils/dateUtils";
+import { formatDateForStorage, parseDateToLocal } from "../utils/dateUtils";
 import { ReminderModal } from "../modals/ReminderModal";
 import { CalendarExportService } from "../services/CalendarExportService";
 import { showConfirmationModal } from "../modals/ConfirmationModal";
@@ -18,6 +18,7 @@ import {
 } from "../utils/dependencyUtils";
 import { generateLink } from "../utils/linkUtils";
 import { ContextMenu } from "./ContextMenu";
+import { TimeblockCreationModal } from "../modals/TimeblockCreationModal";
 
 export interface TaskContextMenuOptions {
 	task: TaskInfo;
@@ -39,6 +40,49 @@ export class TaskContextMenu {
 
 	private t(key: string, params?: Record<string, string | number>): string {
 		return this.options.plugin.i18n.translate(key, params);
+	}
+
+	private formatTimeForInput(date: Date): string {
+		const hours = String(date.getHours()).padStart(2, "0");
+		const minutes = String(date.getMinutes()).padStart(2, "0");
+		return `${hours}:${minutes}`;
+	}
+
+	private getTimeblockPrefillForTask(task: TaskInfo): {
+		date: string;
+		startTime: string;
+		endTime: string;
+	} {
+		let startDate = new Date(this.options.targetDate);
+
+		// If the task has a scheduled datetime, use it as the timeblock anchor.
+		if (task.scheduled && task.scheduled.includes("T")) {
+			try {
+				startDate = parseDateToLocal(task.scheduled);
+			} catch {
+				// Fallback to target date defaults if parsing fails.
+			}
+		}
+
+		if (isNaN(startDate.getTime())) {
+			startDate = new Date();
+		}
+
+		// For date-only tasks, default to a 09:00 planning slot.
+		if (!task.scheduled || !task.scheduled.includes("T")) {
+			startDate.setHours(9, 0, 0, 0);
+		}
+
+		const durationMinutes = task.timeEstimate && task.timeEstimate > 0
+			? task.timeEstimate
+			: 60;
+		const endDate = new Date(startDate.getTime() + durationMinutes * 60 * 1000);
+
+		return {
+			date: formatDateForStorage(startDate),
+			startTime: this.formatTimeForInput(startDate),
+			endTime: this.formatTimeForInput(endDate),
+		};
 	}
 
 	private buildMenu(): void {
@@ -311,6 +355,25 @@ export class TaskContextMenu {
 				plugin.openTimeEntryEditor(task);
 			});
 		});
+
+		// Create timeblock from task
+		if (plugin.settings.calendarViewSettings.enableTimeblocking) {
+			this.menu.addItem((item) => {
+				item.setTitle("Create timeblock");
+				item.setIcon("calendar-plus");
+				item.onClick(() => {
+					const prefill = this.getTimeblockPrefillForTask(task);
+					const modal = new TimeblockCreationModal(plugin.app, plugin, {
+						date: prefill.date,
+						startTime: prefill.startTime,
+						endTime: prefill.endTime,
+						prefilledTitle: task.title,
+						prefilledAttachmentPaths: [task.path],
+					});
+					modal.open();
+				});
+			});
+		}
 
 		// Archive/Unarchive
 		this.menu.addItem((item) => {

--- a/src/modals/FileSelectorModal.ts
+++ b/src/modals/FileSelectorModal.ts
@@ -24,6 +24,16 @@ export interface FileSelectorOptions {
 	filter?: "markdown" | "all" | ((file: TAbstractFile) => boolean);
 	/** Folder to create new files in (default: vault root) */
 	newFileFolder?: string;
+	/** Sort order for results */
+	sortOrder?:
+		| "name-asc"
+		| "name-desc"
+		| "path-asc"
+		| "path-desc"
+		| "created-recent"
+		| "created-oldest"
+		| "modified-recent"
+		| "modified-oldest";
 }
 
 /**
@@ -223,12 +233,39 @@ export class FileSelectorModal extends SuggestModal<TAbstractFile> {
 			);
 		}
 
+		const sortOrder = this.options.sortOrder || "name-asc";
+		const sorted = [...filtered].sort((a, b) => {
+			const aCreated = a instanceof TFile ? a.stat.ctime : 0;
+			const bCreated = b instanceof TFile ? b.stat.ctime : 0;
+			const aModified = a instanceof TFile ? a.stat.mtime : 0;
+			const bModified = b instanceof TFile ? b.stat.mtime : 0;
+			switch (sortOrder) {
+				case "name-desc":
+					return b.name.localeCompare(a.name);
+				case "path-asc":
+					return a.path.localeCompare(b.path);
+				case "path-desc":
+					return b.path.localeCompare(a.path);
+				case "created-recent":
+					return bCreated - aCreated;
+				case "created-oldest":
+					return aCreated - bCreated;
+				case "modified-recent":
+					return bModified - aModified;
+				case "modified-oldest":
+					return aModified - bModified;
+				case "name-asc":
+				default:
+					return a.name.localeCompare(b.name);
+			}
+		});
+
 		// Filter by query
 		if (!query) {
-			return filtered.slice(0, 50); // Limit initial results
+			return sorted.slice(0, 50); // Limit initial results
 		}
 
-		return filtered
+		return sorted
 			.filter((file) => {
 				const searchText = this.getSearchText(file).toLowerCase();
 				return searchText.includes(lowerQuery);
@@ -338,6 +375,15 @@ export function openFileSelector(
 		title?: string;
 		filter?: "markdown" | "all" | ((file: TAbstractFile) => boolean);
 		newFileFolder?: string;
+		sortOrder?:
+			| "name-asc"
+			| "name-desc"
+			| "path-asc"
+			| "path-desc"
+			| "created-recent"
+			| "created-oldest"
+			| "modified-recent"
+			| "modified-oldest";
 	}
 ): void {
 	const modal = new FileSelectorModal(plugin.app, plugin, {
@@ -345,6 +391,7 @@ export function openFileSelector(
 		title: options?.title,
 		filter: options?.filter,
 		newFileFolder: options?.newFileFolder,
+		sortOrder: options?.sortOrder,
 		onResult: (result) => {
 			if (result.type === "selected" || result.type === "created") {
 				onChoose(result.file);

--- a/src/modals/TimeblockCreationModal.ts
+++ b/src/modals/TimeblockCreationModal.ts
@@ -4,6 +4,7 @@ import {
 	Setting,
 	Notice,
 	TAbstractFile,
+	TFile,
 	parseYaml,
 	stringifyYaml,
 	setTooltip,
@@ -361,6 +362,13 @@ export class TimeblockCreationModal extends Modal {
 		if (this.selectedAttachments.some((existing) => existing.path === file.path)) {
 			new Notice(this.translate("notices.timeblockAttachmentExists", { fileName: file.name }));
 			return;
+		}
+
+		// If title is empty, default it to the selected attachment name.
+		if (this.titleInput && !this.titleInput.value.trim()) {
+			const derivedTitle = file instanceof TFile ? file.basename : file.name;
+			this.titleInput.value = derivedTitle;
+			this.validateForm();
 		}
 
 		this.selectedAttachments.push(file);

--- a/src/modals/TimeblockCreationModal.ts
+++ b/src/modals/TimeblockCreationModal.ts
@@ -10,9 +10,10 @@ import {
 	setTooltip,
 } from "obsidian";
 import TaskNotesPlugin from "../main";
-import { TimeBlock, DailyNoteFrontmatter } from "../types";
+import { TimeBlock, DailyNoteFrontmatter, TaskInfo } from "../types";
 import { generateTimeblockId } from "../utils/helpers";
 import { openFileSelector } from "./FileSelectorModal";
+import { openTaskSelector } from "./TaskSelectorWithCreateModal";
 import { parseDateAsLocal } from "../utils/dateUtils";
 import {
 	createDailyNote,
@@ -159,6 +160,14 @@ export class TimeblockCreationModal extends Modal {
 								this.plugin.settings.calendarViewSettings
 									.timeblockAttachmentSearchOrder,
 						});
+					});
+			})
+			.addButton((button) => {
+				button
+					.setButtonText("Add task")
+					.setTooltip("Select task")
+					.onClick(() => {
+						void this.openTaskSelectorForTitle();
 					});
 			});
 
@@ -374,6 +383,35 @@ export class TimeblockCreationModal extends Modal {
 		this.selectedAttachments.push(file);
 		this.renderAttachmentsList();
 		new Notice(this.translate("notices.timeblockAttachmentAdded", { fileName: file.name }));
+	}
+
+	private async openTaskSelectorForTitle(): Promise<void> {
+		try {
+			const allTasks: TaskInfo[] = (await this.plugin.cacheManager.getAllTasks?.()) ?? [];
+			const candidates = allTasks.filter((task) => !task.archived);
+
+			if (candidates.length === 0) {
+				new Notice("No tasks available to select");
+				return;
+			}
+
+			openTaskSelector(this.plugin, candidates, (selectedTask) => {
+				if (!selectedTask) return;
+
+				this.titleInput.value = selectedTask.title || "";
+				this.validateForm();
+
+				const taskFile = this.app.vault.getAbstractFileByPath(selectedTask.path);
+				if (taskFile) {
+					this.addAttachment(taskFile);
+				}
+			}, {
+				title: "Select task",
+			});
+		} catch (error) {
+			console.error("Failed to open task selector for timeblock creation:", error);
+			new Notice("Failed to open task selector");
+		}
 	}
 
 	private removeAttachment(file: TAbstractFile): void {

--- a/src/modals/TimeblockCreationModal.ts
+++ b/src/modals/TimeblockCreationModal.ts
@@ -154,6 +154,9 @@ export class TimeblockCreationModal extends Modal {
 						}, {
 							placeholder: "Search files or type to create new...",
 							filter: "all",
+							sortOrder:
+								this.plugin.settings.calendarViewSettings
+									.timeblockAttachmentSearchOrder,
 						});
 					});
 			});

--- a/src/modals/TimeblockCreationModal.ts
+++ b/src/modals/TimeblockCreationModal.ts
@@ -26,6 +26,7 @@ export interface TimeblockCreationOptions {
 	startTime?: string; // HH:MM format
 	endTime?: string; // HH:MM format
 	prefilledTitle?: string;
+	prefilledAttachmentPaths?: string[];
 }
 
 export class TimeblockCreationModal extends Modal {
@@ -159,6 +160,7 @@ export class TimeblockCreationModal extends Modal {
 
 		// Attachments list container
 		this.attachmentsList = contentEl.createDiv({ cls: "timeblock-attachments-list" });
+		this.initializePrefilledAttachments();
 		this.renderAttachmentsList(); // Initialize empty state
 
 		// Buttons
@@ -209,6 +211,21 @@ export class TimeblockCreationModal extends Modal {
 
 		createButton.disabled = !isValid;
 		createButton.style.opacity = isValid ? "1" : "0.5";
+	}
+
+	private initializePrefilledAttachments(): void {
+		const prefilledPaths = this.options.prefilledAttachmentPaths || [];
+		if (prefilledPaths.length === 0) {
+			return;
+		}
+
+		const uniquePaths = new Set(prefilledPaths.filter((path) => typeof path === "string" && path.trim().length > 0));
+		for (const path of uniquePaths) {
+			const file = this.app.vault.getAbstractFileByPath(path);
+			if (file) {
+				this.selectedAttachments.push(file);
+			}
+		}
 	}
 
 	private async handleSubmit(): Promise<void> {

--- a/src/modals/TimeblockInfoModal.ts
+++ b/src/modals/TimeblockInfoModal.ts
@@ -11,6 +11,7 @@ import {
 } from "obsidian";
 import TaskNotesPlugin from "../main";
 import { openFileSelector } from "./FileSelectorModal";
+import { openTaskSelector } from "./TaskSelectorWithCreateModal";
 import {
 	getDailyNote,
 	getAllDailyNotes,
@@ -18,6 +19,7 @@ import {
 } from "obsidian-daily-notes-interface";
 import { formatDateForStorage } from "../utils/dateUtils";
 import { TranslationKey } from "../i18n";
+import { TaskInfo } from "../types";
 
 export interface TimeBlock {
 	title: string;
@@ -145,6 +147,14 @@ export class TimeblockInfoModal extends Modal {
 									.timeblockAttachmentSearchOrder,
 						});
 					});
+			})
+			.addButton((button) => {
+				button
+					.setButtonText("Add task")
+					.setTooltip("Select task")
+					.onClick(() => {
+						void this.openTaskSelectorForTitle();
+					});
 			});
 
 		// Attachments list container
@@ -234,6 +244,36 @@ export class TimeblockInfoModal extends Modal {
 		this.selectedAttachments.push(file);
 		this.renderAttachmentsList();
 		new Notice(this.translate("notices.timeblockAttachmentAdded", { fileName: file.name }));
+	}
+
+	private async openTaskSelectorForTitle(): Promise<void> {
+		try {
+			const allTasks: TaskInfo[] = (await this.plugin.cacheManager.getAllTasks?.()) ?? [];
+			const candidates = allTasks.filter((task) => !task.archived);
+
+			if (candidates.length === 0) {
+				new Notice("No tasks available to select");
+				return;
+			}
+
+			openTaskSelector(this.plugin, candidates, (selectedTask) => {
+				if (!selectedTask) return;
+
+				this.titleInput.value = selectedTask.title || "";
+				this.timeblock.title = selectedTask.title || "";
+				this.validateForm();
+
+				const taskFile = this.app.vault.getAbstractFileByPath(selectedTask.path);
+				if (taskFile) {
+					this.addAttachment(taskFile);
+				}
+			}, {
+				title: "Select task",
+			});
+		} catch (error) {
+			console.error("Failed to open task selector for timeblock edit:", error);
+			new Notice("Failed to open task selector");
+		}
 	}
 
 	private removeAttachment(file: TAbstractFile): void {

--- a/src/modals/TimeblockInfoModal.ts
+++ b/src/modals/TimeblockInfoModal.ts
@@ -140,6 +140,9 @@ export class TimeblockInfoModal extends Modal {
 						}, {
 							placeholder: "Search files or type to create new...",
 							filter: "all",
+							sortOrder:
+								this.plugin.settings.calendarViewSettings
+									.timeblockAttachmentSearchOrder,
 						});
 					});
 			});

--- a/src/modals/TimeblockInfoModal.ts
+++ b/src/modals/TimeblockInfoModal.ts
@@ -220,6 +220,14 @@ export class TimeblockInfoModal extends Modal {
 			return;
 		}
 
+		// If title is empty, default it to the first selected attachment name.
+		if (this.titleInput && !this.titleInput.value.trim()) {
+			const derivedTitle = file instanceof TFile ? file.basename : file.name;
+			this.titleInput.value = derivedTitle;
+			this.timeblock.title = derivedTitle;
+			this.validateForm();
+		}
+
 		this.selectedAttachments.push(file);
 		this.renderAttachmentsList();
 		new Notice(this.translate("notices.timeblockAttachmentAdded", { fileName: file.name }));

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -168,6 +168,7 @@ export const DEFAULT_CALENDAR_VIEW_SETTINGS: CalendarViewSettings = {
 	enableTimeblocking: false, // Disabled by default - toggleable feature
 	defaultShowTimeblocks: true,
 	defaultTimeblockColor: "#6366f1",
+	timeblockAttachmentSearchOrder: "name-asc",
 	// Calendar behavior
 	nowIndicator: true,
 	selectMirror: true,

--- a/src/settings/tabs/featuresTab.ts
+++ b/src/settings/tabs/featuresTab.ts
@@ -602,6 +602,38 @@ export function renderFeaturesTab(
 
 			if (plugin.settings.calendarViewSettings.enableTimeblocking) {
 				group.addSetting((setting) =>
+					configureDropdownSetting(setting, {
+						name: "Attachment Search Order",
+						desc: "Controls how files are ordered in the Add Attachment search window for timeblocks.",
+						options: [
+							{ value: "name-asc", label: "Name (A to Z)" },
+							{ value: "name-desc", label: "Name (Z to A)" },
+							{ value: "path-asc", label: "Path (A to Z)" },
+							{ value: "path-desc", label: "Path (Z to A)" },
+							{ value: "created-recent", label: "Created (Newest first)" },
+							{ value: "created-oldest", label: "Created (Oldest first)" },
+							{ value: "modified-recent", label: "Modified (Newest first)" },
+							{ value: "modified-oldest", label: "Modified (Oldest first)" },
+						],
+						getValue: () =>
+							plugin.settings.calendarViewSettings.timeblockAttachmentSearchOrder,
+						setValue: async (value: string) => {
+							plugin.settings.calendarViewSettings.timeblockAttachmentSearchOrder =
+								value as
+									| "name-asc"
+									| "name-desc"
+									| "path-asc"
+									| "path-desc"
+									| "created-recent"
+									| "created-oldest"
+									| "modified-recent"
+									| "modified-oldest";
+							save();
+						},
+					})
+				);
+
+				group.addSetting((setting) =>
 					configureToggleSetting(setting, {
 						name: translate("settings.features.timeblocking.showBlocksName"),
 						desc: translate("settings.features.timeblocking.showBlocksDesc"),

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -309,6 +309,16 @@ export interface GoogleCalendarExportSettings {
 	defaultReminderMinutes: number | null; // Popup reminder X minutes before event (null = no reminder)
 }
 
+export type TimeblockAttachmentSearchOrder =
+	| "name-asc"
+	| "name-desc"
+	| "path-asc"
+	| "path-desc"
+	| "created-recent"
+	| "created-oldest"
+	| "modified-recent"
+	| "modified-oldest";
+
 export interface CalendarViewSettings {
 	// Default view
 	defaultView:
@@ -343,6 +353,7 @@ export interface CalendarViewSettings {
 	enableTimeblocking: boolean;
 	defaultShowTimeblocks: boolean;
 	defaultTimeblockColor: string;
+	timeblockAttachmentSearchOrder: TimeblockAttachmentSearchOrder;
 	// Calendar behavior
 	nowIndicator: boolean;
 	selectMirror: boolean;


### PR DESCRIPTION
Fixes #1678
- Open the timeblock modal with the task title prefilled from the task context menu
- In Create and Edit Timeblock, adding an attachment now auto-fills the title when the title is empty
- Add setting for attachment search order in timeblock modal
- Add an "Add task" action to Create Timeblock and Edit Timeblock to select a task and prefill the title