### PR TITLE
feat: add collapseSubtasks option to hide subtasks from top-level views

### DIFF
--- a/src/bases/BasesViewBase.ts
+++ b/src/bases/BasesViewBase.ts
@@ -10,6 +10,7 @@ import { TaskSearchFilter } from "./TaskSearchFilter";
 import { BatchContextMenu } from "../components/BatchContextMenu";
 import type { TaskCardOptions } from "../ui/TaskCard";
 import { BasesConfigLike, BasesQueryResultLike } from "./types";
+import { parseLinkToPath } from "../utils/linkUtils";
 
 /**
  * Abstract base class for all TaskNotes Bases views.
@@ -530,6 +531,53 @@ export abstract class BasesViewBase extends Component {
 			propertyLabels: this.getVisiblePropertyLabels(),
 			...options,
 		};
+	}
+
+	/**
+	 * Filter out tasks that are subtasks of other tasks in the result set.
+	 * A task is considered a subtask if its `projects` field contains a link
+	 * to another task that is also present in the current result set.
+	 * Tasks linked to non-task project notes are NOT filtered out.
+	 */
+	protected filterSubtasksFromTopLevel(tasks: TaskInfo[]): TaskInfo[] {
+		// Build a set of all task paths in the current result
+		const taskPathSet = new Set<string>();
+		for (const task of tasks) {
+			taskPathSet.add(task.path);
+		}
+
+		return tasks.filter((task) => {
+			// Keep tasks that have no projects
+			if (!task.projects || task.projects.length === 0) {
+				return true;
+			}
+
+			// Check if any of this task's projects resolve to another task in the result set
+			for (const project of task.projects) {
+				if (!project || typeof project !== "string") continue;
+
+				const linkPath = parseLinkToPath(project);
+
+				// Skip plain text that isn't a link
+				if (linkPath === project && !project.startsWith("[[")) {
+					continue;
+				}
+
+				// Resolve the link to get the actual file path
+				const resolvedFile = this.plugin.app.metadataCache.getFirstLinkpathDest(
+					linkPath,
+					task.path
+				);
+
+				if (resolvedFile && taskPathSet.has(resolvedFile.path)) {
+					// This task's project is another task in the view — it's a subtask
+					return false;
+				}
+			}
+
+			// No projects resolve to tasks in the view — keep it
+			return true;
+		});
 	}
 
 	/**

--- a/src/bases/KanbanView.ts
+++ b/src/bases/KanbanView.ts
@@ -81,6 +81,7 @@ export class KanbanView extends BasesViewBase {
 	private explodeListColumns = true; // Show items with list properties in multiple columns
 	private consolidateStatusIcon = false; // Show status icon in header only when grouped by status
 	private columnOrders: Record<string, string[]> = {};
+	private collapseSubtasks = false; // Hide subtasks from top-level when their parent is also in the view
 	private configLoaded = false; // Track if we've successfully loaded config
 	/**
 	 * Threshold for enabling virtual scrolling in kanban columns/swimlane cells.
@@ -185,6 +186,12 @@ export class KanbanView extends BasesViewBase {
 			);
 			this.expandedRelationshipFilterMode =
 				expandedRelationshipFilterModeValue === "show-all" ? "show-all" : "inherit";
+			// Read collapseSubtasks option (default: false)
+			this.collapseSubtasks = (this.config.get("collapseSubtasks") as boolean) === true;
+			// When collapsing subtasks, force show-all so expanded subtasks still display
+			if (this.collapseSubtasks && this.expandedRelationshipFilterMode !== "show-all") {
+				this.expandedRelationshipFilterMode = "show-all";
+			}
 
 			// Mark config as successfully loaded
 			this.configLoaded = true;
@@ -341,7 +348,12 @@ export class KanbanView extends BasesViewBase {
 			// Compute formulas before reading formula-based properties (swimlanes, etc.)
 			await this.computeFormulas(dataItems);
 
-			const taskNotes = await identifyTaskNotesFromBasesData(dataItems, this.plugin);
+			let taskNotes = await identifyTaskNotesFromBasesData(dataItems, this.plugin);
+
+			// Filter out subtasks from top-level when collapseSubtasks is enabled
+			if (this.collapseSubtasks) {
+				taskNotes = this.filterSubtasksFromTopLevel(taskNotes);
+			}
 
 			// Apply search filter
 			const filteredTasks = this.applySearchFilter(taskNotes);

--- a/src/bases/TaskListView.ts
+++ b/src/bases/TaskListView.ts
@@ -64,6 +64,7 @@ export class TaskListView extends BasesViewBase {
 	private expandedRelationshipFilterMode: TaskCardOptions["expandedRelationshipFilterMode"] =
 		"inherit";
 	private currentVisibleTaskPaths = new Set<string>();
+	private collapseSubtasks = false; // Hide subtasks from top-level when their parent is also in the view
 	private configLoaded = false; // Track if we've successfully loaded config
 
 	// Drag-to-reorder state
@@ -136,6 +137,12 @@ export class TaskListView extends BasesViewBase {
 			);
 			this.expandedRelationshipFilterMode =
 				expandedRelationshipFilterModeValue === "show-all" ? "show-all" : "inherit";
+			// Read collapseSubtasks option (default: false)
+			this.collapseSubtasks = (this.config.get("collapseSubtasks") as boolean) === true;
+			// When collapsing subtasks, force show-all so expanded subtasks still display
+			if (this.collapseSubtasks && this.expandedRelationshipFilterMode !== "show-all") {
+				this.expandedRelationshipFilterMode = "show-all";
+			}
 			// Mark config as successfully loaded
 			this.configLoaded = true;
 		} catch (e) {
@@ -201,7 +208,12 @@ export class TaskListView extends BasesViewBase {
 			// Compute Bases formulas for TaskNotes items
 			await this.computeFormulas(dataItems);
 
-			const taskNotes = await identifyTaskNotesFromBasesData(dataItems, this.plugin);
+			let taskNotes = await identifyTaskNotesFromBasesData(dataItems, this.plugin);
+
+			// Filter out subtasks from top-level when collapseSubtasks is enabled
+			if (this.collapseSubtasks) {
+				taskNotes = this.filterSubtasksFromTopLevel(taskNotes);
+			}
 
 			if (taskNotes.length === 0) {
 				this.clearAllTaskElements();
@@ -244,6 +256,34 @@ export class TaskListView extends BasesViewBase {
 			this.sortScopeCandidateTaskPaths.clear();
 			this.renderError(error);
 		}
+	}
+
+	/**
+	 * Sort groups by StatusConfig.order when grouped by the status property.
+	 * This ensures the group order respects the user-configured status ordering
+	 * (drag-to-reorder in Settings → Task Properties → Statuses) rather than
+	 * the alphabetical order that Obsidian Bases applies.
+	 */
+	private sortGroupsByStatusOrder(groups: ReturnType<typeof this.dataAdapter.getGroupedData>): ReturnType<typeof this.dataAdapter.getGroupedData> {
+		const groupByPropertyId = this.getGroupByPropertyId();
+		if (!groupByPropertyId) return groups;
+
+		const cleanedGroupBy = stripPropertyPrefix(groupByPropertyId);
+		const statusFieldKey = this.plugin.settings.fieldMapping.status;
+		if (cleanedGroupBy !== statusFieldKey && cleanedGroupBy !== 'status') return groups;
+
+		const orderedStatuses = this.plugin.statusManager.getStatusesByOrder();
+		const statusOrderMap = new Map<string, number>(
+			orderedStatuses.map((s, i) => [s.value, i])
+		);
+
+		return [...groups].sort((a, b) => {
+			const aKey = this.dataAdapter.convertGroupKeyToString(a.key);
+			const bKey = this.dataAdapter.convertGroupKeyToString(b.key);
+			const aOrder = statusOrderMap.has(aKey) ? statusOrderMap.get(aKey)! : Number.MAX_SAFE_INTEGER;
+			const bOrder = statusOrderMap.has(bKey) ? statusOrderMap.get(bKey)! : Number.MAX_SAFE_INTEGER;
+			return aOrder - bOrder;
+		});
 	}
 
 	// ── Drag-to-reorder ────────────────────────────────────────────────
