### PR TITLE
feat: preserve [[wikilinks]] in task titles

### DIFF
--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -195,6 +195,7 @@ export function createTaskInfoFromBasesData(
 		// Merge file properties with existing custom properties
 		return {
 			...taskInfo,
+			displayTitle: taskInfo.rawTitle || undefined,
 			customProperties: {
 				...mappedTaskInfo.customProperties,
 				...taskInfo.customProperties,

--- a/src/modals/TaskCreationModal.ts
+++ b/src/modals/TaskCreationModal.ts
@@ -1310,8 +1310,14 @@ export class TaskCreationModal extends TaskModal {
 			tagList.push(this.plugin.settings.taskTag);
 		}
 
+		// Capture raw NLP input for H1 heading (preserves [[wikilinks]])
+		const rawTitle = this.plugin.settings.enableNaturalLanguageInput
+			? this.getNLPInputValue().trim().split("\n")[0] || this.title.trim()
+			: this.title.trim();
+
 		const taskData: TaskCreationData = {
 			title: this.title.trim(),
+			rawTitle,
 			due: this.dueDate || undefined,
 			scheduled: this.scheduledDate || undefined,
 			priority: this.priority,

--- a/src/services/FieldMapper.ts
+++ b/src/services/FieldMapper.ts
@@ -182,6 +182,11 @@ export class FieldMapper {
 			mapped.sortOrder = typeof val === "string" ? val : String(val);
 		}
 
+		// Preserve raw title with [[wikilinks]] for display
+		if (frontmatter.rawTitle !== undefined) {
+			mapped.rawTitle = frontmatter.rawTitle;
+		}
+
 		// Handle tags array (includes archive tag)
 		if (frontmatter.tags && Array.isArray(frontmatter.tags)) {
 			mapped.tags = frontmatter.tags;

--- a/src/services/task-service/TaskCreationService.ts
+++ b/src/services/task-service/TaskCreationService.ts
@@ -161,6 +161,11 @@ export class TaskCreationService {
 				finalFrontmatter = { ...finalFrontmatter, ...taskData.customFrontmatter };
 			}
 
+			// Store raw title with [[wikilinks]] preserved in frontmatter
+			if (taskData.rawTitle && taskData.rawTitle !== title) {
+				finalFrontmatter.rawTitle = taskData.rawTitle;
+			}
+
 			const yamlHeader = stringifyYaml(finalFrontmatter);
 			let content = `---\n${yamlHeader}---\n\n`;
 			if (normalizedBody.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -466,6 +466,8 @@ export interface TaskInfo {
 	isBlocking?: boolean; // True if this task blocks at least one other task
 	details?: string; // Optional task body content
 	sortOrder?: string; // LexoRank string for ordering within column
+	rawTitle?: string; // Raw title with [[wikilinks]] preserved (for H1 heading)
+	displayTitle?: string; // Title resolved from H1 heading (for rendering with links)
 }
 
 export interface TaskCreationData extends Partial<TaskInfo> {

--- a/src/ui/TaskCard.ts
+++ b/src/ui/TaskCard.ts
@@ -1544,9 +1544,15 @@ export function createTaskCard(
 		await showTaskContextMenu(e as MouseEvent, task.path, plugin, targetDate);
 	});
 
-	// First line: Task title
+	// First line: Task title (rendered with link support)
 	const titleEl = contentContainer.createEl(layout === "inline" ? "span" : "div", { cls: "task-card__title" });
-	const titleTextEl = titleEl.createSpan({ cls: "task-card__title-text", text: task.title });
+	const titleTextEl = titleEl.createSpan({ cls: "task-card__title-text" });
+	const titleLinkServices: LinkServices = {
+		metadataCache: plugin.app.metadataCache,
+		workspace: plugin.app.workspace,
+		sourcePath: task.path,
+	};
+	renderTextWithLinks(titleTextEl, task.displayTitle || task.title, titleLinkServices);
 
 	if (isCompleted) {
 		titleEl.classList.add("completed");
@@ -2066,7 +2072,13 @@ export function updateTaskCard(
 	const titleContainer = element.querySelector(".task-card__title") as HTMLElement;
 	const titleIsCompleted = isCompleted;
 	if (titleText) {
-		titleText.textContent = task.title;
+		titleText.innerHTML = "";
+		const updateLinkServices: LinkServices = {
+			metadataCache: plugin.app.metadataCache,
+			workspace: plugin.app.workspace,
+			sourcePath: task.path,
+		};
+		renderTextWithLinks(titleText, task.displayTitle || task.title, updateLinkServices);
 		titleText.classList.toggle("completed", titleIsCompleted);
 	}
 	if (titleContainer) {

--- a/src/utils/TaskManager.ts
+++ b/src/utils/TaskManager.ts
@@ -284,6 +284,7 @@ export class TaskManager extends Events {
 				id: path, // Add id field for API consistency
 				path, // Ensure path is set (FieldMapper should set this, but be explicit)
 				title: mappedTask.title || "Untitled task",
+				displayTitle: mappedTask.rawTitle || undefined,
 				status: mappedTask.status || this.settings.defaultTaskStatus,
 				priority: mappedTask.priority || "normal",
 				archived: mappedTask.archived || false,


### PR DESCRIPTION
Closes #1733

When creating a task with `[[wikilinks]]` in the title, the NLP parser strips the link markup, making links unclickable in task cards.

This stores the raw NLP input as `rawTitle` in frontmatter (only when it differs from the parsed title) and renders it with link support in task cards across kanban, list, and Bases views.

No breaking changes - existing tasks without `rawTitle` fall back to `task.title`.