### PR TITLE
Fix auto-archive Google Calendar cleanup retries

### DIFF
--- a/src/services/AutoArchiveService.ts
+++ b/src/services/AutoArchiveService.ts
@@ -19,6 +19,20 @@ export class AutoArchiveService {
 		return !!task.googleCalendarEventId;
 	}
 
+	private getCalendarCleanupState(): "ready" | "retry" | "skip" {
+		const googleCalendarExport = this.plugin.settings.googleCalendarExport;
+
+		if (!googleCalendarExport?.enabled || !googleCalendarExport?.syncOnTaskDelete) {
+			return "skip";
+		}
+
+		if (!this.plugin.taskCalendarSyncService) {
+			return "retry";
+		}
+
+		return this.plugin.taskCalendarSyncService.isEnabled() ? "ready" : "retry";
+	}
+
 	/**
 	 * Start the auto-archive service and begin periodic processing
 	 */
@@ -150,10 +164,19 @@ export class AutoArchiveService {
 		}
 
 		if (currentTask.archived) {
-			if (
-				this.plugin.taskCalendarSyncService?.isEnabled() &&
-				this.hasGoogleCalendarLink(currentTask)
-			) {
+			if (this.hasGoogleCalendarLink(currentTask)) {
+				const calendarCleanupState = this.getCalendarCleanupState();
+				if (calendarCleanupState === "skip") {
+					return true;
+				}
+
+				if (calendarCleanupState === "retry") {
+					console.warn(
+						`Auto-archive Google cleanup deferred until calendar sync is ready for ${item.taskPath}`
+					);
+					return false;
+				}
+
 				const deleted =
 					await this.plugin.taskCalendarSyncService.deleteTaskFromCalendar(currentTask);
 				if (!deleted) {
@@ -171,11 +194,18 @@ export class AutoArchiveService {
 		// Archive the task
 		try {
 			const archivedTask = await this.plugin.taskService.toggleArchive(currentTask);
-			if (
-				archivedTask.archived &&
-				this.plugin.taskCalendarSyncService?.isEnabled() &&
-				this.hasGoogleCalendarLink(archivedTask)
-			) {
+			if (archivedTask.archived && this.hasGoogleCalendarLink(archivedTask)) {
+				item.taskPath = archivedTask.path;
+				const calendarCleanupState = this.getCalendarCleanupState();
+				if (calendarCleanupState === "skip") {
+					return true;
+				}
+
+				if (calendarCleanupState === "retry") {
+					console.warn(
+						`Auto-archive Google cleanup deferred until calendar sync is ready for ${item.taskPath}`
+					);
+				}
 				return false;
 			}
 			return true;

--- a/tests/unit/issues/issue-google-calendar-archive-reliability.test.ts
+++ b/tests/unit/issues/issue-google-calendar-archive-reliability.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { describe, it, expect, jest } from "@jest/globals";
 import { TFile } from "obsidian";
 
 import { AutoArchiveService } from "../../../src/services/AutoArchiveService";
@@ -16,6 +16,17 @@ jest.mock("obsidian", () => ({
 		}
 	},
 }));
+
+const createGoogleCleanupEnabledPlugin = () =>
+	PluginFactory.createMockPlugin({
+		settings: {
+			...PluginFactory.createMockPlugin().settings,
+			googleCalendarExport: {
+				enabled: true,
+				syncOnTaskDelete: true,
+			},
+		},
+	});
 
 describe("Google Calendar archive reliability", () => {
 	it("preserves the Google Calendar event ID when deletion fails so cleanup can be retried", async () => {
@@ -97,7 +108,7 @@ describe("Google Calendar archive reliability", () => {
 	});
 
 	it("keeps an auto-archive queue item pending when Google cleanup is still incomplete after archiving", async () => {
-		const plugin = PluginFactory.createMockPlugin();
+		const plugin = createGoogleCleanupEnabledPlugin();
 		plugin.cacheManager.getTaskByPath = jest.fn();
 		plugin.taskService.toggleArchive = jest.fn();
 		plugin.taskCalendarSyncService = {
@@ -136,7 +147,7 @@ describe("Google Calendar archive reliability", () => {
 	});
 
 	it("retries Google cleanup for archived tasks that still have calendar links", async () => {
-		const plugin = PluginFactory.createMockPlugin();
+		const plugin = createGoogleCleanupEnabledPlugin();
 		plugin.cacheManager.getTaskByPath = jest.fn();
 		plugin.taskService.toggleArchive = jest.fn();
 		plugin.taskCalendarSyncService = {
@@ -167,5 +178,179 @@ describe("Google Calendar archive reliability", () => {
 			archivedTask
 		);
 		expect(plugin.taskService.toggleArchive).not.toHaveBeenCalled();
+	});
+
+	it("persists the archived path in the retry queue when cleanup remains pending after an archive-folder move", async () => {
+		const plugin = createGoogleCleanupEnabledPlugin();
+		const initialItem = {
+			taskPath: "TaskNotes/Tasks/archive-me.md",
+			statusChangeTimestamp: 0,
+			archiveAfterTimestamp: 0,
+			statusValue: "done",
+		};
+		const pluginData = { autoArchiveQueue: [initialItem] };
+		plugin.loadData = jest.fn().mockResolvedValue(pluginData);
+		plugin.saveData = jest.fn().mockResolvedValue(undefined);
+		plugin.cacheManager.getTaskByPath = jest.fn();
+		plugin.taskService.toggleArchive = jest.fn();
+		plugin.taskCalendarSyncService = {
+			isEnabled: jest.fn().mockReturnValue(true),
+			deleteTaskFromCalendar: jest.fn().mockResolvedValue(true),
+		};
+
+		const autoArchiveService = new AutoArchiveService(plugin);
+		const currentTask: TaskInfo = TaskFactory.createTask({
+			path: "TaskNotes/Tasks/archive-me.md",
+			status: "done",
+			archived: false,
+			googleCalendarEventId: "master-event-id",
+		});
+		const archivedTask: TaskInfo = {
+			...currentTask,
+			path: "TaskNotes/Archive/archive-me.md",
+			archived: true,
+			tags: ["task", "archived"],
+		};
+
+		plugin.cacheManager.getTaskByPath.mockResolvedValue(currentTask);
+		plugin.taskService.toggleArchive.mockResolvedValue(archivedTask);
+
+		await (autoArchiveService as any).processQueue();
+
+		expect(plugin.saveData).toHaveBeenCalledWith({
+			autoArchiveQueue: [{ ...initialItem, taskPath: archivedTask.path }],
+		});
+	});
+
+	it("keeps archived tasks in the retry queue until calendar sync is ready", async () => {
+		const plugin = createGoogleCleanupEnabledPlugin();
+		const archivedItem = {
+			taskPath: "TaskNotes/Archive/archive-me.md",
+			statusChangeTimestamp: 0,
+			archiveAfterTimestamp: 0,
+			statusValue: "done",
+		};
+		const pluginData = { autoArchiveQueue: [archivedItem] };
+		plugin.loadData = jest.fn().mockResolvedValue(pluginData);
+		plugin.saveData = jest.fn().mockResolvedValue(undefined);
+		plugin.cacheManager.getTaskByPath = jest.fn();
+		plugin.taskService.toggleArchive = jest.fn();
+		plugin.taskCalendarSyncService = undefined;
+
+		const autoArchiveService = new AutoArchiveService(plugin);
+		const archivedTask: TaskInfo = TaskFactory.createTask({
+			path: archivedItem.taskPath,
+			status: "done",
+			archived: true,
+			tags: ["task", "archived"],
+			googleCalendarEventId: "master-event-id",
+		});
+
+		plugin.cacheManager.getTaskByPath.mockResolvedValue(archivedTask);
+
+		await (autoArchiveService as any).processQueue();
+
+		expect(plugin.saveData).toHaveBeenCalledWith({
+			autoArchiveQueue: [archivedItem],
+		});
+		expect(plugin.taskService.toggleArchive).not.toHaveBeenCalled();
+	});
+
+	it("drops archived tasks from the retry queue when Google cleanup is intentionally disabled", async () => {
+		const plugin = PluginFactory.createMockPlugin({
+			settings: {
+				...createGoogleCleanupEnabledPlugin().settings,
+				googleCalendarExport: {
+					enabled: false,
+					syncOnTaskDelete: true,
+				},
+			},
+		});
+		const archivedItem = {
+			taskPath: "TaskNotes/Archive/archive-me.md",
+			statusChangeTimestamp: 0,
+			archiveAfterTimestamp: 0,
+			statusValue: "done",
+		};
+		const pluginData = { autoArchiveQueue: [archivedItem] };
+		plugin.loadData = jest.fn().mockResolvedValue(pluginData);
+		plugin.saveData = jest.fn().mockResolvedValue(undefined);
+		plugin.cacheManager.getTaskByPath = jest.fn();
+		plugin.taskService.toggleArchive = jest.fn();
+		plugin.taskCalendarSyncService = {
+			isEnabled: jest.fn().mockReturnValue(false),
+			deleteTaskFromCalendar: jest.fn().mockResolvedValue(true),
+		};
+
+		const autoArchiveService = new AutoArchiveService(plugin);
+		const archivedTask: TaskInfo = TaskFactory.createTask({
+			path: archivedItem.taskPath,
+			status: "done",
+			archived: true,
+			tags: ["task", "archived"],
+			googleCalendarEventId: "master-event-id",
+		});
+
+		plugin.cacheManager.getTaskByPath.mockResolvedValue(archivedTask);
+
+		await (autoArchiveService as any).processQueue();
+
+		expect(plugin.saveData).toHaveBeenCalledWith({
+			autoArchiveQueue: [],
+		});
+		expect(plugin.taskCalendarSyncService.deleteTaskFromCalendar).not.toHaveBeenCalled();
+		expect(plugin.taskService.toggleArchive).not.toHaveBeenCalled();
+	});
+
+	it("drops newly archived tasks from the retry queue when Google cleanup is intentionally disabled", async () => {
+		const plugin = PluginFactory.createMockPlugin({
+			settings: {
+				...createGoogleCleanupEnabledPlugin().settings,
+				googleCalendarExport: {
+					enabled: false,
+					syncOnTaskDelete: true,
+				},
+			},
+		});
+		const initialItem = {
+			taskPath: "TaskNotes/Tasks/archive-me.md",
+			statusChangeTimestamp: 0,
+			archiveAfterTimestamp: 0,
+			statusValue: "done",
+		};
+		const pluginData = { autoArchiveQueue: [initialItem] };
+		plugin.loadData = jest.fn().mockResolvedValue(pluginData);
+		plugin.saveData = jest.fn().mockResolvedValue(undefined);
+		plugin.cacheManager.getTaskByPath = jest.fn();
+		plugin.taskService.toggleArchive = jest.fn();
+		plugin.taskCalendarSyncService = {
+			isEnabled: jest.fn().mockReturnValue(false),
+			deleteTaskFromCalendar: jest.fn().mockResolvedValue(true),
+		};
+
+		const autoArchiveService = new AutoArchiveService(plugin);
+		const currentTask: TaskInfo = TaskFactory.createTask({
+			path: initialItem.taskPath,
+			status: "done",
+			archived: false,
+			googleCalendarEventId: "master-event-id",
+		});
+		const archivedTask: TaskInfo = {
+			...currentTask,
+			path: "TaskNotes/Archive/archive-me.md",
+			archived: true,
+			tags: ["task", "archived"],
+		};
+
+		plugin.cacheManager.getTaskByPath.mockResolvedValue(currentTask);
+		plugin.taskService.toggleArchive.mockResolvedValue(archivedTask);
+
+		await (autoArchiveService as any).processQueue();
+
+		expect(plugin.saveData).toHaveBeenCalledWith({
+			autoArchiveQueue: [],
+		});
+		expect(plugin.taskService.toggleArchive).toHaveBeenCalledWith(currentTask);
+		expect(plugin.taskCalendarSyncService.deleteTaskFromCalendar).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- keep auto-archive queue items pending when Google Calendar cleanup is still intended but the sync service is not ready yet
- persist the archived path into the retry queue when archiving moves a task before cleanup succeeds
- drop retry queue items when Google Calendar cleanup is intentionally disabled in settings

## Validation
- `npx jest tests/unit/issues/issue-google-calendar-archive-reliability.test.ts tests/services/TaskCalendarSyncService.test.ts --runInBand`
- `npx tsc --noEmit`
- `npm run build`

Closes #1765
Related to #1695

## CI note
The `test (20)` check fails on `Could not locate module tasknotes-nlp-core`.
This is a pre-existing repo-wide CI issue that is also affecting other PRs (for example #1677), and it was not introduced by these changes.
