### PR TITLE
feat: support numeric priority values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tasknotes",
-	"version": "3.23.1",
+	"version": "3.23.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tasknotes",
-			"version": "3.23.1",
+			"version": "3.23.4",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/view": "^6.37.2",

--- a/src/components/PriorityContextMenu.ts
+++ b/src/components/PriorityContextMenu.ts
@@ -3,8 +3,8 @@ import TaskNotesPlugin from '../main';
 import { PriorityConfig } from '../types';
 
 export interface PriorityContextMenuOptions {
-    currentValue?: string;
-    onSelect: (value: string) => void;
+    currentValue?: string | number;
+    onSelect: (value: string | number) => void;
     plugin: TaskNotesPlugin;
 }
 
@@ -32,8 +32,8 @@ export class PriorityContextMenu {
                 // Use consistent icon for all items
                 item.setIcon('star');
                 
-                // Highlight current selection with visual indicator
-                if (priority.value === this.options.currentValue) {
+                // Highlight current selection with visual indicator (compare as strings for consistency)
+                if (String(priority.value) === String(this.options.currentValue)) {
                     title = `✓ ${priority.label}`;
                 }
                 

--- a/src/components/TaskContextMenu.ts
+++ b/src/components/TaskContextMenu.ts
@@ -498,7 +498,7 @@ export class TaskContextMenu {
                 
                 // Apply priority color
                 else if (title === 'Priority') {
-                    const priorityConfig = plugin.settings.customPriorities.find(p => p.value === task.priority);
+                    const priorityConfig = plugin.settings.customPriorities.find(p => String(p.value) === String(task.priority));
                     if (priorityConfig && priorityConfig.color) {
                         (iconEl as HTMLElement).style.color = priorityConfig.color;
                     }
@@ -564,8 +564,8 @@ export class TaskContextMenu {
                 // Use consistent icon for all items
                 item.setIcon('star');
                 
-                // Highlight current selection with visual indicator
-                if (priority.value === task.priority) {
+                // Highlight current selection with visual indicator (compare as strings for consistency)
+                if (String(priority.value) === String(task.priority)) {
                     title = `✓ ${priority.label}`;
                 }
                 

--- a/src/modals/TaskActionPaletteModal.ts
+++ b/src/modals/TaskActionPaletteModal.ts
@@ -78,7 +78,7 @@ export class TaskActionPaletteModal extends FuzzySuggestModal<TaskAction> {
                 description: `Change task priority to ${priorityConfig.label}`,
                 icon: isCurrentPriority ? 'check' : 'flag',
                 category: 'priority',
-                keywords: ['priority', priorityConfig.value, priorityConfig.label, 'change', 'set'],
+                keywords: ['priority', String(priorityConfig.value), priorityConfig.label, 'change', 'set'],
                 isApplicable: () => !isCurrentPriority,
                 execute: async (task) => {
                     await this.plugin.updateTaskProperty(task, 'priority', priorityConfig.value);

--- a/src/modals/TaskModal.ts
+++ b/src/modals/TaskModal.ts
@@ -18,7 +18,7 @@ export abstract class TaskModal extends Modal {
     protected details = '';
     protected dueDate = '';
     protected scheduledDate = '';
-    protected priority = 'normal';
+    protected priority: string | number = 'normal';
     protected status = 'open';
     protected contexts = '';
     protected projects = '';
@@ -599,7 +599,7 @@ export abstract class TaskModal extends Modal {
         return 'open'; // fallback
     }
 
-    protected getDefaultPriority(): string {
+    protected getDefaultPriority(): string | number {
         // Get the priority with lowest weight as default
         const priorityConfigs = this.plugin.settings.customPriorities;
         if (priorityConfigs && priorityConfigs.length > 0) {
@@ -745,9 +745,9 @@ export abstract class TaskModal extends Modal {
         // Update priority icon
         const priorityIcon = this.actionBar.querySelector('[data-type="priority"]') as HTMLElement;
         if (priorityIcon) {
-            // Find the priority config to get the label and color
-            const priorityConfig = this.plugin.settings.customPriorities.find(p => p.value === this.priority);
-            const priorityLabel = priorityConfig ? priorityConfig.label : this.priority;
+            // Find the priority config to get the label and color (compare as strings for consistency)
+            const priorityConfig = this.plugin.settings.customPriorities.find(p => String(p.value) === String(this.priority));
+            const priorityLabel = priorityConfig ? priorityConfig.label : String(this.priority);
             
             if (this.priority && priorityConfig && priorityConfig.value !== this.getDefaultPriority()) {
                 priorityIcon.classList.add('has-value');

--- a/src/modals/UnscheduledTasksSelectorModal.ts
+++ b/src/modals/UnscheduledTasksSelectorModal.ts
@@ -120,8 +120,8 @@ export class UnscheduledTasksSelectorModal extends FuzzySuggestModal<TaskInfo> {
         // Priority indicator
         if (task.priority) {
             metaEl.createSpan({
-                text: task.priority.toUpperCase(),
-                cls: `unscheduled-tasks-selector__priority priority-${(task.priority || 'normal').toLowerCase()}`
+                text: String(task.priority).toUpperCase(),
+                cls: `unscheduled-tasks-selector__priority priority-${String(task.priority || 'normal').toLowerCase()}`
             });
         }
         

--- a/src/services/FieldMapper.ts
+++ b/src/services/FieldMapper.ts
@@ -155,8 +155,12 @@ export class FieldMapper {
 
     /**
      * Convert internal task data to frontmatter using mapping
+     * @param taskData The task data to convert
+     * @param taskTag Optional task tag to add to tags array
+     * @param storeTitleInFilename Whether title is stored in filename
+     * @param priorityValueType Optional type for priority values ('text' or 'number')
      */
-    mapToFrontmatter(taskData: Partial<TaskInfo>, taskTag?: string, storeTitleInFilename?: boolean): any {
+    mapToFrontmatter(taskData: Partial<TaskInfo>, taskTag?: string, storeTitleInFilename?: boolean, priorityValueType?: 'text' | 'number'): any {
         const frontmatter: any = {};
 
         // Map each field if it exists in task data
@@ -176,7 +180,17 @@ export class FieldMapper {
         }
 
         if (taskData.priority !== undefined) {
-            frontmatter[this.mapping.priority] = taskData.priority;
+            // Convert priority value based on priorityValueType setting
+            let priorityValue: string | number = taskData.priority;
+            if (priorityValueType === 'number') {
+                const numValue = Number(taskData.priority);
+                if (!isNaN(numValue)) {
+                    priorityValue = numValue;
+                }
+            } else if (priorityValueType === 'text') {
+                priorityValue = String(taskData.priority);
+            }
+            frontmatter[this.mapping.priority] = priorityValue;
         }
 
         if (taskData.due !== undefined) {

--- a/src/services/FilterService.ts
+++ b/src/services/FilterService.ts
@@ -954,8 +954,9 @@ export class FilterService extends EventEmitter {
 
     /**
      * Compare priorities using PriorityManager weights
+     * Supports both string and numeric priority values
      */
-    private comparePriorities(priorityA: string, priorityB: string): number {
+    private comparePriorities(priorityA: string | number, priorityB: string | number): number {
         const weightA = this.priorityManager.getPriorityWeight(priorityA);
         const weightB = this.priorityManager.getPriorityWeight(priorityB);
 
@@ -1178,7 +1179,7 @@ export class FilterService extends EventEmitter {
                             groupValue = task.status || 'no-status';
                             break;
                         case 'priority':
-                            groupValue = task.priority || 'unknown';
+                            groupValue = String(task.priority || 'unknown');
                             break;
                         case 'context':
                             // For multiple contexts, put task in first context or 'none'

--- a/src/services/InstantTaskConvertService.ts
+++ b/src/services/InstantTaskConvertService.ts
@@ -373,7 +373,7 @@ export class InstantTaskConvertService {
         const parsedScheduledTime = parsedData.scheduledTime?.trim() || undefined;
         
         // Apply task creation defaults if setting is enabled
-        let priority: string | undefined;
+        let priority: string | number | undefined;
         let status: string | undefined;
         let dueDate: string | undefined;
         let scheduledDate: string | undefined;
@@ -535,13 +535,15 @@ export class InstantTaskConvertService {
     }
 
     /**
-     * Sanitize priority input
+     * Sanitize priority input (supports both string and number)
      */
-    private sanitizePriority(priority: string): string {
+    private sanitizePriority(priority: string | number): string | number {
         const validPriorities = this.priorityManager.getAllPriorities()
             .map((p: any) => p && typeof p === 'object' ? p.value : p)
             .filter(value => value != null);
-        return validPriorities.includes(priority) ? priority : '';
+        const normalizedPriority = String(priority);
+        const found = validPriorities.find(v => String(v) === normalizedPriority);
+        return found !== undefined ? found : '';
     }
 
     /**

--- a/src/services/NaturalLanguageParser.ts
+++ b/src/services/NaturalLanguageParser.ts
@@ -11,7 +11,7 @@ export interface ParsedTaskData {
     scheduledDate?: string;
     dueTime?: string;
     scheduledTime?: string;
-    priority?: string;
+    priority?: string | number; // Supports both text and numeric priorities
     status?: string;
     tags: string[];
     contexts: string[];
@@ -23,7 +23,7 @@ export interface ParsedTaskData {
 
 interface RegexPattern {
     regex: RegExp;
-    value: string;
+    value: string | number; // Supports both text and numeric priority values
 }
 
 /**
@@ -245,16 +245,20 @@ export class NaturalLanguageParser {
     /**
      * Pre-builds priority regex patterns from configuration for efficiency.
      * Creates patterns for both custom priority configs and language fallbacks.
+     * Supports both text and numeric priority values.
      * 
      * @param configs Custom priority configurations
      * @returns Array of compiled regex patterns with their corresponding priority values
      */
     private buildPriorityPatterns(configs: PriorityConfig[]): RegexPattern[] {
         if (configs.length > 0) {
-            return configs.flatMap(config => [
-                { regex: new RegExp(`\\b${this.escapeRegex(config.value)}\\b`, 'i'), value: config.value },
-                { regex: new RegExp(`\\b${this.escapeRegex(config.label)}\\b`, 'i'), value: config.value }
-            ]);
+            return configs.flatMap(config => {
+                const valueStr = String(config.value);
+                return [
+                    { regex: new RegExp(`\\b${this.escapeRegex(valueStr)}\\b`, 'i'), value: config.value },
+                    { regex: new RegExp(`\\b${this.escapeRegex(config.label)}\\b`, 'i'), value: config.value }
+                ];
+            });
         }
         // Fallback patterns from language config - order matters, most specific first
         const patterns: RegexPattern[] = [];
@@ -373,7 +377,7 @@ export class NaturalLanguageParser {
         // Fallback to regex patterns for built-in status keywords
         for (const pattern of this.statusPatterns) {
             if (pattern.regex.test(text)) {
-                result.status = pattern.value;
+                result.status = String(pattern.value);
                 return this.cleanupWhitespace(text.replace(pattern.regex, ''));
             }
         }

--- a/src/services/PriorityManager.ts
+++ b/src/services/PriorityManager.ts
@@ -7,10 +7,20 @@ export class PriorityManager {
     constructor(private priorities: PriorityConfig[]) {}
 
     /**
-     * Get priority configuration by value
+     * Normalize priority value to string for comparison
      */
-    getPriorityConfig(value: string): PriorityConfig | undefined {
-        return this.priorities.find(p => p.value === value);
+    private normalizeValue(value: string | number | undefined): string {
+        if (value === undefined || value === null) return '';
+        return String(value);
+    }
+
+    /**
+     * Get priority configuration by value (supports both string and number)
+     */
+    getPriorityConfig(value: string | number | undefined): PriorityConfig | undefined {
+        if (value === undefined || value === null) return undefined;
+        const normalizedValue = this.normalizeValue(value);
+        return this.priorities.find(p => this.normalizeValue(p.value) === normalizedValue);
     }
 
     /**
@@ -30,9 +40,10 @@ export class PriorityManager {
     /**
      * Get next priority in cycle (cycling by weight order)
      */
-    getNextPriority(currentPriority: string): string {
+    getNextPriority(currentPriority: string | number): string | number {
         const sortedPriorities = this.getPrioritiesByWeightAsc();
-        const currentIndex = sortedPriorities.findIndex(p => p.value === currentPriority);
+        const normalizedCurrent = this.normalizeValue(currentPriority);
+        const currentIndex = sortedPriorities.findIndex(p => this.normalizeValue(p.value) === normalizedCurrent);
         
         if (currentIndex === -1) {
             // Current priority not found, return first priority
@@ -48,7 +59,7 @@ export class PriorityManager {
      * Compare priorities for sorting (higher weight = higher priority)
      * Returns negative if a has lower priority, positive if higher, 0 if equal
      */
-    comparePriorities(a: string, b: string): number {
+    comparePriorities(a: string | number, b: string | number): number {
         const priorityA = this.getPriorityConfig(a);
         const priorityB = this.getPriorityConfig(b);
         
@@ -66,7 +77,7 @@ export class PriorityManager {
         const cssRules: string[] = [];
         
         for (const priority of this.priorities) {
-            const cssClass = `--priority-${priority.value.replace(/[^a-zA-Z0-9-]/g, '-')}-color`;
+            const cssClass = `--priority-${String(priority.value).replace(/[^a-zA-Z0-9-]/g, '-')}-color`;
             cssRules.push(`${cssClass}: ${priority.color};`);
         }
         
@@ -90,7 +101,7 @@ export class PriorityManager {
     /**
      * Get the highest priority value (highest weight)
      */
-    getHighestPriority(): string | undefined {
+    getHighestPriority(): string | number | undefined {
         const sorted = this.getPrioritiesByWeight();
         return sorted[0]?.value;
     }
@@ -98,7 +109,7 @@ export class PriorityManager {
     /**
      * Get the lowest priority value (lowest weight)
      */
-    getLowestPriority(): string | undefined {
+    getLowestPriority(): string | number | undefined {
         const sorted = this.getPrioritiesByWeightAsc();
         return sorted[0]?.value;
     }
@@ -106,7 +117,7 @@ export class PriorityManager {
     /**
      * Get priority weight for sorting
      */
-    getPriorityWeight(priority: string): number {
+    getPriorityWeight(priority: string | number): number {
         const config = this.getPriorityConfig(priority);
         return config?.weight || 0;
     }
@@ -114,7 +125,7 @@ export class PriorityManager {
     /**
      * Check if priority A is higher than priority B
      */
-    isHigherPriority(a: string, b: string): boolean {
+    isHigherPriority(a: string | number, b: string | number): boolean {
         return this.comparePriorities(a, b) > 0;
     }
 
@@ -152,11 +163,11 @@ export class PriorityManager {
 
         // Check for empty values and labels
         for (const priority of priorities) {
-            if (!priority.value || priority.value.trim() === '') {
+            if (priority.value === undefined || priority.value === null || String(priority.value).trim() === '') {
                 errors.push('Priority values cannot be empty');
                 break;
             }
-            if (!priority.label || priority.label.trim() === '') {
+            if (!priority.label || String(priority.label).trim() === '') {
                 errors.push('Priority labels cannot be empty');
                 break;
             }

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -99,7 +99,7 @@ export class TaskService {
             
             // Handle priority
             const priority = taskData.priority || '';
-            processedPath = processedPath.replace(/\{\{priority\}\}/g, priority);
+            processedPath = processedPath.replace(/\{\{priority\}\}/g, String(priority));
             
             // Handle status
             const status = taskData.status || '';
@@ -117,7 +117,7 @@ export class TaskService {
             processedPath = processedPath.replace(/\{\{scheduledDate\}\}/g, scheduledDate);
             
             // Priority and status variations
-            const priorityShort = priority ? priority.substring(0, 1).toUpperCase() : '';
+            const priorityShort = priority ? String(priority).substring(0, 1).toUpperCase() : '';
             processedPath = processedPath.replace(/\{\{priorityShort\}\}/g, priorityShort);
             
             const statusShort = status ? status.substring(0, 1).toUpperCase() : '';
@@ -307,7 +307,12 @@ export class TaskService {
             };
 
             // Use field mapper to convert to frontmatter with proper field mapping
-            const frontmatter = this.plugin.fieldMapper.mapToFrontmatter(completeTaskData, this.plugin.settings.taskTag, this.plugin.settings.storeTitleInFilename);
+            const frontmatter = this.plugin.fieldMapper.mapToFrontmatter(
+                completeTaskData, 
+                this.plugin.settings.taskTag, 
+                this.plugin.settings.storeTitleInFilename,
+                this.plugin.settings.priorityValueType
+            );
             
             // Handle task identification based on settings
             if (this.plugin.settings.taskIdentificationMethod === 'property') {
@@ -1040,7 +1045,8 @@ export class TaskService {
                 const mappedFrontmatter = this.plugin.fieldMapper.mapToFrontmatter(
                     completeTaskData,
                     this.plugin.settings.taskTag,
-                    this.plugin.settings.storeTitleInFilename
+                    this.plugin.settings.storeTitleInFilename,
+                    this.plugin.settings.priorityValueType
                 );
 
                 Object.keys(mappedFrontmatter).forEach(key => {

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -68,7 +68,7 @@ export const DEFAULT_STATUSES: StatusConfig[] = [
 	}
 ];
 
-// Default priority configuration matches current hardcoded behavior
+// Default priority configuration - uses text values for backward compatibility
 export const DEFAULT_PRIORITIES: PriorityConfig[] = [
 	{
 		id: 'none',
@@ -183,7 +183,7 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	taskPropertyName: '',
 	taskPropertyValue: '',
 	excludedFolders: '',  // Default to no excluded folders
-	defaultTaskPriority: 'normal',
+	defaultTaskPriority: 'normal',  // Text priority for backward compatibility
 	defaultTaskStatus: 'open',
 	taskOrgFiltersCollapsed: false,  // Default to expanded
 	// Task filename defaults
@@ -230,6 +230,7 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	fieldMapping: DEFAULT_FIELD_MAPPING,
 	customStatuses: DEFAULT_STATUSES,
 	customPriorities: DEFAULT_PRIORITIES,
+	priorityValueType: 'text',  // Default to text for backward compatibility
 	// Migration defaults
 	recurrenceMigrated: false,
 	// Status bar defaults

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -468,10 +468,10 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 				dropdown.selectEl.setAttribute('aria-label', 'Default priority for new tasks');
 				// Populate with custom priorities
 				this.plugin.settings.customPriorities.forEach(priority => {
-					dropdown.addOption(priority.value, priority.label);
+					dropdown.addOption(String(priority.value), priority.label);
 				});
 				return dropdown
-					.setValue(this.plugin.settings.defaultTaskPriority)
+					.setValue(String(this.plugin.settings.defaultTaskPriority))
 					.onChange(async (value: any) => {
 						this.plugin.settings.defaultTaskPriority = value;
 						await this.plugin.saveSettings();
@@ -2530,7 +2530,7 @@ export class TaskNotesSettingTab extends PluginSettingTab {
 			// Priority value input
 			const valueInput = priorityRow.createEl('input', {
 				type: 'text',
-				value: priority.value,
+				value: String(priority.value),
 				cls: 'settings-input value-input settings-view__input settings-view__input--value',
 				attr: {
 					'aria-label': `Priority value for ${priority.label}`,

--- a/src/settings/tabs/defaultsTab.ts
+++ b/src/settings/tabs/defaultsTab.ts
@@ -46,13 +46,15 @@ export function renderDefaultsTab(container: HTMLElement, plugin: TaskNotesPlugi
         options: [
             { value: '', label: 'No default' },
             ...plugin.settings.customPriorities.map(priority => ({
-                value: priority.value,
-                label: priority.label || priority.value
+                value: String(priority.value),
+                label: String(priority.label || priority.value)
             }))
         ],
-        getValue: () => plugin.settings.defaultTaskPriority,
+        getValue: () => String(plugin.settings.defaultTaskPriority),
         setValue: async (value: string) => {
-            plugin.settings.defaultTaskPriority = value;
+            // Convert back to number if the value looks like a number
+            const numericValue = Number(value);
+            plugin.settings.defaultTaskPriority = !isNaN(numericValue) && value !== '' ? numericValue : value;
             save();
         }
     });

--- a/src/settings/tabs/taskPropertiesTab.ts
+++ b/src/settings/tabs/taskPropertiesTab.ts
@@ -93,10 +93,11 @@ export function renderTaskPropertiesTab(container: HTMLElement, plugin: TaskNote
     const priorityHelpContainer = container.createDiv('tasknotes-settings__help-section');
     priorityHelpContainer.createEl('h4', { text: 'How priorities work:' });
     const priorityHelpList = priorityHelpContainer.createEl('ul');
-    priorityHelpList.createEl('li', { text: 'Value: The internal identifier stored in your task files (e.g., "high")' });
+    priorityHelpList.createEl('li', { text: 'Value: The identifier stored in task files - supports both numbers (1, 2, 3) and text (high, normal, low)' });
     priorityHelpList.createEl('li', { text: 'Display Label: The display name shown in the interface (e.g., "High Priority")' });
     priorityHelpList.createEl('li', { text: 'Color: Visual indicator color for the priority dot and badges' });
     priorityHelpList.createEl('li', { text: 'Weight: Numeric value for sorting (higher weights appear first in lists)' });
+    priorityHelpList.createEl('li', { text: 'Value Type: Choose whether to store priorities as numbers or text in your task files' });
     priorityHelpContainer.createEl('p', {
         text: 'Tasks are automatically sorted by priority weight in descending order (highest weight first). Weights can be any positive number.',
         cls: 'settings-help-note'
@@ -116,7 +117,7 @@ export function renderTaskPropertiesTab(container: HTMLElement, plugin: TaskNote
                 const newId = `priority_${Date.now()}`;
                 const newPriority = {
                     id: newId,
-                    value: '',
+                    value: plugin.settings.priorityValueType === 'number' ? 0 : '',
                     label: '',
                     color: '#6366f1',
                     weight: 1
@@ -124,6 +125,19 @@ export function renderTaskPropertiesTab(container: HTMLElement, plugin: TaskNote
                 plugin.settings.customPriorities.push(newPriority);
                 save();
                 renderPriorityList(priorityList, plugin, save);
+            }));
+
+    // Priority value type setting
+    new Setting(container)
+        .setName('Priority value type')
+        .setDesc('How priority values are stored in your task files. Text (e.g., "high", "low") or Number (e.g., 1, 2, 3)')
+        .addDropdown(dropdown => dropdown
+            .addOption('text', 'Text')
+            .addOption('number', 'Number')
+            .setValue(plugin.settings.priorityValueType || 'number')
+            .onChange(async (value: 'text' | 'number') => {
+                plugin.settings.priorityValueType = value;
+                save();
             }));
 
     createValidationNote(container, 'Note: You must have at least 1 priority. Higher weights take precedence in sorting and visual hierarchy.');
@@ -392,7 +406,7 @@ function renderPriorityList(container: HTMLElement, plugin: TaskNotesPlugin, sav
     const sortedPriorities = [...plugin.settings.customPriorities].sort((a, b) => b.weight - a.weight);
     
     sortedPriorities.forEach((priority, index) => {
-        const valueInput = createCardInput('text', 'high', priority.value);
+        const valueInput = createCardInput('text', '1 or high', String(priority.value));
         const labelInput = createCardInput('text', 'High Priority', priority.label);
         const colorInput = createCardInput('color', '', priority.color);
         const weightInput = createCardNumberInput(0, undefined, 1, priority.weight);
@@ -403,7 +417,7 @@ function renderPriorityList(container: HTMLElement, plugin: TaskNotesPlugin, sav
             defaultCollapsed: true,
             colorIndicator: { color: priority.color },
             header: {
-                primaryText: priority.label || priority.value || 'untitled',
+                primaryText: String(priority.label || priority.value || 'untitled'),
                 secondaryText: `Weight: ${priority.weight}`,
                 actions: [
                     createDeleteHeaderButton(() => {
@@ -430,13 +444,16 @@ function renderPriorityList(container: HTMLElement, plugin: TaskNotesPlugin, sav
         });
 
         valueInput.addEventListener('change', () => {
-            priority.value = valueInput.value;
+            // Support both numeric and text priority values
+            const inputValue = valueInput.value.trim();
+            const numericValue = Number(inputValue);
+            priority.value = !isNaN(numericValue) && inputValue !== '' ? numericValue : inputValue;
             save();
         });
 
         labelInput.addEventListener('change', () => {
             priority.label = labelInput.value;
-            card.querySelector('.tasknotes-settings__card-primary-text')!.textContent = priority.label || priority.value || 'untitled';
+            card.querySelector('.tasknotes-settings__card-primary-text')!.textContent = String(priority.label || priority.value || 'untitled');
             save();
         });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,7 +225,7 @@ export interface TaskInfo {
 	id?: string; // Task identifier (typically same as path for API consistency)
 	title: string;
 	status: string;
-	priority: string;
+	priority: string | number; // Supports both text ("high") and numeric (1, 2, 3) priorities
 	due?: string;
 	scheduled?: string; // Date (YYYY-MM-DD) when task is scheduled to be worked on
 	path: string;
@@ -322,7 +322,7 @@ export interface TaskFrontmatter {
 	due?: string;
 	scheduled?: string;
 	tags: string[];
-	priority: 'low' | 'normal' | 'high';
+	priority: string | number; // Supports both text ('low'|'normal'|'high') and numeric priorities
 	contexts?: string[];
 	projects?: string[];
 	recurrence?: string | RecurrenceInfo | undefined; // RFC 5545 recurrence rule string (preferred) or legacy RecurrenceInfo object (deprecated)
@@ -435,7 +435,7 @@ export interface StatusConfig {
 
 export interface PriorityConfig {
 	id: string;          // Unique identifier
-	value: string;       // What gets written to YAML
+	value: string | number; // What gets written to YAML (supports both text and numeric priorities)
 	label: string;       // What displays in UI
 	color: string;       // Hex color for indicators
 	weight: number;      // For sorting (higher = more important)

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -34,7 +34,7 @@ export interface TaskNotesSettings {
 	taskPropertyName: string;     // Property name for property-based identification
 	taskPropertyValue: string;    // Property value for property-based identification
 	excludedFolders: string;  // Comma-separated list of folders to exclude from Notes tab
-	defaultTaskPriority: string;  // Changed to string to support custom priorities
+	defaultTaskPriority: string | number;  // Supports both text and numeric priorities
 	defaultTaskStatus: string;    // Changed to string to support custom statuses
 	taskOrgFiltersCollapsed: boolean;  // Save collapse state of task organization filters
 	// Task filename settings
@@ -82,6 +82,7 @@ export interface TaskNotesSettings {
 	fieldMapping: FieldMapping;
 	customStatuses: StatusConfig[];
 	customPriorities: PriorityConfig[];
+	priorityValueType: 'text' | 'number';  // How priority values are stored in frontmatter
 	// Migration tracking
 	recurrenceMigrated?: boolean;
 	// Status bar settings

--- a/src/ui/FilterBar.ts
+++ b/src/ui/FilterBar.ts
@@ -1221,7 +1221,8 @@ export class FilterBar extends EventEmitter {
                 break;
             case 'priority':
                 this.filterOptions.priorities.forEach(priorityConfig => {
-                    dropdown.addOption(priorityConfig.value, priorityConfig.label);
+                    // Convert value to string for dropdown (supports both numeric and text priorities)
+                    dropdown.addOption(String(priorityConfig.value), priorityConfig.label);
                 });
                 break;
             case 'tags':

--- a/src/utils/MinimalNativeCache.ts
+++ b/src/utils/MinimalNativeCache.ts
@@ -531,7 +531,7 @@ export class MinimalNativeCache extends Events {
             if (metadata?.frontmatter && this.isTaskFile(metadata.frontmatter)) {
                 const taskInfo = this.extractTaskInfoFromNative(file.path, metadata.frontmatter);
                 if (taskInfo?.priority) {
-                    priorities.add(taskInfo.priority);
+                    priorities.add(String(taskInfo.priority));
                 }
             }
         }

--- a/src/utils/TasksPluginParser.ts
+++ b/src/utils/TasksPluginParser.ts
@@ -3,7 +3,7 @@ import { parseDateToUTC, isPastDate, isToday, formatDateForStorage } from './dat
 export interface ParsedTaskData {
 	title: string;
 	status?: string;
-	priority?: string;
+	priority?: string | number;
 	dueDate?: string;
 	scheduledDate?: string;
 	dueTime?: string;

--- a/src/utils/filenameGenerator.ts
+++ b/src/utils/filenameGenerator.ts
@@ -4,7 +4,7 @@ import { TaskNotesSettings } from '../types/settings';
 
 export interface FilenameContext {
     title: string;
-    priority: string;
+    priority: string | number;
     status: string;
     date?: Date;
     dueDate?: string; // YYYY-MM-DD format
@@ -194,7 +194,8 @@ function generateCustomFilename(
     try {
         // Validate and sanitize context values
         const sanitizedTitle = sanitizeForFilename(context.title);
-        const sanitizedPriority = (context.priority && ['low', 'normal', 'medium', 'high'].includes(context.priority)) ? context.priority : 'normal';
+        const priorityStr = String(context.priority || 'normal');
+        const sanitizedPriority = (context.priority && ['low', 'normal', 'medium', 'high'].includes(priorityStr)) ? priorityStr : 'normal';
         const sanitizedStatus = (context.status && ['open', 'in-progress', 'done', 'scheduled'].includes(context.status)) ? context.status : 'open';
         
         const variables: Record<string, string> = {

--- a/src/utils/templateProcessor.ts
+++ b/src/utils/templateProcessor.ts
@@ -4,7 +4,7 @@ import { parseYaml } from 'obsidian';
 
 export interface TemplateData {
     title: string;
-    priority: string;
+    priority: string | number;
     status: string;
     contexts: string[];
     tags: string[];
@@ -135,8 +135,8 @@ function processTemplateVariablesForYaml(template: string, taskData: TemplateDat
     const quotedTitle = needsYamlQuoting(title) ? `"${escapeYamlString(title)}"` : title;
     result = result.replace(/\{\{title\}\}/g, quotedTitle);
     
-    // {{priority}} - Task priority
-    result = result.replace(/\{\{priority\}\}/g, taskData.priority || '');
+    // {{priority}} - Task priority (supports both string and number)
+    result = result.replace(/\{\{priority\}\}/g, String(taskData.priority || ''));
     
     // {{status}} - Task status
     result = result.replace(/\{\{status\}\}/g, taskData.status || '');
@@ -253,8 +253,8 @@ function processTemplateVariables(template: string, taskData: TemplateData | ICS
     // {{title}} - Task title
     result = result.replace(/\{\{title\}\}/g, taskData.title || '');
     
-    // {{priority}} - Task priority
-    result = result.replace(/\{\{priority\}\}/g, taskData.priority || '');
+    // {{priority}} - Task priority (supports both string and number)
+    result = result.replace(/\{\{priority\}\}/g, String(taskData.priority || ''));
     
     // {{status}} - Task status
     result = result.replace(/\{\{status\}\}/g, taskData.status || '');


### PR DESCRIPTION
Try to close #1289 

I had the AI write it, and after finishing, I roughly reviewed the changes it made.  
Then I realized the amount of changes involved is indeed quite substantial, and I understand the difficulty of this requirement now. 😅  

However, most of the changes are type conversions—which, in a way, is quite suitable for AI to handle ;)  

This PR is just a reminder and is not urgent to merge. **I’ll test it locally for a while to see if it works properly.**  

Also, if anyone else is interested in the priority of numeric types, feel free to give it a try. Salute!

---

- Add support for both string and number types in priority values
- **Add 'Priority value type' setting to choose output format (text/number)**
- FieldMapper converts priority to chosen format when writing frontmatter
- **Default to text values** for backward compatibility

<img width="951" height="656" alt="Snipaste_2026-03-11_14-28-49" src="https://github.com/user-attachments/assets/7a6cdb78-c420-4bd7-b6c4-9d0468854e26" />


