### PR TITLE
docs: fix sidebar overlay being always present on smallest media query

### DIFF
--- a/docs-builder/src/styles/main.css
+++ b/docs-builder/src/styles/main.css
@@ -856,10 +856,11 @@ body {
   }
 
   .overlay {
-    display: block;
+    display: none;
   }
 
   .overlay.is-visible {
+    display: block;
     opacity: 1;
     pointer-events: auto;
   }


### PR DESCRIPTION
Currently there's a bug in the docs at https://tasknotes.dev where the smallest media query `@media (max-width: 720px)` sets the sidebar overlay to `display: block` on top of anything else, making the content impossible to interact with. 
I corrected the css to set the expected behavior.