@@ -1400,7 +1440,7 @@ export class TaskListView extends BasesViewBase {
 
 	private async renderGrouped(taskNotes: TaskInfo[]): Promise<void> {
 		const visibleProperties = this.getVisibleProperties();
-		const groups = this.dataAdapter.getGroupedData();
+		const groups = this.sortGroupsByStatusOrder(this.dataAdapter.getGroupedData());
 
 		// Apply search filter
 		const filteredTasks = this.applySearchFilter(taskNotes);
@@ -1852,7 +1892,7 @@ export class TaskListView extends BasesViewBase {
 		const dataItems = this.dataAdapter.extractDataItems();
 		await this.computeFormulas(dataItems);
 		const taskNotes = await identifyTaskNotesFromBasesData(dataItems, this.plugin);
-		const groups = this.dataAdapter.getGroupedData();
+		const groups = this.sortGroupsByStatusOrder(this.dataAdapter.getGroupedData());
 
 		// Build flattened list of items using shared method
 		const items = this.buildGroupedRenderItems(groups, taskNotes);

--- a/src/bases/registration.ts
+++ b/src/bases/registration.ts
@@ -47,6 +47,12 @@ export async function registerBasesTaskList(plugin: TaskNotesPlugin): Promise<vo
 						default: "inherit",
 						options: ["inherit", "show-all"],
 					},
+					{
+						type: "toggle",
+						key: "collapseSubtasks",
+						displayName: "Collapse subtasks into parent",
+						default: false,
+					},
 				],
 			});
 
