### PR TITLE
Fix NLP package resolution in tests

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -28,3 +28,4 @@ Example:
 
 - (#1764) Fixed Google Calendar sync using stale task metadata after rapid task updates, and fixed late recurring completions/skips recording the completion day instead of the scheduled occurrence date.
   - Thanks to @martin-forge for the PR and to @jpmoo for reporting the recurring completion issues.
+- Fixed CI test runs resolving the NLP parser package from a local sibling checkout instead of the published dependency.

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,6 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/tests/test-setup.ts'],
   moduleNameMapper: {
-    '^tasknotes-nlp-core$': '<rootDir>/../tasknotes-nlp-core/src/index.ts',
     '^obsidian$': '<rootDir>/tests/__mocks__/obsidian.ts',
     '^@fullcalendar/(.*)$': '<rootDir>/tests/__mocks__/fullcalendar.ts',
     // Keep mocks for complex/large libraries that benefit from controlled testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tasknotes",
-	"version": "4.4.0",
+	"version": "4.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tasknotes",
-			"version": "4.4.0",
+			"version": "4.5.1",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/view": "^6.37.2",
@@ -24,7 +24,7 @@
 				"obsidian-daily-notes-interface": "^0.9.4",
 				"reflect-metadata": "^0.2.2",
 				"rrule": "^2.8.1",
-				"tasknotes-nlp-core": "^0.1.0",
+				"tasknotes-nlp-core": "^0.1.1",
 				"yaml": "^2.3.1",
 				"zod": "^3.24.0"
 			},
@@ -13082,9 +13082,9 @@
 			}
 		},
 		"node_modules/tasknotes-nlp-core": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/tasknotes-nlp-core/-/tasknotes-nlp-core-0.1.0.tgz",
-			"integrity": "sha512-A8yw2D8VO9VD+h21c5rJ040VcIga+phUo5/XY49tFAfViahSYUNtZUPNCSZUci59DK9cFsZ0MB81arHJyQd5+Q==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/tasknotes-nlp-core/-/tasknotes-nlp-core-0.1.1.tgz",
+			"integrity": "sha512-TRc+E6aZ09+Q3g2SQffnnsA7HZqu3aqJFAS5CXqOyiy1/P4RdgiiOyTnwCBNob1EuLo7UbNyHF1zsjdHRljJqQ==",
 			"license": "MIT",
 			"dependencies": {
 				"chrono-node": "^2.7.5",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"obsidian-daily-notes-interface": "^0.9.4",
 		"reflect-metadata": "^0.2.2",
 		"rrule": "^2.8.1",
-		"tasknotes-nlp-core": "^0.1.0",
+		"tasknotes-nlp-core": "^0.1.1",
 		"yaml": "^2.3.1",
 		"zod": "^3.24.0"
 	}


### PR DESCRIPTION
## Summary

- Bump tasknotes-nlp-core to 0.1.1, which publishes both ESM and CommonJS package exports
- Remove the Jest mapper that forced tests to resolve tasknotes-nlp-core from a local sibling checkout
- Add an unreleased note for the CI dependency-resolution fix

## Test plan

- npm test -- tests/unit/services/NaturalLanguageParser.test.ts tests/unit/settings/TabButtons.css-classes.test.ts
- npm run typecheck
- git diff --check
- npm run test:ci -- --runInBand --silent
- OBSIDIAN_PLUGIN_PATH=/home/calluma/testvault/test/.obsidian/plugins/tasknotes npm run build:test
- obsidian plugin:reload id=tasknotes vault=test

Obsidian dev errors only showed the existing advanced-canvas errors, not TaskNotes errors.