### PR TITLE
fix(#1756): deliver user-defined custom fields via HTTP API

### DIFF
--- a/src/bases/helpers.ts
+++ b/src/bases/helpers.ts
@@ -97,6 +97,10 @@ function createTaskInfoFromProperties(
 		"skipped_instances",
 		"blockedBy",
 		"blocking",
+		// Prevent double-nesting: when this function is called with a Partial<TaskInfo>
+		// that already has customProperties populated (e.g. from mapFromFrontmatter),
+		// we must not re-classify it as an unknown property.
+		"customProperties",
 	]);
 
 	const customProperties: Record<string, any> = {};

--- a/src/bootstrap/pluginBootstrap.ts
+++ b/src/bootstrap/pluginBootstrap.ts
@@ -63,7 +63,7 @@ export function registerTaskNotesIcon(): void {
 }
 
 export async function initializeCoreServices(plugin: TaskNotesPlugin): Promise<void> {
-	plugin.fieldMapper = new FieldMapper(plugin.settings.fieldMapping);
+	plugin.fieldMapper = new FieldMapper(plugin.settings.fieldMapping, plugin.settings.userFields ?? []);
 	plugin.statusManager = new StatusManager(
 		plugin.settings.customStatuses,
 		plugin.settings.defaultTaskStatus

--- a/src/core/fieldMapping.ts
+++ b/src/core/fieldMapping.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { FieldMapping, TaskInfo } from "../types";
+import type { UserMappedField } from "../types/settings";
 import {
 	normalizeDependencyEntry,
 	normalizeDependencyList,
@@ -23,7 +24,8 @@ export function mapTaskFromFrontmatter(
 	mapping: FieldMapping,
 	frontmatter: Record<string, any> | undefined | null,
 	filePath: string,
-	storeTitleInFilename?: boolean
+	storeTitleInFilename?: boolean,
+	userFields: UserMappedField[] = []
 ): Partial<TaskInfo> {
 	if (!frontmatter) return {};
 
@@ -151,6 +153,15 @@ export function mapTaskFromFrontmatter(
 		mapped.archived = frontmatter.tags.includes(mapping.archiveTag);
 	}
 
+	if (userFields.length > 0) {
+		const mappedAny = mapped as Record<string, any>;
+		for (const field of userFields) {
+			if (frontmatter[field.key] !== undefined) {
+				mappedAny[field.key] = frontmatter[field.key];
+			}
+		}
+	}
+
 	return mapped;
 }
 
@@ -158,7 +169,8 @@ export function mapTaskToFrontmatter(
 	mapping: FieldMapping,
 	taskData: Partial<TaskInfo>,
 	taskTag?: string,
-	storeTitleInFilename?: boolean
+	storeTitleInFilename?: boolean,
+	userFields: UserMappedField[] = []
 ): Record<string, any> {
 	const frontmatter: Record<string, any> = {};
 
@@ -274,6 +286,15 @@ export function mapTaskToFrontmatter(
 
 	if (tags.length > 0) {
 		frontmatter.tags = tags;
+	}
+
+	if (userFields.length > 0) {
+		const taskAny = taskData as Record<string, any>;
+		for (const field of userFields) {
+			if (Object.prototype.hasOwnProperty.call(taskAny, field.key) && taskAny[field.key] !== undefined) {
+				frontmatter[field.key] = taskAny[field.key];
+			}
+		}
 	}
 
 	void storeTitleInFilename;

--- a/src/services/FieldMapper.ts
+++ b/src/services/FieldMapper.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { FieldMapping, TaskInfo } from "../types";
+import type { UserMappedField } from "../types/settings";
 import {
 	isPropertyForField,
 	isRecognizedProperty,
@@ -15,7 +16,24 @@ import {
  * Service for mapping between internal field names and user-configured property names
  */
 export class FieldMapper {
-	constructor(private mapping: FieldMapping) {}
+	constructor(
+		private mapping: FieldMapping,
+		private userFields: UserMappedField[] = []
+	) {}
+
+	/**
+	 * Update user-defined field definitions (call when settings change)
+	 */
+	updateUserFields(fields: UserMappedField[]): void {
+		this.userFields = fields;
+	}
+
+	/**
+	 * Get current user-defined field definitions
+	 */
+	getUserFields(): UserMappedField[] {
+		return [...this.userFields];
+	}
 
 	/**
 	 * Convert internal field name to user's property name
@@ -25,25 +43,29 @@ export class FieldMapper {
 	}
 
 	/**
-	 * Convert frontmatter object using mapping to internal task data
+	 * Convert frontmatter object using mapping to internal task data.
+	 * User-defined fields (settings.userFields) are written as top-level properties
+	 * on the returned object, keyed by their frontmatter key (e.g. "start_date").
 	 */
 	mapFromFrontmatter(
 		frontmatter: any,
 		filePath: string,
 		storeTitleInFilename?: boolean
 	): Partial<TaskInfo> {
-		return mapTaskFromFrontmatter(this.mapping, frontmatter, filePath, storeTitleInFilename);
+		return mapTaskFromFrontmatter(this.mapping, frontmatter, filePath, storeTitleInFilename, this.userFields);
 	}
 
 	/**
-	 * Convert internal task data to frontmatter using mapping
+	 * Convert internal task data to frontmatter using mapping.
+	 * User-defined fields are read from top-level task properties and written
+	 * back to frontmatter using each field's configured frontmatter key.
 	 */
 	mapToFrontmatter(
 		taskData: Partial<TaskInfo>,
 		taskTag?: string,
 		storeTitleInFilename?: boolean
 	): any {
-		return mapTaskToFrontmatter(this.mapping, taskData, taskTag, storeTitleInFilename);
+		return mapTaskToFrontmatter(this.mapping, taskData, taskTag, storeTitleInFilename, this.userFields);
 	}
 
 	/**

--- a/src/services/SettingsLifecycleService.ts
+++ b/src/services/SettingsLifecycleService.ts
@@ -60,6 +60,7 @@ export class SettingsLifecycleService {
 		const timeTrackingSettingsChanged = this.haveTimeTrackingSettingsChanged();
 
 		this.plugin.fieldMapper?.updateMapping(this.plugin.settings.fieldMapping);
+		this.plugin.fieldMapper?.updateUserFields(this.plugin.settings.userFields ?? []);
 		this.plugin.statusManager?.updateStatuses(this.plugin.settings.customStatuses);
 		this.plugin.priorityManager?.updatePriorities(this.plugin.settings.customPriorities);
 
@@ -87,6 +88,7 @@ export class SettingsLifecycleService {
 		this.plugin.apiService?.syncWebhookSettings?.();
 
 		this.plugin.fieldMapper?.updateMapping(this.plugin.settings.fieldMapping);
+		this.plugin.fieldMapper?.updateUserFields(this.plugin.settings.userFields ?? []);
 		this.plugin.statusManager?.updateStatuses(this.plugin.settings.customStatuses);
 		this.plugin.priorityManager?.updatePriorities(this.plugin.settings.customPriorities);
 

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -361,13 +361,16 @@ export class TaskService {
 		const defaults = this.plugin.settings.taskCreationDefaults;
 		const result = { ...taskData };
 
-		// Apply default due date if not provided
-		if (!result.due && defaults.defaultDueDate !== "none") {
+		// Apply default due date if not provided.
+		// Use === undefined (not !result.due) so that an explicit null from the API
+		// is treated as "clear this field" rather than "apply the default".
+		if (result.due === undefined && defaults.defaultDueDate !== "none") {
 			result.due = calculateDefaultDate(defaults.defaultDueDate);
 		}
 
-		// Apply default scheduled date if not provided
-		if (!result.scheduled && defaults.defaultScheduledDate !== "none") {
+		// Apply default scheduled date if not provided.
+		// Same null-vs-undefined distinction as due above.
+		if (result.scheduled === undefined && defaults.defaultScheduledDate !== "none") {
 			result.scheduled = calculateDefaultDate(defaults.defaultScheduledDate);
 		}
 

--- a/src/services/task-service/TaskCreationService.ts
+++ b/src/services/task-service/TaskCreationService.ts
@@ -106,6 +106,20 @@ export class TaskCreationService {
 				icsEventId: taskData.icsEventId || undefined,
 			};
 
+			// Thread user-defined field values from taskData through to frontmatter.
+			// completeTaskData only lists hardcoded core fields, so we copy any user
+			// field values here before mapToFrontmatter is called.
+			const userFields = plugin.fieldMapper.getUserFields();
+			if (userFields.length > 0) {
+				const taskDataAny = taskData as Record<string, any>;
+				const completeAny = completeTaskData as Record<string, any>;
+				for (const field of userFields) {
+					if (Object.prototype.hasOwnProperty.call(taskDataAny, field.key) && taskDataAny[field.key] !== undefined) {
+						completeAny[field.key] = taskDataAny[field.key];
+					}
+				}
+			}
+
 			if (
 				completeTaskData.recurrence &&
 				typeof completeTaskData.recurrence === "string" &&

--- a/tests/unit/issues/issue-1756-custom-fields-http-api.test.ts
+++ b/tests/unit/issues/issue-1756-custom-fields-http-api.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Issue #1756: Custom fields are not delivered via HTTP API
+ *
+ * Users who define custom fields (via Settings → User Fields) store arbitrary
+ * frontmatter properties in their task notes. Prior to this fix, those fields
+ * were never extracted into the TaskInfo object, so they were absent from every
+ * HTTP API response (GET /api/tasks, GET /api/tasks/:id, POST /api/tasks/query).
+ *
+ * Fix: mapTaskFromFrontmatter now accepts an optional UserMappedField[] argument.
+ * Each user field whose frontmatter key is present in the raw YAML is written
+ * directly onto the returned TaskInfo object under its own frontmatter key —
+ * the same flat structure as core fields like `due` or `status`.
+ * mapTaskToFrontmatter performs the reverse so writes round-trip correctly.
+ * FieldMapper holds the user fields and threads them through both directions.
+ *
+ * Secondary fix: TaskCreationService was building completeTaskData from a
+ * hardcoded list of core fields, silently dropping any user field values
+ * present in the POST /api/tasks request body. User field values from
+ * taskData are now copied into completeTaskData before mapToFrontmatter
+ * is called, so POST /api/tasks correctly persists custom fields.
+ *
+ * @see https://github.com/callumalpass/tasknotes/issues/1756
+ */
+
+import { mapTaskFromFrontmatter, mapTaskToFrontmatter } from "../../../src/core/fieldMapping";
+import { FieldMapper } from "../../../src/services/FieldMapper";
+import { DEFAULT_FIELD_MAPPING } from "../../../src/settings/defaults";
+import type { UserMappedField } from "../../../src/types/settings";
+
+const USER_FIELDS: UserMappedField[] = [
+	{ id: "start", key: "start_date", type: "date", displayName: "Start Date" },
+	{ id: "effort", key: "effort_level", type: "number", displayName: "Effort" },
+	{ id: "assignee", key: "assigned_to", type: "text", displayName: "Assignee" },
+	{ id: "flagged", key: "is_flagged", type: "boolean", displayName: "Flagged" },
+	{ id: "labels", key: "custom_labels", type: "list", displayName: "Labels" },
+];
+
+describe("Issue #1756: Custom fields flow through the HTTP API", () => {
+	describe("mapTaskFromFrontmatter — extracting user fields as top-level properties", () => {
+		it("writes user field values directly onto the task object using their frontmatter key", () => {
+			const result = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				{
+					title: "Test task",
+					status: "open",
+					start_date: "2025-01-15",
+					effort_level: 3,
+				},
+				"tasks/test.md",
+				false,
+				USER_FIELDS
+			) as Record<string, any>;
+
+			expect(result.start_date).toBe("2025-01-15");
+			expect(result.effort_level).toBe(3);
+		});
+
+		it("only includes user fields that are actually present in frontmatter", () => {
+			const result = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				{
+					title: "Sparse task",
+					status: "open",
+					start_date: "2026-04-01",
+				},
+				"tasks/sparse.md",
+				false,
+				USER_FIELDS
+			) as Record<string, any>;
+
+			expect(result.start_date).toBe("2026-04-01");
+			expect(result.effort_level).toBeUndefined();
+			expect(result.assigned_to).toBeUndefined();
+		});
+
+		it("does not add user field keys when they are absent from frontmatter", () => {
+			const result = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				{ title: "No custom fields", status: "open" },
+				"tasks/no-custom.md",
+				false,
+				USER_FIELDS
+			) as Record<string, any>;
+
+			expect(result.start_date).toBeUndefined();
+			expect(result.effort_level).toBeUndefined();
+		});
+
+		it("handles all supported field types correctly", () => {
+			const result = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				{
+					title: "All types",
+					status: "open",
+					start_date: "2025-06-01",
+					effort_level: 5,
+					assigned_to: "Alice",
+					is_flagged: true,
+					custom_labels: ["urgent", "review"],
+				},
+				"tasks/all-types.md",
+				false,
+				USER_FIELDS
+			) as Record<string, any>;
+
+			expect(result.start_date).toBe("2025-06-01");
+			expect(result.effort_level).toBe(5);
+			expect(result.assigned_to).toBe("Alice");
+			expect(result.is_flagged).toBe(true);
+			expect(result.custom_labels).toEqual(["urgent", "review"]);
+		});
+
+		it("is backward compatible: returns identical output when no user fields are configured", () => {
+			const withoutUserFields = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				{ title: "Task", status: "open", due: "2025-03-01" },
+				"tasks/compat.md"
+			);
+
+			const withEmptyUserFields = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				{ title: "Task", status: "open", due: "2025-03-01" },
+				"tasks/compat.md",
+				false,
+				[]
+			);
+
+			expect(withoutUserFields).toEqual(withEmptyUserFields);
+		});
+
+		it("does not include undefined frontmatter values", () => {
+			const result = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				{
+					title: "Task",
+					status: "open",
+					start_date: undefined,
+					effort_level: 2,
+				},
+				"tasks/undef.md",
+				false,
+				USER_FIELDS
+			) as Record<string, any>;
+
+			expect(result.effort_level).toBe(2);
+			expect(result.start_date).toBeUndefined();
+		});
+
+		it("does not nest values under customProperties", () => {
+			const result = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				{ title: "Task", status: "open", start_date: "2025-01-15" },
+				"tasks/flat.md",
+				false,
+				USER_FIELDS
+			);
+
+			expect(result.customProperties).toBeUndefined();
+		});
+	});
+
+	describe("mapTaskToFrontmatter — writing user fields back", () => {
+		it("writes top-level user field properties to their frontmatter keys", () => {
+			const frontmatter = mapTaskToFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				Object.assign(
+					{ title: "Write test", status: "open" },
+					{ start_date: "2025-01-15", effort_level: 3 }
+				),
+				"task",
+				false,
+				USER_FIELDS
+			);
+
+			expect(frontmatter.start_date).toBe("2025-01-15");
+			expect(frontmatter.effort_level).toBe(3);
+		});
+
+		it("does not write keys for user fields absent from the task object", () => {
+			const frontmatter = mapTaskToFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				Object.assign({ title: "Partial", status: "open" }, { start_date: "2025-02-01" }),
+				"task",
+				false,
+				USER_FIELDS
+			);
+
+			expect(frontmatter.start_date).toBe("2025-02-01");
+			expect(frontmatter).not.toHaveProperty("effort_level");
+			expect(frontmatter).not.toHaveProperty("assigned_to");
+		});
+
+		it("round-trips: a value read via mapTaskFromFrontmatter is written back identically", () => {
+			const originalFrontmatter = {
+				title: "Round-trip task",
+				status: "open",
+				start_date: "2025-05-20",
+				effort_level: 4,
+				assigned_to: "Bob",
+			};
+
+			const taskInfo = mapTaskFromFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				originalFrontmatter,
+				"tasks/rt.md",
+				false,
+				USER_FIELDS
+			);
+
+			const writtenFrontmatter = mapTaskToFrontmatter(
+				DEFAULT_FIELD_MAPPING,
+				taskInfo,
+				"task",
+				false,
+				USER_FIELDS
+			);
+
+			expect(writtenFrontmatter.start_date).toBe("2025-05-20");
+			expect(writtenFrontmatter.effort_level).toBe(4);
+			expect(writtenFrontmatter.assigned_to).toBe("Bob");
+		});
+
+		it("is backward compatible: output is identical when no user fields are configured", () => {
+			const taskData = { title: "Task", status: "open", due: "2025-03-01" };
+
+			const withoutUserFields = mapTaskToFrontmatter(DEFAULT_FIELD_MAPPING, taskData, "task");
+			const withEmptyUserFields = mapTaskToFrontmatter(DEFAULT_FIELD_MAPPING, taskData, "task", false, []);
+
+			expect(withoutUserFields).toEqual(withEmptyUserFields);
+		});
+	});
+
+	describe("FieldMapper — user field awareness", () => {
+		it("extracts user field values as top-level properties", () => {
+			const mapper = new FieldMapper(DEFAULT_FIELD_MAPPING, USER_FIELDS);
+
+			const result = mapper.mapFromFrontmatter(
+				{ title: "Task", status: "open", start_date: "2025-03-10", effort_level: 2 },
+				"tasks/mapper-test.md"
+			) as Record<string, any>;
+
+			expect(result.start_date).toBe("2025-03-10");
+			expect(result.effort_level).toBe(2);
+			expect(result.customProperties).toBeUndefined();
+		});
+
+		it("writes top-level user field properties back via mapToFrontmatter", () => {
+			const mapper = new FieldMapper(DEFAULT_FIELD_MAPPING, USER_FIELDS);
+
+			const frontmatter = mapper.mapToFrontmatter(
+				Object.assign({ title: "Task", status: "open" }, { start_date: "2025-03-10", effort_level: 2 })
+			);
+
+			expect(frontmatter.start_date).toBe("2025-03-10");
+			expect(frontmatter.effort_level).toBe(2);
+		});
+
+		it("picks up new user fields after updateUserFields is called", () => {
+			const mapper = new FieldMapper(DEFAULT_FIELD_MAPPING, []);
+
+			const before = mapper.mapFromFrontmatter(
+				{ title: "Task", status: "open", start_date: "2025-01-01" },
+				"tasks/update-test.md"
+			) as Record<string, any>;
+			expect(before.start_date).toBeUndefined();
+
+			mapper.updateUserFields(USER_FIELDS);
+
+			const after = mapper.mapFromFrontmatter(
+				{ title: "Task", status: "open", start_date: "2025-01-01" },
+				"tasks/update-test.md"
+			) as Record<string, any>;
+			expect(after.start_date).toBe("2025-01-01");
+		});
+
+		it("produces no user field properties after updateUserFields clears the list", () => {
+			const mapper = new FieldMapper(DEFAULT_FIELD_MAPPING, USER_FIELDS);
+			mapper.updateUserFields([]);
+
+			const result = mapper.mapFromFrontmatter(
+				{ title: "Task", status: "open", start_date: "2025-01-01" },
+				"tasks/cleared.md"
+			) as Record<string, any>;
+
+			expect(result.start_date).toBeUndefined();
+		});
+
+		it("does not affect core field extraction when user fields are present", () => {
+			const mapper = new FieldMapper(DEFAULT_FIELD_MAPPING, USER_FIELDS);
+
+			const result = mapper.mapFromFrontmatter(
+				{
+					title: "Core fields intact",
+					status: "open",
+					priority: "high",
+					due: "2025-06-01",
+					start_date: "2025-05-01",
+				},
+				"tasks/core-intact.md"
+			) as Record<string, any>;
+
+			expect(result.title).toBe("Core fields intact");
+			expect(result.status).toBe("open");
+			expect(result.priority).toBe("high");
+			expect(result.due).toBe("2025-06-01");
+			expect(result.start_date).toBe("2025-05-01");
+		});
+	});
+});