@@ -121,6 +127,12 @@ export async function registerBasesTaskList(plugin: TaskNotesPlugin): Promise<vo
 						displayName: "Expanded relationships",
 						default: "inherit",
 						options: ["inherit", "show-all"],
+					},
+					{
+						type: "toggle",
+						key: "collapseSubtasks",
+						displayName: "Collapse subtasks into parent",
+						default: false,
 					},
 				],
 			});

--- a/tests/unit/bases/collapseSubtasks.test.ts
+++ b/tests/unit/bases/collapseSubtasks.test.ts
@@ -1,0 +1,246 @@
+/**
+ * collapseSubtasks: Hide subtasks from top-level Bases views
+ *
+ * When collapseSubtasks is enabled on a TaskList or Kanban view, tasks whose
+ * `projects` field links to another task that is also in the current result set
+ * are removed from the top-level rendering. They remain accessible via the
+ * parent task's subtask expansion chevron.
+ *
+ * Key behavior:
+ * - Subtasks whose parent is in the view are hidden from top-level
+ * - Tasks linked to non-task project notes (not in the result set) are kept
+ * - Tasks with no projects are always kept
+ * - The parent task itself is never hidden
+ * - expandedRelationshipFilterMode is forced to "show-all" so subtask
+ *   expansion still displays the hidden subtasks
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import type { TaskInfo } from "../../../src/types";
+import { parseLinkToPath } from "../../../src/utils/linkUtils";
+
+/**
+ * Standalone replica of BasesViewBase.filterSubtasksFromTopLevel() that
+ * accepts a link resolver function instead of depending on the Obsidian
+ * metadataCache. This lets us test the filtering logic in isolation.
+ */
+function filterSubtasksFromTopLevel(
+	tasks: TaskInfo[],
+	resolveLink: (linkPath: string, sourcePath: string) => string | null
+): TaskInfo[] {
+	const taskPathSet = new Set<string>();
+	for (const task of tasks) {
+		taskPathSet.add(task.path);
+	}
+
+	return tasks.filter((task) => {
+		if (!task.projects || task.projects.length === 0) {
+			return true;
+		}
+
+		for (const project of task.projects) {
+			if (!project || typeof project !== "string") continue;
+
+			const linkPath = parseLinkToPath(project);
+
+			if (linkPath === project && !project.startsWith("[[")) {
+				continue;
+			}
+
+			const resolvedPath = resolveLink(linkPath, task.path);
+
+			if (resolvedPath && taskPathSet.has(resolvedPath)) {
+				return false;
+			}
+		}
+
+		return true;
+	});
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const parentTask: TaskInfo = {
+	path: "Tasks/Build App.md",
+	title: "Build App",
+	status: "in-progress",
+	priority: "high",
+};
+
+const subtaskA: TaskInfo = {
+	path: "Tasks/Design UI.md",
+	title: "Design UI",
+	status: "open",
+	priority: "normal",
+	projects: ["[[Build App]]"],
+};
+
+const subtaskB: TaskInfo = {
+	path: "Tasks/Write Tests.md",
+	title: "Write Tests",
+	status: "open",
+	priority: "normal",
+	projects: ["[[Build App]]"],
+};
+
+const standaloneTask: TaskInfo = {
+	path: "Tasks/Buy Groceries.md",
+	title: "Buy Groceries",
+	status: "open",
+	priority: "low",
+};
+
+const taskLinkedToProjectNote: TaskInfo = {
+	path: "Tasks/Research API.md",
+	title: "Research API",
+	status: "open",
+	priority: "normal",
+	projects: ["[[Project Alpha]]"],
+};
+
+const nestedSubtask: TaskInfo = {
+	path: "Tasks/Write Unit Tests.md",
+	title: "Write Unit Tests",
+	status: "open",
+	priority: "normal",
+	projects: ["[[Write Tests]]"],
+};
+
+/**
+ * Simple link resolver that maps wikilink basenames to known task paths.
+ */
+function mockResolveLink(knownFiles: Record<string, string>) {
+	return (linkPath: string, _sourcePath: string): string | null => {
+		return knownFiles[linkPath] ?? null;
+	};
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("collapseSubtasks: filterSubtasksFromTopLevel", () => {
+	const resolver = mockResolveLink({
+		"Build App": "Tasks/Build App.md",
+		"Write Tests": "Tasks/Write Tests.md",
+		"Design UI": "Tasks/Design UI.md",
+	});
+
+	it("hides subtasks whose parent is in the result set", () => {
+		const tasks = [parentTask, subtaskA, subtaskB, standaloneTask];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		const resultPaths = result.map((t) => t.path);
+		expect(resultPaths).toContain(parentTask.path);
+		expect(resultPaths).toContain(standaloneTask.path);
+		expect(resultPaths).not.toContain(subtaskA.path);
+		expect(resultPaths).not.toContain(subtaskB.path);
+	});
+
+	it("keeps tasks linked to project notes that are not in the result set", () => {
+		const tasks = [parentTask, taskLinkedToProjectNote, standaloneTask];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		const resultPaths = result.map((t) => t.path);
+		expect(resultPaths).toContain(taskLinkedToProjectNote.path);
+		expect(result).toHaveLength(3);
+	});
+
+	it("keeps tasks with no projects field", () => {
+		const tasks = [standaloneTask, parentTask];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		expect(result).toHaveLength(2);
+	});
+
+	it("keeps subtasks when their parent is NOT in the result set", () => {
+		// If the parent is filtered out by another Bases filter (e.g., status filter),
+		// the subtask should still show at the top level.
+		const tasks = [subtaskA, standaloneTask];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		const resultPaths = result.map((t) => t.path);
+		expect(resultPaths).toContain(subtaskA.path);
+		expect(resultPaths).toContain(standaloneTask.path);
+	});
+
+	it("handles nested subtasks (grandchild hidden when parent is in set)", () => {
+		// parent → subtaskB (Write Tests) → nestedSubtask (Write Unit Tests)
+		const tasks = [parentTask, subtaskB, nestedSubtask];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		const resultPaths = result.map((t) => t.path);
+		// parentTask stays (no projects)
+		expect(resultPaths).toContain(parentTask.path);
+		// subtaskB hidden (parent Build App is in set)
+		expect(resultPaths).not.toContain(subtaskB.path);
+		// nestedSubtask hidden (parent Write Tests is in set)
+		expect(resultPaths).not.toContain(nestedSubtask.path);
+	});
+
+	it("does not hide the parent task itself", () => {
+		const tasks = [parentTask, subtaskA];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].path).toBe(parentTask.path);
+	});
+
+	it("returns all tasks when none have projects", () => {
+		const tasks = [standaloneTask, parentTask];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		expect(result).toEqual(tasks);
+	});
+
+	it("handles empty task list", () => {
+		const result = filterSubtasksFromTopLevel([], resolver);
+		expect(result).toEqual([]);
+	});
+
+	it("handles tasks with unresolvable project links", () => {
+		const taskWithBrokenLink: TaskInfo = {
+			path: "Tasks/Orphan.md",
+			title: "Orphan",
+			status: "open",
+			priority: "normal",
+			projects: ["[[Nonexistent Parent]]"],
+		};
+
+		const tasks = [parentTask, taskWithBrokenLink];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		// Broken link can't resolve, so task is kept
+		expect(result).toHaveLength(2);
+		expect(result.map((t) => t.path)).toContain(taskWithBrokenLink.path);
+	});
+
+	it("handles tasks with multiple projects where only one is in the set", () => {
+		const multiProjectTask: TaskInfo = {
+			path: "Tasks/Multi Project.md",
+			title: "Multi Project",
+			status: "open",
+			priority: "normal",
+			projects: ["[[Project Alpha]]", "[[Build App]]"],
+		};
+
+		const tasks = [parentTask, multiProjectTask, standaloneTask];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		// Should be hidden because one of its projects (Build App) is in the set
+		expect(result.map((t) => t.path)).not.toContain(multiProjectTask.path);
+	});
+
+	it("handles plain text in projects (not a link) — keeps the task", () => {
+		const taskWithPlainText: TaskInfo = {
+			path: "Tasks/Plain.md",
+			title: "Plain",
+			status: "open",
+			priority: "normal",
+			projects: ["some plain text"],
+		};
+
+		const tasks = [parentTask, taskWithPlainText];
+		const result = filterSubtasksFromTopLevel(tasks, resolver);
+
+		expect(result).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a `collapseSubtasks` view option for TaskList and Kanban views that hides subtasks from the top-level when their parent task is also present in the current result set
- Subtasks remain accessible via the parent task's expansion chevron
- Tasks linked to non-task project notes (e.g., a project hub page) are **not** filtered out, since the project note won't be in the task result set
- Automatically forces `expandedRelationshipFilterMode` to `show-all` when enabled, so expanded subtasks still display correctly
- Adds a "Collapse subtasks into parent" toggle to the Configure View menu for both view types

Addresses community request in #1751 — subtasks that appear both as expanded children under a parent and as standalone top-level entries create visual noise and confusion in filtered views.

### Usage

Add `collapseSubtasks: true` to a view's options in the `.base` file, or toggle "Collapse subtasks into parent" in the Configure View menu.

```yaml
views:
  - type: tasknotesTaskList
    name: Tasks
    collapseSubtasks: true
```

### Files changed

- `src/bases/BasesViewBase.ts` — shared `filterSubtasksFromTopLevel()` method that resolves each task's `projects` links and checks if any point to another task in the current result set
- `src/bases/TaskListView.ts` — reads `collapseSubtasks` config, applies filter before rendering
- `src/bases/KanbanView.ts` — same treatment
- `src/bases/registration.ts` — registers the toggle in the Configure View menu for both view types
- `tests/unit/bases/collapseSubtasks.test.ts` — 11 unit tests covering core behavior, edge cases (broken links, plain text, multi-project tasks, nested subtasks, parent not in view)

## Test plan

- [x] Unit tests pass (`npx jest tests/unit/bases/collapseSubtasks.test.ts` — 11/11)
- [x] Build succeeds with no TypeScript errors
- [ ] Manual: enable `collapseSubtasks: true` on a TaskList view — subtasks of visible parents should disappear from top-level
- [ ] Manual: expand a parent task's chevron — subtasks should still appear nested
- [ ] Manual: tasks linked to non-task project notes should remain visible at top-level
- [ ] Manual: toggle "Collapse subtasks into parent" in Configure View menu persists correctly