### PR TITLE
Fix Google Calendar sync race condition and recurring completion date bug

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -23,3 +23,8 @@ Example:
 ```
 
 -->
+
+## Fixed
+
+- (#1764) Fixed Google Calendar sync using stale task metadata after rapid task updates, and fixed late recurring completions/skips recording the completion day instead of the scheduled occurrence date.
+  - Thanks to @martin-forge for the PR and to @jpmoo for reporting the recurring completion issues.

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import { TaskEditModal } from "./modals/TaskEditModal";
 import { openTaskSelector } from "./modals/TaskSelectorWithCreateModal";
 import { PomodoroService } from "./services/PomodoroService";
 import { formatTime, getActiveTimeEntry } from "./utils/helpers";
-import { convertUTCToLocalCalendarDate, getCurrentTimestamp } from "./utils/dateUtils";
+import { convertUTCToLocalCalendarDate, getCurrentTimestamp, getDatePart, parseDateToUTC } from "./utils/dateUtils";
 import { TaskManager } from "./utils/TaskManager";
 import { DependencyCache } from "./utils/DependencyCache";
 import { RequestDeduplicator, PredictivePrefetcher } from "./utils/RequestDeduplicator";
@@ -1063,11 +1063,13 @@ export default class TaskNotesPlugin extends Plugin {
 			// Let TaskService handle the date logic (defaults to local today, not selectedDate)
 			const updatedTask = await this.taskService.toggleRecurringTaskComplete(task, date);
 
-			// For notification, determine the actual completion date from the task
-			// Use local today if no explicit date provided
+			// Use the same implicit-date resolution as TaskService (#396)
 			const targetDate =
 				date ||
 				(() => {
+					if (task.recurrence_anchor !== "completion" && task.scheduled) {
+						return parseDateToUTC(getDatePart(task.scheduled));
+					}
 					const todayLocal = getTodayLocal();
 					return createUTCDateFromLocalCalendarDate(todayLocal);
 				})();

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import { TaskEditModal } from "./modals/TaskEditModal";
 import { openTaskSelector } from "./modals/TaskSelectorWithCreateModal";
 import { PomodoroService } from "./services/PomodoroService";
 import { formatTime, getActiveTimeEntry } from "./utils/helpers";
-import { convertUTCToLocalCalendarDate, getCurrentTimestamp, getDatePart, parseDateToUTC } from "./utils/dateUtils";
+import { convertUTCToLocalCalendarDate, getCurrentTimestamp } from "./utils/dateUtils";
 import { TaskManager } from "./utils/TaskManager";
 import { DependencyCache } from "./utils/DependencyCache";
 import { RequestDeduplicator, PredictivePrefetcher } from "./utils/RequestDeduplicator";
@@ -49,7 +49,6 @@ import { ViewStateManager } from "./services/ViewStateManager";
 import { DragDropManager } from "./utils/DragDropManager";
 import {
 	formatDateForStorage,
-	createUTCDateFromLocalCalendarDate,
 	parseDateToLocal,
 	getTodayLocal,
 } from "./utils/dateUtils";
@@ -1060,20 +1059,8 @@ export default class TaskNotesPlugin extends Plugin {
 	 */
 	async toggleRecurringTaskComplete(task: TaskInfo, date?: Date): Promise<TaskInfo> {
 		try {
-			// Resolve the implicit date from cacheManager — the same authoritative
-			// source the service uses — before the service mutates state (#396)
-			const freshTask = (await this.cacheManager.getTaskInfo(task.path)) || task;
-			const targetDate =
-				date ||
-				(() => {
-					if (freshTask.recurrence_anchor !== "completion" && freshTask.scheduled) {
-						return parseDateToUTC(getDatePart(freshTask.scheduled));
-					}
-					const todayLocal = getTodayLocal();
-					return createUTCDateFromLocalCalendarDate(todayLocal);
-				})();
-
-			const updatedTask = await this.taskService.toggleRecurringTaskComplete(task, date);
+			const targetDate = await this.taskService.resolveRecurringTaskActionDate(task, date);
+			const updatedTask = await this.taskService.toggleRecurringTaskComplete(task, targetDate);
 
 			const dateStr = formatDateForStorage(targetDate);
 			const wasCompleted = updatedTask.complete_instances?.includes(dateStr);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1060,19 +1060,20 @@ export default class TaskNotesPlugin extends Plugin {
 	 */
 	async toggleRecurringTaskComplete(task: TaskInfo, date?: Date): Promise<TaskInfo> {
 		try {
-			// Let TaskService handle the date logic (defaults to local today, not selectedDate)
-			const updatedTask = await this.taskService.toggleRecurringTaskComplete(task, date);
-
-			// Use the same implicit-date resolution as TaskService (#396)
+			// Resolve the implicit date from cacheManager — the same authoritative
+			// source the service uses — before the service mutates state (#396)
+			const freshTask = (await this.cacheManager.getTaskInfo(task.path)) || task;
 			const targetDate =
 				date ||
 				(() => {
-					if (task.recurrence_anchor !== "completion" && task.scheduled) {
-						return parseDateToUTC(getDatePart(task.scheduled));
+					if (freshTask.recurrence_anchor !== "completion" && freshTask.scheduled) {
+						return parseDateToUTC(getDatePart(freshTask.scheduled));
 					}
 					const todayLocal = getTodayLocal();
 					return createUTCDateFromLocalCalendarDate(todayLocal);
 				})();
+
+			const updatedTask = await this.taskService.toggleRecurringTaskComplete(task, date);
 
 			const dateStr = formatDateForStorage(targetDate);
 			const wasCompleted = updatedTask.complete_instances?.includes(dateStr);

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -19,8 +19,6 @@ const GOOGLE_API_CALL_SPACING_MS = 100;
 /**
  * Service for syncing TaskNotes tasks to Google Calendar.
  * Handles creating, updating, and deleting calendar events when tasks change.
- * 
- * Patched locally: __codexTaskCalendarDebounceStaleCachePatch20260404
  */
 export class TaskCalendarSyncService {
 	private plugin: TaskNotesPlugin;
@@ -789,9 +787,9 @@ export class TaskCalendarSyncService {
 				const latestTask = this.pendingTasks.get(taskPath);
 				this.pendingTasks.delete(taskPath);
 
-				// Fallback to cache ONLY if for some reason the pending task is missing
+				// Fallback to cache only if the pending task is missing
 				const freshTask = latestTask || await this.plugin.cacheManager.getTaskInfo(taskPath);
-				
+
 				if (!freshTask) {
 					resolve();
 					return;

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -19,6 +19,8 @@ const GOOGLE_API_CALL_SPACING_MS = 100;
 /**
  * Service for syncing TaskNotes tasks to Google Calendar.
  * Handles creating, updating, and deleting calendar events when tasks change.
+ * 
+ * Patched locally: __codexTaskCalendarDebounceStaleCachePatch20260404
  */
 export class TaskCalendarSyncService {
 	private plugin: TaskNotesPlugin;
@@ -35,6 +37,9 @@ export class TaskCalendarSyncService {
 	/** Track previous task state for detecting recurrence removal */
 	private previousTaskState: Map<string, TaskInfo> = new Map();
 
+	/** Store the latest explicitly passed task object during debounce to avoid cache race conditions */
+	private pendingTasks: Map<string, TaskInfo> = new Map();
+
 	constructor(plugin: TaskNotesPlugin, googleCalendarService: GoogleCalendarService) {
 		this.plugin = plugin;
 		this.googleCalendarService = googleCalendarService;
@@ -49,6 +54,7 @@ export class TaskCalendarSyncService {
 		}
 		this.pendingSyncs.clear();
 		this.previousTaskState.clear();
+		this.pendingTasks.clear();
 	}
 
 	/**
@@ -765,6 +771,9 @@ export class TaskCalendarSyncService {
 			clearTimeout(existingTimer);
 		}
 
+		// Store the authoritative task state passed to us so we don't rely on the async metadata cache
+		this.pendingTasks.set(taskPath, task);
+
 		// Return a promise that resolves when the debounced sync completes
 		return new Promise((resolve, reject) => {
 			const timer = setTimeout(async () => {
@@ -776,8 +785,13 @@ export class TaskCalendarSyncService {
 					await inFlight.catch(() => {}); // Ignore errors from previous sync
 				}
 
-				// Re-fetch the task to get the latest state after debounce
-				const freshTask = await this.plugin.cacheManager.getTaskInfo(taskPath);
+				// Use the latest task data that was passed to us explicitly
+				const latestTask = this.pendingTasks.get(taskPath);
+				this.pendingTasks.delete(taskPath);
+
+				// Fallback to cache ONLY if for some reason the pending task is missing
+				const freshTask = latestTask || await this.plugin.cacheManager.getTaskInfo(taskPath);
+				
 				if (!freshTask) {
 					resolve();
 					return;

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -39,10 +39,12 @@ import {
 import { getProjectDisplayName } from "../utils/linkUtils";
 import {
 	formatDateForStorage,
+	getDatePart,
 	getCurrentDateString,
 	getCurrentTimestamp,
 	getTodayLocal,
 	createUTCDateFromLocalCalendarDate,
+	parseDateToUTC,
 } from "../utils/dateUtils";
 import { format } from "date-fns";
 import { processFolderTemplate, TaskTemplateData } from "../utils/folderTemplateProcessor";
@@ -1288,11 +1290,14 @@ export class TaskService {
 			throw new Error("Task is not recurring");
 		}
 
-		// Default to local today instead of selectedDate for recurring task completion
-		// This ensures completion is recorded for user's actual calendar day unless explicitly overridden
+		// For scheduled-anchor recurring tasks, default to the scheduled occurrence
+		// date — not today — so late completions mark the correct instance (#396)
 		const targetDate =
 			date ||
 			(() => {
+				if (freshTask.recurrence_anchor !== "completion" && freshTask.scheduled) {
+					return parseDateToUTC(getDatePart(freshTask.scheduled));
+				}
 				const todayLocal = getTodayLocal();
 				return createUTCDateFromLocalCalendarDate(todayLocal);
 			})();
@@ -1514,10 +1519,14 @@ export class TaskService {
 			throw new Error("Task is not recurring");
 		}
 
-		// Default to local today
+		// For scheduled-anchor recurring tasks, default to the scheduled occurrence
+		// date — not today — so late skips mark the correct instance (#396)
 		const targetDate =
 			date ||
 			(() => {
+				if (freshTask.recurrence_anchor !== "completion" && freshTask.scheduled) {
+					return parseDateToUTC(getDatePart(freshTask.scheduled));
+				}
 				const todayLocal = getTodayLocal();
 				return createUTCDateFromLocalCalendarDate(todayLocal);
 			})();

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -1277,6 +1277,28 @@ export class TaskService {
 	/**
 	 * Toggle completion status for recurring tasks on a specific date
 	 */
+	async resolveRecurringTaskActionDate(task: TaskInfo, date?: Date): Promise<Date> {
+		if (date) {
+			return date;
+		}
+
+		const freshTask = (await this.plugin.cacheManager.getTaskInfo(task.path)) || task;
+		return this.getRecurringTaskActionDate(freshTask);
+	}
+
+	private getRecurringTaskActionDate(task: TaskInfo, date?: Date): Date {
+		if (date) {
+			return date;
+		}
+
+		if (task.recurrence_anchor !== "completion" && task.scheduled) {
+			return parseDateToUTC(getDatePart(task.scheduled));
+		}
+
+		const todayLocal = getTodayLocal();
+		return createUTCDateFromLocalCalendarDate(todayLocal);
+	}
+
 	async toggleRecurringTaskComplete(task: TaskInfo, date?: Date): Promise<TaskInfo> {
 		const file = this.plugin.app.vault.getAbstractFileByPath(task.path);
 		if (!(file instanceof TFile)) {
@@ -1290,17 +1312,7 @@ export class TaskService {
 			throw new Error("Task is not recurring");
 		}
 
-		// For scheduled-anchor recurring tasks, default to the scheduled occurrence
-		// date — not today — so late completions mark the correct instance (#396)
-		const targetDate =
-			date ||
-			(() => {
-				if (freshTask.recurrence_anchor !== "completion" && freshTask.scheduled) {
-					return parseDateToUTC(getDatePart(freshTask.scheduled));
-				}
-				const todayLocal = getTodayLocal();
-				return createUTCDateFromLocalCalendarDate(todayLocal);
-			})();
+		const targetDate = this.getRecurringTaskActionDate(freshTask, date);
 		const dateStr = formatDateForStorage(targetDate);
 
 		// Check current completion status for this date using fresh data
@@ -1519,17 +1531,7 @@ export class TaskService {
 			throw new Error("Task is not recurring");
 		}
 
-		// For scheduled-anchor recurring tasks, default to the scheduled occurrence
-		// date — not today — so late skips mark the correct instance (#396)
-		const targetDate =
-			date ||
-			(() => {
-				if (freshTask.recurrence_anchor !== "completion" && freshTask.scheduled) {
-					return parseDateToUTC(getDatePart(freshTask.scheduled));
-				}
-				const todayLocal = getTodayLocal();
-				return createUTCDateFromLocalCalendarDate(todayLocal);
-			})();
+		const targetDate = this.getRecurringTaskActionDate(freshTask, date);
 		const dateStr = formatDateForStorage(targetDate);
 
 		// Check current skip status for this date

--- a/tests/services/TaskCalendarSyncService.test.ts
+++ b/tests/services/TaskCalendarSyncService.test.ts
@@ -7,6 +7,8 @@ describe("TaskCalendarSyncService", () => {
     let mockGoogleCalendarService: any;
 
     beforeEach(() => {
+        jest.useFakeTimers();
+
         mockPlugin = {
             settings: {
                 googleCalendarExport: {
@@ -34,20 +36,24 @@ describe("TaskCalendarSyncService", () => {
         };
 
         syncService = new TaskCalendarSyncService(mockPlugin, mockGoogleCalendarService);
-        
+
         // Mock internal methods to avoid testing downstream serialization logic which might be complex
         syncService.executeTaskUpdate = jest.fn().mockResolvedValue(undefined);
     });
 
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
     it("should use the most recently passed task explicitly, avoiding stale cacheManager payloads during debounce", async () => {
         const taskPath = "test/path.md";
-        
+
         const firstPayload: TaskInfo = {
             path: taskPath,
             title: "Task Title",
             scheduled: "2026-04-04"
         };
-        
+
         const secondPayload: TaskInfo = {
             path: taskPath,
             title: "Task Title",
@@ -61,11 +67,12 @@ describe("TaskCalendarSyncService", () => {
         syncService.updateTaskInCalendar(firstPayload);
         syncService.updateTaskInCalendar(secondPayload);
 
-        // Fast-forward the 500ms debounce
-        await new Promise(r => setTimeout(r, 600));
+        // Fast-forward past the 500ms debounce
+        jest.advanceTimersByTime(500);
 
-        // Let the event loop flush the internal promises
-        await new Promise(process.nextTick);
+        // Flush the microtask queue so the async debounce handler completes
+        await Promise.resolve();
+        await Promise.resolve();
 
         // Assert: It should execute only once, and pass the explicit secondPayload, not the stale cache!
         expect(syncService.executeTaskUpdate).toHaveBeenCalledTimes(1);

--- a/tests/services/TaskCalendarSyncService.test.ts
+++ b/tests/services/TaskCalendarSyncService.test.ts
@@ -1,0 +1,74 @@
+import { TaskCalendarSyncService } from "../../src/services/TaskCalendarSyncService";
+import { TaskInfo } from "../../src/types";
+
+describe("TaskCalendarSyncService", () => {
+    let syncService: any;
+    let mockPlugin: any;
+    let mockGoogleCalendarService: any;
+
+    beforeEach(() => {
+        mockPlugin = {
+            settings: {
+                googleCalendarExport: {
+                    syncOnTaskUpdate: true,
+                    targetCalendarId: "test-calendar",
+                }
+            },
+            cacheManager: {
+                getTaskInfo: jest.fn()
+            },
+            statusManager: {
+                getStatusConfig: jest.fn().mockReturnValue({ label: "Todo" })
+            },
+            priorityManager: {
+                getPriorityConfig: jest.fn().mockReturnValue({ label: "High" })
+            },
+            i18n: {
+                translate: jest.fn().mockReturnValue("Untitled Task")
+            }
+        };
+
+        mockGoogleCalendarService = {
+            updateEvent: jest.fn().mockResolvedValue({}),
+            createEvent: jest.fn().mockResolvedValue({ id: "test-id" })
+        };
+
+        syncService = new TaskCalendarSyncService(mockPlugin, mockGoogleCalendarService);
+        
+        // Mock internal methods to avoid testing downstream serialization logic which might be complex
+        syncService.executeTaskUpdate = jest.fn().mockResolvedValue(undefined);
+    });
+
+    it("should use the most recently passed task explicitly, avoiding stale cacheManager payloads during debounce", async () => {
+        const taskPath = "test/path.md";
+        
+        const firstPayload: TaskInfo = {
+            path: taskPath,
+            title: "Task Title",
+            scheduled: "2026-04-04"
+        };
+        
+        const secondPayload: TaskInfo = {
+            path: taskPath,
+            title: "Task Title",
+            scheduled: "2026-04-06" // Agent updated it to April 6
+        };
+
+        // Pretend the metadataCache hasn't caught up and still returns the stale task
+        mockPlugin.cacheManager.getTaskInfo.mockResolvedValue(firstPayload);
+
+        // Act: trigger sync twice rapidly to simulate MCP updates or user typing
+        syncService.updateTaskInCalendar(firstPayload);
+        syncService.updateTaskInCalendar(secondPayload);
+
+        // Fast-forward the 500ms debounce
+        await new Promise(r => setTimeout(r, 600));
+
+        // Let the event loop flush the internal promises
+        await new Promise(process.nextTick);
+
+        // Assert: It should execute only once, and pass the explicit secondPayload, not the stale cache!
+        expect(syncService.executeTaskUpdate).toHaveBeenCalledTimes(1);
+        expect(syncService.executeTaskUpdate).toHaveBeenCalledWith(secondPayload);
+    });
+});

--- a/tests/unit/issues/issue-396-recurring-late-completion-wrong-date.test.ts
+++ b/tests/unit/issues/issue-396-recurring-late-completion-wrong-date.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #396: Recurring tasks completed after scheduled date do not process
+ * into next available recurrence.
+ *
+ * Root cause: toggleRecurringTaskComplete defaults to getTodayLocal() when no
+ * explicit date is passed. For scheduled-anchor recurring tasks, this records
+ * today in complete_instances instead of the scheduled occurrence date.
+ *
+ * Fix: default to task.scheduled (via getDatePart) for scheduled-anchor tasks.
+ */
+
+import { getDatePart, parseDateToUTC } from "../../../src/utils/dateUtils";
+
+describe("Issue #396 — recurring late completion records wrong date", () => {
+    it("getDatePart extracts date from scheduled datetime", () => {
+        expect(getDatePart("2026-04-04")).toBe("2026-04-04");
+        expect(getDatePart("2026-04-04T10:00:00")).toBe("2026-04-04");
+    });
+
+    it("scheduled-anchor task should use scheduled date, not today, when date is omitted", () => {
+        // Simulate the fixed defaulting logic
+        const freshTask = {
+            recurrence_anchor: "scheduled",
+            scheduled: "2026-04-04",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
+        };
+
+        // The fix: when date is omitted and anchor is not "completion", use scheduled
+        const resolvedDate = (() => {
+            if (freshTask.recurrence_anchor !== "completion" && freshTask.scheduled) {
+                return parseDateToUTC(getDatePart(freshTask.scheduled));
+            }
+            fail("Should not reach today fallback for scheduled-anchor task");
+        })();
+
+        // The resolved date should represent April 4, not whatever today happens to be
+        expect(resolvedDate.toISOString()).toMatch(/^2026-04-04/);
+    });
+
+    it("completion-anchor task should still default to today when date is omitted", () => {
+        const freshTask = {
+            recurrence_anchor: "completion",
+            scheduled: "2026-04-04",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
+        };
+
+        // The fix should NOT change completion-anchor behavior
+        const usedScheduled =
+            freshTask.recurrence_anchor !== "completion" && freshTask.scheduled;
+        expect(usedScheduled).toBeFalsy();
+    });
+
+    it("undefined recurrence_anchor should default to using scheduled date", () => {
+        // Default anchor is "scheduled" — undefined should behave the same
+        const freshTask = {
+            recurrence_anchor: undefined,
+            scheduled: "2026-04-04",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
+        };
+
+        const usedScheduled =
+            freshTask.recurrence_anchor !== "completion" && freshTask.scheduled;
+        expect(usedScheduled).toBeTruthy();
+    });
+});

--- a/tests/unit/issues/issue-396-recurring-late-completion-wrong-date.test.ts
+++ b/tests/unit/issues/issue-396-recurring-late-completion-wrong-date.test.ts
@@ -1,10 +1,12 @@
 /**
- * Issue #396: Recurring tasks completed after scheduled date do not process
- * into next available recurrence.
+ * Issue #396: Recurring tasks completed/skipped after scheduled date do not
+ * process into next available recurrence.
  *
- * Root cause: toggleRecurringTaskComplete defaults to getTodayLocal() when no
- * explicit date is passed. For scheduled-anchor recurring tasks, this records
- * today in complete_instances instead of the scheduled occurrence date.
+ * Root cause: toggleRecurringTaskComplete and toggleRecurringTaskSkipped
+ * default to getTodayLocal() when no explicit date is passed. For
+ * scheduled-anchor recurring tasks, this records today in
+ * complete_instances / skipped_instances instead of the scheduled
+ * occurrence date.
  *
  * Fix: default to task.scheduled (via getDatePart) for scheduled-anchor tasks.
  */
@@ -23,59 +25,55 @@ jest.mock("../../../src/utils/dateUtils", () => ({
 
 const mockGetTodayLocal = getTodayLocal as jest.MockedFunction<typeof getTodayLocal>;
 
+function buildMockPlugin(task: TaskInfo) {
+    const writtenFrontmatter: Record<string, any> = {};
+    const plugin = {
+        app: {
+            vault: {
+                getAbstractFileByPath: jest.fn().mockReturnValue(new TFile(task.path)),
+                modify: jest.fn(),
+                read: jest.fn().mockResolvedValue(""),
+            },
+            workspace: { getActiveFile: jest.fn() },
+            metadataCache: { getCache: jest.fn() },
+            fileManager: {
+                processFrontMatter: jest.fn().mockImplementation((_file: any, fn: any) => {
+                    const fm: Record<string, any> = {};
+                    fn(fm);
+                    Object.assign(writtenFrontmatter, fm);
+                    return Promise.resolve();
+                }),
+            },
+        },
+        settings: {
+            taskFolder: "tasks",
+            fieldMapping: {},
+            defaultTaskStatus: "open",
+            taskTag: "#task",
+            storeTitleInFilename: false,
+            resetCheckboxesOnRecurrence: false,
+            maintainDueDateOffsetInRecurring: false,
+        },
+        statusManager: {
+            isCompletedStatus: jest.fn((s: string) => s === "done"),
+            getCompletedStatuses: jest.fn(() => ["done"]),
+        },
+        fieldMapper: { toUserField: jest.fn((f: string) => f) },
+        cacheManager: {
+            getTaskInfo: jest.fn().mockResolvedValue(task),
+            updateTaskInfoInCache: jest.fn(),
+            waitForFreshTaskData: jest.fn().mockResolvedValue(undefined),
+        },
+        emitter: { trigger: jest.fn() },
+    } as any;
+    return { plugin, writtenFrontmatter };
+}
+
 describe("Issue #396 — recurring late completion records wrong date", () => {
-    let taskService: TaskService;
-    let writtenFrontmatter: Record<string, any>;
-
-    function buildMockPlugin(task: TaskInfo) {
-        writtenFrontmatter = {};
-        return {
-            app: {
-                vault: {
-                    getAbstractFileByPath: jest.fn().mockReturnValue(new TFile(task.path)),
-                    modify: jest.fn(),
-                    read: jest.fn().mockResolvedValue(""),
-                },
-                workspace: { getActiveFile: jest.fn() },
-                metadataCache: { getCache: jest.fn() },
-                fileManager: {
-                    processFrontMatter: jest.fn().mockImplementation((_file: any, fn: any) => {
-                        // Start with empty frontmatter like Obsidian does
-                        const fm: Record<string, any> = {};
-                        fn(fm);
-                        Object.assign(writtenFrontmatter, fm);
-                        return Promise.resolve();
-                    }),
-                },
-            },
-            settings: {
-                taskFolder: "tasks",
-                fieldMapping: {},
-                defaultTaskStatus: "open",
-                taskTag: "#task",
-                storeTitleInFilename: false,
-                resetCheckboxesOnRecurrence: false,
-            },
-            statusManager: {
-                isCompletedStatus: jest.fn((s: string) => s === "done"),
-                getCompletedStatuses: jest.fn(() => ["done"]),
-            },
-            // Return field names as-is — the test checks the mapped field name
-            fieldMapper: { toUserField: jest.fn((f: string) => f) },
-            cacheManager: {
-                getTaskInfo: jest.fn().mockResolvedValue(task),
-                updateTaskInfoInCache: jest.fn(),
-                waitForFreshTaskData: jest.fn().mockResolvedValue(undefined),
-            },
-            emitter: { trigger: jest.fn() },
-        } as any;
-    }
-
     it("scheduled-anchor task completed late records the scheduled date, not today", async () => {
-        // Saturday task, completed on Sunday
         mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
 
-        const saturdayTask = TaskFactory.createTask({
+        const task = TaskFactory.createTask({
             path: "tasks/test.md",
             title: "Weekly task",
             recurrence: "FREQ=WEEKLY;BYDAY=SA",
@@ -84,13 +82,12 @@ describe("Issue #396 — recurring late completion records wrong date", () => {
             complete_instances: [],
         });
 
-        const plugin = buildMockPlugin(saturdayTask);
-        taskService = new TaskService(plugin);
+        const { plugin, writtenFrontmatter } = buildMockPlugin(task);
+        const taskService = new TaskService(plugin);
 
         // Call WITHOUT explicit date — should default to scheduled, not today
-        await taskService.toggleRecurringTaskComplete(saturdayTask);
+        await taskService.toggleRecurringTaskComplete(task);
 
-        // completeInstances is the mapped field name (toUserField returns as-is)
         expect(writtenFrontmatter.completeInstances).toContain("2026-04-04");
         expect(writtenFrontmatter.completeInstances).not.toContain("2026-04-05");
     });
@@ -98,7 +95,7 @@ describe("Issue #396 — recurring late completion records wrong date", () => {
     it("completion-anchor task completed late records today, not the scheduled date", async () => {
         mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
 
-        const completionTask = TaskFactory.createTask({
+        const task = TaskFactory.createTask({
             path: "tasks/test.md",
             title: "Completion-anchor task",
             recurrence: "FREQ=WEEKLY;BYDAY=SA",
@@ -107,12 +104,11 @@ describe("Issue #396 — recurring late completion records wrong date", () => {
             complete_instances: [],
         });
 
-        const plugin = buildMockPlugin(completionTask);
-        taskService = new TaskService(plugin);
+        const { plugin, writtenFrontmatter } = buildMockPlugin(task);
+        const taskService = new TaskService(plugin);
 
-        await taskService.toggleRecurringTaskComplete(completionTask);
+        await taskService.toggleRecurringTaskComplete(task);
 
-        // completion-anchor should use today (Sunday), not scheduled (Saturday)
         expect(writtenFrontmatter.completeInstances).toContain("2026-04-05");
         expect(writtenFrontmatter.completeInstances).not.toContain("2026-04-04");
     });
@@ -120,22 +116,89 @@ describe("Issue #396 — recurring late completion records wrong date", () => {
     it("undefined recurrence_anchor defaults to using the scheduled date", async () => {
         mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
 
-        const defaultTask = TaskFactory.createTask({
+        const task = TaskFactory.createTask({
             path: "tasks/test.md",
             title: "Default anchor task",
             recurrence: "FREQ=WEEKLY;BYDAY=SA",
             scheduled: "2026-04-04", // Saturday
             complete_instances: [],
         });
-        // Ensure recurrence_anchor is undefined (default = scheduled)
-        delete (defaultTask as any).recurrence_anchor;
+        delete (task as any).recurrence_anchor;
 
-        const plugin = buildMockPlugin(defaultTask);
-        taskService = new TaskService(plugin);
+        const { plugin, writtenFrontmatter } = buildMockPlugin(task);
+        const taskService = new TaskService(plugin);
 
-        await taskService.toggleRecurringTaskComplete(defaultTask);
+        await taskService.toggleRecurringTaskComplete(task);
 
         expect(writtenFrontmatter.completeInstances).toContain("2026-04-04");
         expect(writtenFrontmatter.completeInstances).not.toContain("2026-04-05");
+    });
+});
+
+describe("Issue #396 — recurring late skip records wrong date", () => {
+    it("scheduled-anchor task skipped late records the scheduled date, not today", async () => {
+        mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
+
+        const task = TaskFactory.createTask({
+            path: "tasks/test.md",
+            title: "Weekly task",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
+            recurrence_anchor: "scheduled",
+            scheduled: "2026-04-04", // Saturday
+            complete_instances: [],
+            skipped_instances: [],
+        });
+
+        const { plugin, writtenFrontmatter } = buildMockPlugin(task);
+        const taskService = new TaskService(plugin);
+
+        await taskService.toggleRecurringTaskSkipped(task);
+
+        expect(writtenFrontmatter.skippedInstances).toContain("2026-04-04");
+        expect(writtenFrontmatter.skippedInstances).not.toContain("2026-04-05");
+    });
+
+    it("completion-anchor task skipped late records today, not the scheduled date", async () => {
+        mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
+
+        const task = TaskFactory.createTask({
+            path: "tasks/test.md",
+            title: "Completion-anchor task",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
+            recurrence_anchor: "completion",
+            scheduled: "2026-04-04", // Saturday
+            complete_instances: [],
+            skipped_instances: [],
+        });
+
+        const { plugin, writtenFrontmatter } = buildMockPlugin(task);
+        const taskService = new TaskService(plugin);
+
+        await taskService.toggleRecurringTaskSkipped(task);
+
+        expect(writtenFrontmatter.skippedInstances).toContain("2026-04-05");
+        expect(writtenFrontmatter.skippedInstances).not.toContain("2026-04-04");
+    });
+
+    it("undefined recurrence_anchor defaults to using the scheduled date for skip", async () => {
+        mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
+
+        const task = TaskFactory.createTask({
+            path: "tasks/test.md",
+            title: "Default anchor task",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
+            scheduled: "2026-04-04", // Saturday
+            complete_instances: [],
+            skipped_instances: [],
+        });
+        delete (task as any).recurrence_anchor;
+
+        const { plugin, writtenFrontmatter } = buildMockPlugin(task);
+        const taskService = new TaskService(plugin);
+
+        await taskService.toggleRecurringTaskSkipped(task);
+
+        expect(writtenFrontmatter.skippedInstances).toContain("2026-04-04");
+        expect(writtenFrontmatter.skippedInstances).not.toContain("2026-04-05");
     });
 });

--- a/tests/unit/issues/issue-396-recurring-late-completion-wrong-date.test.ts
+++ b/tests/unit/issues/issue-396-recurring-late-completion-wrong-date.test.ts
@@ -9,57 +9,133 @@
  * Fix: default to task.scheduled (via getDatePart) for scheduled-anchor tasks.
  */
 
-import { getDatePart, parseDateToUTC } from "../../../src/utils/dateUtils";
+import { TFile } from "obsidian";
+import { TaskService } from "../../../src/services/TaskService";
+import { TaskInfo } from "../../../src/types";
+import { TaskFactory } from "../../helpers/mock-factories";
+import { getTodayLocal } from "../../../src/utils/dateUtils";
+
+// Mock dateUtils so we can control "today"
+jest.mock("../../../src/utils/dateUtils", () => ({
+    ...jest.requireActual("../../../src/utils/dateUtils"),
+    getTodayLocal: jest.fn(),
+}));
+
+const mockGetTodayLocal = getTodayLocal as jest.MockedFunction<typeof getTodayLocal>;
 
 describe("Issue #396 — recurring late completion records wrong date", () => {
-    it("getDatePart extracts date from scheduled datetime", () => {
-        expect(getDatePart("2026-04-04")).toBe("2026-04-04");
-        expect(getDatePart("2026-04-04T10:00:00")).toBe("2026-04-04");
-    });
+    let taskService: TaskService;
+    let writtenFrontmatter: Record<string, any>;
 
-    it("scheduled-anchor task should use scheduled date, not today, when date is omitted", () => {
-        // Simulate the fixed defaulting logic
-        const freshTask = {
+    function buildMockPlugin(task: TaskInfo) {
+        writtenFrontmatter = {};
+        return {
+            app: {
+                vault: {
+                    getAbstractFileByPath: jest.fn().mockReturnValue(new TFile(task.path)),
+                    modify: jest.fn(),
+                    read: jest.fn().mockResolvedValue(""),
+                },
+                workspace: { getActiveFile: jest.fn() },
+                metadataCache: { getCache: jest.fn() },
+                fileManager: {
+                    processFrontMatter: jest.fn().mockImplementation((_file: any, fn: any) => {
+                        // Start with empty frontmatter like Obsidian does
+                        const fm: Record<string, any> = {};
+                        fn(fm);
+                        Object.assign(writtenFrontmatter, fm);
+                        return Promise.resolve();
+                    }),
+                },
+            },
+            settings: {
+                taskFolder: "tasks",
+                fieldMapping: {},
+                defaultTaskStatus: "open",
+                taskTag: "#task",
+                storeTitleInFilename: false,
+                resetCheckboxesOnRecurrence: false,
+            },
+            statusManager: {
+                isCompletedStatus: jest.fn((s: string) => s === "done"),
+                getCompletedStatuses: jest.fn(() => ["done"]),
+            },
+            // Return field names as-is — the test checks the mapped field name
+            fieldMapper: { toUserField: jest.fn((f: string) => f) },
+            cacheManager: {
+                getTaskInfo: jest.fn().mockResolvedValue(task),
+                updateTaskInfoInCache: jest.fn(),
+                waitForFreshTaskData: jest.fn().mockResolvedValue(undefined),
+            },
+            emitter: { trigger: jest.fn() },
+        } as any;
+    }
+
+    it("scheduled-anchor task completed late records the scheduled date, not today", async () => {
+        // Saturday task, completed on Sunday
+        mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
+
+        const saturdayTask = TaskFactory.createTask({
+            path: "tasks/test.md",
+            title: "Weekly task",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
             recurrence_anchor: "scheduled",
-            scheduled: "2026-04-04",
-            recurrence: "FREQ=WEEKLY;BYDAY=SA",
-        };
+            scheduled: "2026-04-04", // Saturday
+            complete_instances: [],
+        });
 
-        // The fix: when date is omitted and anchor is not "completion", use scheduled
-        const resolvedDate = (() => {
-            if (freshTask.recurrence_anchor !== "completion" && freshTask.scheduled) {
-                return parseDateToUTC(getDatePart(freshTask.scheduled));
-            }
-            fail("Should not reach today fallback for scheduled-anchor task");
-        })();
+        const plugin = buildMockPlugin(saturdayTask);
+        taskService = new TaskService(plugin);
 
-        // The resolved date should represent April 4, not whatever today happens to be
-        expect(resolvedDate.toISOString()).toMatch(/^2026-04-04/);
+        // Call WITHOUT explicit date — should default to scheduled, not today
+        await taskService.toggleRecurringTaskComplete(saturdayTask);
+
+        // completeInstances is the mapped field name (toUserField returns as-is)
+        expect(writtenFrontmatter.completeInstances).toContain("2026-04-04");
+        expect(writtenFrontmatter.completeInstances).not.toContain("2026-04-05");
     });
 
-    it("completion-anchor task should still default to today when date is omitted", () => {
-        const freshTask = {
+    it("completion-anchor task completed late records today, not the scheduled date", async () => {
+        mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
+
+        const completionTask = TaskFactory.createTask({
+            path: "tasks/test.md",
+            title: "Completion-anchor task",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
             recurrence_anchor: "completion",
-            scheduled: "2026-04-04",
-            recurrence: "FREQ=WEEKLY;BYDAY=SA",
-        };
+            scheduled: "2026-04-04", // Saturday
+            complete_instances: [],
+        });
 
-        // The fix should NOT change completion-anchor behavior
-        const usedScheduled =
-            freshTask.recurrence_anchor !== "completion" && freshTask.scheduled;
-        expect(usedScheduled).toBeFalsy();
+        const plugin = buildMockPlugin(completionTask);
+        taskService = new TaskService(plugin);
+
+        await taskService.toggleRecurringTaskComplete(completionTask);
+
+        // completion-anchor should use today (Sunday), not scheduled (Saturday)
+        expect(writtenFrontmatter.completeInstances).toContain("2026-04-05");
+        expect(writtenFrontmatter.completeInstances).not.toContain("2026-04-04");
     });
 
-    it("undefined recurrence_anchor should default to using scheduled date", () => {
-        // Default anchor is "scheduled" — undefined should behave the same
-        const freshTask = {
-            recurrence_anchor: undefined,
-            scheduled: "2026-04-04",
-            recurrence: "FREQ=WEEKLY;BYDAY=SA",
-        };
+    it("undefined recurrence_anchor defaults to using the scheduled date", async () => {
+        mockGetTodayLocal.mockReturnValue(new Date("2026-04-05T12:00:00")); // Sunday
 
-        const usedScheduled =
-            freshTask.recurrence_anchor !== "completion" && freshTask.scheduled;
-        expect(usedScheduled).toBeTruthy();
+        const defaultTask = TaskFactory.createTask({
+            path: "tasks/test.md",
+            title: "Default anchor task",
+            recurrence: "FREQ=WEEKLY;BYDAY=SA",
+            scheduled: "2026-04-04", // Saturday
+            complete_instances: [],
+        });
+        // Ensure recurrence_anchor is undefined (default = scheduled)
+        delete (defaultTask as any).recurrence_anchor;
+
+        const plugin = buildMockPlugin(defaultTask);
+        taskService = new TaskService(plugin);
+
+        await taskService.toggleRecurringTaskComplete(defaultTask);
+
+        expect(writtenFrontmatter.completeInstances).toContain("2026-04-04");
+        expect(writtenFrontmatter.completeInstances).not.toContain("2026-04-05");
     });
 });


### PR DESCRIPTION
## Summary

Two independent Google Calendar sync reliability fixes:

- **Debounce stale metadata cache:** `TaskCalendarSyncService.updateTaskInCalendar` discarded the explicit task payload during the 500ms debounce and re-fetched from `cacheManager.getTaskInfo`, which often returned stale data because Obsidian's metadata cache hadn't finished indexing. Fixed by caching the authoritative task payload in a `pendingTasks` Map during the debounce window.

- **Recurring completion records wrong occurrence:** `toggleRecurringTaskComplete` and `toggleRecurringTaskSkipped` defaulted to `getTodayLocal()` when no explicit date was passed, even for scheduled-anchor recurring tasks. Completing a task late (e.g. Saturday's task on Sunday) recorded Sunday in `complete_instances` — but `complete_instances` is an occurrence index, not a completion timestamp, so this left Saturday's occurrence open and sent the wrong `EXDATE` to Google Calendar. Fixed by defaulting to `task.scheduled` for scheduled-anchor tasks, so the correct occurrence is marked as done.

## Issue linkage

- Closes #1763
- Closes #396
- Closes #574
- Related to #1594 — this PR fixes the overdue recurring wrong-date behaviour, not the separate note-view/calendar occurrence-context bug described there.

## Test plan

- [x] `npx jest tests/services/TaskCalendarSyncService.test.ts` — debounce uses explicit payload, not stale cache
- [x] `npx jest tests/unit/issues/issue-396-recurring-late-completion-wrong-date.test.ts` — scheduled-anchor defaults to scheduled date; completion-anchor still defaults to today; undefined anchor defaults to scheduled
- [x] `npx tsc --noEmit` — clean typecheck
- [x] `npm run build` — clean build
- [x] Validated locally: rapid MCP task updates reflect correct dates in Google Calendar; late-completed recurring tasks mark the scheduled occurrence as done rather than recording a non-existent occurrence on the completion date

## CI note

The `test (20)` check fails on `Could not locate module tasknotes-nlp-core` — this is a pre-existing repo-wide CI issue that is also affecting other PRs (for example #1677), and it was not introduced by these changes.