### PR DESCRIPTION
Custom fields configured under Settings → User Fields were never extracted into TaskInfo, so they were absent from all HTTP API responses and could not be written back via the API.

Changes:
- mapTaskFromFrontmatter: new optional userFields param writes each user field present in YAML as a flat top-level property on the returned TaskInfo (e.g. start_date, effort_level), matching the same structure as core fields like due and status.
- mapTaskToFrontmatter: matching optional userFields param reads those top-level properties back and writes them to frontmatter so round-trips are lossless.
- FieldMapper: holds userFields, passes them through both map functions; new updateUserFields() / getUserFields() methods mirror the existing updateMapping() pattern.
- pluginBootstrap: constructs FieldMapper with settings.userFields so user fields are active from startup.
- SettingsLifecycleService: calls updateUserFields() in both saveSettings() and onExternalSettingsChange() so live settings changes take effect without a plugin restart.
- TaskCreationService: copies user field values from taskData into completeTaskData before mapToFrontmatter is called; previously only hardcoded core fields were included so POST /api/tasks silently dropped custom field values.
- TaskService.applyTaskCreationDefaults: changed !result.due and !result.scheduled to === undefined checks so an explicit null from the API is treated as "clear this field" rather than triggering the configured default (e.g. defaulting to today).
- bases/helpers: adds "customProperties" to knownProperties to prevent double-nesting in the Bases integration code path.
- tests: new test suite (16 tests) covering extraction, write-back, round-trips, backward compat, live updateUserFields, and the absence of a customProperties wrapper.