### PR TITLE
Improve Google Calendar task sync reliability

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -29,4 +29,5 @@ Example:
 - Persist failed Google Calendar task-event deletions in plugin data and retry them after restart or reconnect, preventing orphaned task events when a task file is deleted while Google cleanup fails or sync is not ready.
 - Track exported Google Calendar task events in plugin data so startup can recover cleanup for task files deleted while Obsidian was closed.
 - Persist Google Calendar task sync requests while Google Calendar is not ready and replay the current task state after reconnect for scheduled, due, or both-date calendar modes.
+- Restore cancelled Google Calendar event tombstones when a task is synced to an existing event ID, so deleted-but-still-addressable events become visible again.
 - Prevent duplicate Google Calendar task events when concurrent syncs race before the newly created event ID reaches Obsidian metadata.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -23,3 +23,9 @@ Example:
 ```
 
 -->
+
+## Fixed
+
+- Persist failed Google Calendar task-event deletions in plugin data and retry them after restart or reconnect, preventing orphaned task events when a task file is deleted while Google cleanup fails or sync is not ready.
+- Track exported Google Calendar task events in plugin data so startup can recover cleanup for task files deleted while Obsidian was closed.
+- Prevent duplicate Google Calendar task events when concurrent syncs race before the newly created event ID reaches Obsidian metadata.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -28,4 +28,5 @@ Example:
 
 - Persist failed Google Calendar task-event deletions in plugin data and retry them after restart or reconnect, preventing orphaned task events when a task file is deleted while Google cleanup fails or sync is not ready.
 - Track exported Google Calendar task events in plugin data so startup can recover cleanup for task files deleted while Obsidian was closed.
+- Persist Google Calendar task sync requests while Google Calendar is not ready and replay the current task state after reconnect for scheduled, due, or both-date calendar modes.
 - Prevent duplicate Google Calendar task events when concurrent syncs race before the newly created event ID reaches Obsidian metadata.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -31,3 +31,4 @@ Example:
 - Persist Google Calendar task sync requests while Google Calendar is not ready and replay the current task state after reconnect for scheduled, due, or both-date calendar modes.
 - Restore cancelled Google Calendar event tombstones when a task is synced to an existing event ID, so deleted-but-still-addressable events become visible again.
 - Prevent duplicate Google Calendar task events when concurrent syncs race before the newly created event ID reaches Obsidian metadata.
+- Prevent pending intermediate status updates from overwriting completed Google Calendar task events when users quickly cycle a task to done.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -32,3 +32,4 @@ Example:
 - Restore cancelled Google Calendar event tombstones when a task is synced to an existing event ID, so deleted-but-still-addressable events become visible again.
 - Prevent duplicate Google Calendar task events when concurrent syncs race before the newly created event ID reaches Obsidian metadata.
 - Prevent pending intermediate status updates from overwriting completed Google Calendar task events when users quickly cycle a task to done.
+- Mark Google Calendar events as completed when tasks were already done before they became calendar-eligible.

--- a/src/bootstrap/pluginBootstrap.ts
+++ b/src/bootstrap/pluginBootstrap.ts
@@ -270,10 +270,11 @@ export function initializeServicesLazily(plugin: TaskNotesPlugin): void {
 
 			plugin.taskCalendarSyncService = new (await import("../services/TaskCalendarSyncService"))
 				.TaskCalendarSyncService(plugin, plugin.googleCalendarService);
+			plugin.taskCalendarSyncService.startDeletionQueueProcessor();
 
 			plugin.registerEvent(
 				plugin.emitter.on("file-deleted", (data: FileDeletedEventData) => {
-					if (!plugin.taskCalendarSyncService?.isEnabled()) {
+					if (!plugin.taskCalendarSyncService) {
 						return;
 					}
 

--- a/src/components/BatchContextMenu.ts
+++ b/src/components/BatchContextMenu.ts
@@ -334,7 +334,7 @@ export class BatchContextMenu {
 					const file = plugin.app.vault.getAbstractFileByPath(path);
 					if (file) {
 						// Delete from Google Calendar before trashing file
-						if (plugin.taskCalendarSyncService?.isEnabled()) {
+						if (plugin.taskCalendarSyncService) {
 							const task = await plugin.cacheManager.getTaskInfo(path);
 							if (task?.googleCalendarEventId) {
 								try {

--- a/src/components/TaskContextMenu.ts
+++ b/src/components/TaskContextMenu.ts
@@ -466,14 +466,15 @@ export class TaskContextMenu {
 						});
 						if (confirmed) {
 							// Delete from Google Calendar before trashing file
-							if (plugin.taskCalendarSyncService?.isEnabled() && task.googleCalendarEventId) {
-								plugin.taskCalendarSyncService
-									.deleteTaskFromCalendarByPath(task.path, task.googleCalendarEventId)
-									.catch((error) => {
-										console.warn("Failed to delete task from Google Calendar:", error);
-									});
+							if (plugin.taskCalendarSyncService && task.googleCalendarEventId) {
+								try {
+									await plugin.taskCalendarSyncService
+										.deleteTaskFromCalendarByPath(task.path, task.googleCalendarEventId);
+								} catch (error) {
+									console.warn("Failed to delete task from Google Calendar:", error);
+								}
 							}
-							plugin.app.vault.trash(file, true);
+							await plugin.app.vault.trash(file, true);
 						}
 					});
 				});

--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -602,6 +602,9 @@ export class GoogleCalendarService extends CalendarProvider {
 
 			// Build update payload
 			const payload: any = { ...currentEvent };
+			if (payload.status === "cancelled") {
+				payload.status = "confirmed";
+			}
 
 			// Support both 'title' and 'summary'
 			if (updates.title !== undefined || updates.summary !== undefined) {

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -256,7 +256,17 @@ export class TaskCalendarSyncService {
 	): Promise<void> {
 		const index = await this.getEventIndex();
 		const key = this.getDeletionQueueKey({ calendarId, eventId });
-		const filteredIndex = index.filter((item) => this.getDeletionQueueKey(item) !== key);
+		const replacedEntries = index.filter(
+			(item) =>
+				item.taskPath === taskPath &&
+				item.calendarId === calendarId &&
+				item.eventId !== eventId
+		);
+		const filteredIndex = index.filter(
+			(item) =>
+				this.getDeletionQueueKey(item) !== key &&
+				!(item.taskPath === taskPath && item.calendarId === calendarId)
+		);
 
 		filteredIndex.push({
 			taskPath,
@@ -266,6 +276,19 @@ export class TaskCalendarSyncService {
 		});
 
 		await this.saveEventIndex(filteredIndex);
+
+		for (const item of replacedEntries) {
+			const deleted = await this.deleteOrQueueCalendarEvent(
+				item.taskPath,
+				item.calendarId,
+				item.eventId
+			);
+			if (!deleted) {
+				console.warn(
+					`[TaskCalendarSync] Replaced event cleanup queued for ${item.taskPath}`
+				);
+			}
+		}
 	}
 
 	private async removeEventIndexForTask(taskPath: string): Promise<void> {
@@ -1353,6 +1376,22 @@ export class TaskCalendarSyncService {
 		});
 	}
 
+	private cancelPendingTaskUpdate(taskPath: string): void {
+		const existingTimer = this.pendingSyncs.get(taskPath);
+		if (existingTimer) {
+			clearTimeout(existingTimer);
+			this.pendingSyncs.delete(taskPath);
+			this.pendingTasks.delete(taskPath);
+		}
+	}
+
+	private async waitForInFlightTaskSync(taskPath: string): Promise<void> {
+		const inFlight = this.inFlightSyncs.get(taskPath);
+		if (inFlight) {
+			await inFlight.catch(() => {});
+		}
+	}
+
 	/**
 	 * Internal method that performs the actual task update sync
 	 */
@@ -1392,10 +1431,33 @@ export class TaskCalendarSyncService {
 			return;
 		}
 
+		this.cancelPendingTaskUpdate(task.path);
+		await this.waitForInFlightTaskSync(task.path);
+
+		const completionPromise = this.executeTaskCompletion(task);
+		this.inFlightSyncs.set(task.path, completionPromise);
+
+		try {
+			await completionPromise;
+		} finally {
+			if (this.inFlightSyncs.get(task.path) === completionPromise) {
+				this.inFlightSyncs.delete(task.path);
+			}
+		}
+	}
+
+	private async executeTaskCompletion(task: TaskInfo): Promise<void> {
 		const settings = this.plugin.settings.googleCalendarExport;
-		const existingEventId = this.getTaskEventId(task);
+		let existingEventId = this.getTaskEventId(task);
 		if (!existingEventId) {
-			return;
+			const synced = await this.syncTaskToCalendar(task);
+			if (!synced) {
+				return;
+			}
+			existingEventId = this.getTaskEventId(task);
+			if (!existingEventId) {
+				return;
+			}
 		}
 
 		// For recurring tasks, update EXDATE to exclude completed instance

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -2,7 +2,12 @@ import { Notice, TFile } from "obsidian";
 import { format } from "date-fns";
 import TaskNotesPlugin from "../main";
 import { GoogleCalendarService } from "./GoogleCalendarService";
-import { GoogleCalendarEventIndexEntry, PendingGoogleCalendarDeletion, TaskInfo } from "../types";
+import {
+	GoogleCalendarEventIndexEntry,
+	PendingGoogleCalendarDeletion,
+	PendingGoogleCalendarSync,
+	TaskInfo,
+} from "../types";
 import { convertToGoogleRecurrence } from "../utils/rruleConverter";
 import { TokenRefreshError } from "./errors";
 
@@ -22,8 +27,11 @@ const GOOGLE_CALENDAR_DELETION_QUEUE_KEY = "googleCalendarDeletionQueue";
 /** Persistent plugin-data key for task paths that currently own Google Calendar events */
 const GOOGLE_CALENDAR_EVENT_INDEX_KEY = "googleCalendarEventIndex";
 
-/** How often to retry queued Google Calendar deletions */
-const DELETION_QUEUE_PROCESSOR_INTERVAL_MS = 60000;
+/** Persistent plugin-data key for task paths that need Google Calendar sync replay */
+const GOOGLE_CALENDAR_SYNC_QUEUE_KEY = "googleCalendarSyncQueue";
+
+/** How often to retry queued Google Calendar recovery work */
+const RECOVERY_QUEUE_PROCESSOR_INTERVAL_MS = 60000;
 
 type CalendarEventPayload = {
 	summary: string;
@@ -47,7 +55,7 @@ export class TaskCalendarSyncService {
 	private googleCalendarService: GoogleCalendarService;
 	private rateLimitChain: Promise<unknown> = Promise.resolve();
 	private lastApiCallAt = 0;
-	private deletionQueueProcessorInterval: ReturnType<typeof setInterval> | null = null;
+	private recoveryQueueProcessorInterval: ReturnType<typeof setInterval> | null = null;
 
 	/** Debounce timers for pending syncs, keyed by task path */
 	private pendingSyncs: Map<string, ReturnType<typeof setTimeout>> = new Map();
@@ -79,9 +87,9 @@ export class TaskCalendarSyncService {
 		for (const timer of this.pendingSyncs.values()) {
 			clearTimeout(timer);
 		}
-		if (this.deletionQueueProcessorInterval) {
-			clearInterval(this.deletionQueueProcessorInterval);
-			this.deletionQueueProcessorInterval = null;
+		if (this.recoveryQueueProcessorInterval) {
+			clearInterval(this.recoveryQueueProcessorInterval);
+			this.recoveryQueueProcessorInterval = null;
 		}
 		this.pendingSyncs.clear();
 		this.previousTaskState.clear();
@@ -156,28 +164,34 @@ export class TaskCalendarSyncService {
 	}
 
 	/**
-	 * Start retrying persisted calendar deletion work.
+	 * Start retrying persisted calendar recovery work.
 	 */
 	startDeletionQueueProcessor(): void {
-		if (this.deletionQueueProcessorInterval) {
+		if (this.recoveryQueueProcessorInterval) {
 			return;
 		}
 
 		this.processStartupDeletionRecovery().catch((error) => {
-			console.error("[TaskCalendarSync] Failed to process deletion queue:", error);
+			console.error("[TaskCalendarSync] Failed to process recovery queues:", error);
 		});
 
-		this.deletionQueueProcessorInterval = setInterval(() => {
-			this.processDeletionQueue().catch((error) => {
-				console.error("[TaskCalendarSync] Failed to process deletion queue:", error);
+		this.recoveryQueueProcessorInterval = setInterval(() => {
+			this.processRecoveryQueues().catch((error) => {
+				console.error("[TaskCalendarSync] Failed to process recovery queues:", error);
 			});
-		}, DELETION_QUEUE_PROCESSOR_INTERVAL_MS);
+		}, RECOVERY_QUEUE_PROCESSOR_INTERVAL_MS);
 	}
 
 	private isDeletionQueueReady(): boolean {
 		const settings = this.plugin.settings.googleCalendarExport;
 		const isConnected = this.googleCalendarService.getAvailableCalendars().length > 0;
 		return !!settings?.enabled && !!settings?.syncOnTaskDelete && isConnected;
+	}
+
+	private isSyncQueueReady(): boolean {
+		const settings = this.plugin.settings.googleCalendarExport;
+		const isConnected = this.googleCalendarService.getAvailableCalendars().length > 0;
+		return !!settings?.enabled && !!settings?.targetCalendarId && isConnected;
 	}
 
 	private getDeletionQueueKey(item: Pick<PendingGoogleCalendarDeletion, "calendarId" | "eventId">): string {
@@ -221,6 +235,17 @@ export class TaskCalendarSyncService {
 	private async saveEventIndex(index: GoogleCalendarEventIndexEntry[]): Promise<void> {
 		const data = (await this.plugin.loadData()) || {};
 		data[GOOGLE_CALENDAR_EVENT_INDEX_KEY] = index;
+		await this.plugin.saveData(data);
+	}
+
+	private async getSyncQueue(): Promise<PendingGoogleCalendarSync[]> {
+		const data = await this.plugin.loadData();
+		return data?.[GOOGLE_CALENDAR_SYNC_QUEUE_KEY] || [];
+	}
+
+	private async saveSyncQueue(queue: PendingGoogleCalendarSync[]): Promise<void> {
+		const data = (await this.plugin.loadData()) || {};
+		data[GOOGLE_CALENDAR_SYNC_QUEUE_KEY] = queue;
 		await this.plugin.saveData(data);
 	}
 
@@ -279,6 +304,34 @@ export class TaskCalendarSyncService {
 			return String(error.message);
 		}
 		return String(error);
+	}
+
+	private async queueTaskSync(taskPath: string, error?: any, attempted = false): Promise<void> {
+		const now = Date.now();
+		const queue = await this.getSyncQueue();
+		const existing = queue.find((item) => item.taskPath === taskPath);
+		const lastError = error ? this.getErrorMessage(error) : undefined;
+
+		if (existing) {
+			existing.requestedAt = now;
+			if (attempted) {
+				existing.attempts += 1;
+				existing.lastAttemptAt = now;
+			}
+			if (lastError) {
+				existing.lastError = lastError;
+			}
+		} else {
+			queue.push({
+				taskPath,
+				requestedAt: now,
+				attempts: attempted ? 1 : 0,
+				lastAttemptAt: attempted ? now : undefined,
+				lastError,
+			});
+		}
+
+		await this.saveSyncQueue(queue);
 	}
 
 	private async removeFromDeletionQueue(calendarId: string, eventId: string): Promise<void> {
@@ -390,7 +443,12 @@ export class TaskCalendarSyncService {
 
 	async processStartupDeletionRecovery(): Promise<void> {
 		await this.recoverDeletedTaskEventsFromIndex();
+		await this.processRecoveryQueues();
+	}
+
+	async processRecoveryQueues(): Promise<void> {
 		await this.processDeletionQueue();
+		await this.processPendingSyncQueue();
 	}
 
 	async recoverDeletedTaskEventsFromIndex(): Promise<void> {
@@ -436,6 +494,67 @@ export class TaskCalendarSyncService {
 					: new Error("Indexed task file no longer exists")
 			);
 		}
+	}
+
+	async processPendingSyncQueue(): Promise<{ synced: number; failed: number; deleted: number; dropped: number; remaining: number }> {
+		const results = { synced: 0, failed: 0, deleted: 0, dropped: 0, remaining: 0 };
+		const queue = await this.getSyncQueue();
+
+		if (queue.length === 0) {
+			return results;
+		}
+
+		if (!this.isSyncQueueReady()) {
+			results.remaining = queue.length;
+			return results;
+		}
+
+		const dedupedQueue = new Map<string, PendingGoogleCalendarSync>();
+		for (const item of queue) {
+			dedupedQueue.set(item.taskPath, item);
+		}
+
+		const remainingItems: PendingGoogleCalendarSync[] = [];
+
+		for (const item of dedupedQueue.values()) {
+			const task = await this.plugin.cacheManager.getTaskInfo(item.taskPath);
+			if (!task) {
+				results.dropped++;
+				continue;
+			}
+
+			if (!this.isTaskCalendarEligible(task)) {
+				const eventId = this.getTaskEventId(task);
+				if (eventId) {
+					const deleted = await this.deleteTaskFromCalendar(task);
+					if (!deleted) {
+						console.warn(`[TaskCalendarSync] Calendar deletion queued while replaying sync for ${item.taskPath}`);
+					}
+					results.deleted++;
+				} else {
+					results.dropped++;
+				}
+				continue;
+			}
+
+			const synced = await this.syncTaskToCalendar(task, undefined, { queueOnFailure: false });
+			if (synced) {
+				results.synced++;
+				continue;
+			}
+
+			results.failed++;
+			remainingItems.push({
+				...item,
+				attempts: item.attempts + 1,
+				lastAttemptAt: Date.now(),
+				lastError: "Failed to replay queued Google Calendar sync",
+			});
+		}
+
+		results.remaining = remainingItems.length;
+		await this.saveSyncQueue(remainingItems);
+		return results;
 	}
 
 	async processDeletionQueue(): Promise<{ deleted: number; failed: number; remaining: number }> {
@@ -1063,9 +1182,15 @@ export class TaskCalendarSyncService {
 	/**
 	 * Sync a task to Google Calendar (create or update)
 	 */
-	async syncTaskToCalendar(task: TaskInfo, previous?: TaskInfo): Promise<void> {
-		if (!this.shouldSyncTask(task)) {
-			return;
+	async syncTaskToCalendar(
+		task: TaskInfo,
+		previous?: TaskInfo,
+		options: { queueOnFailure?: boolean } = {}
+	): Promise<boolean> {
+		const queueOnFailure = options.queueOnFailure ?? true;
+
+		if (!this.isTaskCalendarEligible(task)) {
+			return true;
 		}
 
 		const settings = this.plugin.settings.googleCalendarExport;
@@ -1073,18 +1198,34 @@ export class TaskCalendarSyncService {
 		const targetCalendarId = settings.targetCalendarId;
 
 		try {
+			if (!this.isEnabled()) {
+				if (queueOnFailure) {
+					await this.queueTaskSync(
+						task.path,
+						new Error("Google Calendar sync is not ready")
+					);
+				}
+				return false;
+			}
+
 			// Check if recurrence was removed (previous had recurrence, current doesn't)
 			const clearRecurrence = !!(previous?.recurrence && !task.recurrence);
 			
 			const eventData = this.taskToCalendarEvent(task, clearRecurrence);
 			if (!eventData) {
 				console.warn("[TaskCalendarSync] Could not convert task to event:", task.path);
-				return;
+				return false;
 			}
 
 			if (!targetCalendarId) {
 				console.warn("[TaskCalendarSync] Cannot sync task without target calendar:", task.path);
-				return;
+				if (queueOnFailure) {
+					await this.queueTaskSync(
+						task.path,
+						new Error("Google Calendar target calendar is not configured")
+					);
+				}
+				return false;
 			}
 
 			if (existingEventId) {
@@ -1103,7 +1244,7 @@ export class TaskCalendarSyncService {
 					await this.withGoogleRateLimit(() =>
 						this.googleCalendarService.updateEvent(targetCalendarId, eventId, eventData)
 					);
-					return;
+					return true;
 				}
 
 				const createPromise = this.createCalendarEventForTask(task, eventData, targetCalendarId);
@@ -1116,6 +1257,8 @@ export class TaskCalendarSyncService {
 					}
 				}
 			}
+
+			return true;
 		} catch (error: any) {
 			// Check if it's a 404 error (event was deleted externally)
 			if (error.status === 404 && existingEventId) {
@@ -1124,11 +1267,14 @@ export class TaskCalendarSyncService {
 				// Retry without the link - refetch task to get updated version
 				const updatedTask = await this.plugin.cacheManager.getTaskInfo(task.path);
 				if (updatedTask) {
-					return this.syncTaskToCalendar(updatedTask, previous);
+					return this.syncTaskToCalendar(updatedTask, previous, options);
 				}
 			}
 
 			console.error("[TaskCalendarSync] Failed to sync task:", task.path, error);
+			if (queueOnFailure) {
+				await this.queueTaskSync(task.path, error, true);
+			}
 
 			// Show user-friendly message for token refresh errors
 			// TokenRefreshError indicates the OAuth connection expired and user needs to reconnect
@@ -1137,6 +1283,8 @@ export class TaskCalendarSyncService {
 			} else {
 				new Notice(this.plugin.i18n.translate("settings.integrations.googleCalendarExport.notices.syncFailed", { message: error.message }));
 			}
+
+			return false;
 		}
 	}
 
@@ -1212,11 +1360,11 @@ export class TaskCalendarSyncService {
 		const existingEventId = this.getTaskEventId(task);
 
 		// If task no longer meets sync criteria, delete the event
-		if (!this.shouldSyncTask(task)) {
+		if (!this.isTaskCalendarEligible(task)) {
 			if (existingEventId) {
 				const deleted = await this.deleteTaskFromCalendar(task);
 				if (!deleted) {
-					throw new Error(`Failed to delete task from Google Calendar: ${task.path}`);
+					console.warn(`Google Calendar deletion queued for ${task.path}`);
 				}
 			}
 			// Clean up previous state
@@ -1427,8 +1575,12 @@ export class TaskCalendarSyncService {
 		// Process tasks in parallel with concurrency limit
 		await this.processInParallel(tasksToSync, async (task) => {
 			try {
-				await this.syncTaskToCalendar(task);
-				results.synced++;
+				const synced = await this.syncTaskToCalendar(task);
+				if (synced) {
+					results.synced++;
+				} else {
+					results.failed++;
+				}
 			} catch (error) {
 				results.failed++;
 				console.error(`[TaskCalendarSync] Failed to sync task ${task.path}:`, error);

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -2,7 +2,7 @@ import { Notice, TFile } from "obsidian";
 import { format } from "date-fns";
 import TaskNotesPlugin from "../main";
 import { GoogleCalendarService } from "./GoogleCalendarService";
-import { TaskInfo } from "../types";
+import { GoogleCalendarEventIndexEntry, PendingGoogleCalendarDeletion, TaskInfo } from "../types";
 import { convertToGoogleRecurrence } from "../utils/rruleConverter";
 import { TokenRefreshError } from "./errors";
 
@@ -16,6 +16,28 @@ const SYNC_CONCURRENCY_LIMIT = 5;
  *  Google Calendar enforces ~10 req/s per-user; 100ms keeps us comfortably under that. */
 const GOOGLE_API_CALL_SPACING_MS = 100;
 
+/** Persistent plugin-data key for Google Calendar deletion retries */
+const GOOGLE_CALENDAR_DELETION_QUEUE_KEY = "googleCalendarDeletionQueue";
+
+/** Persistent plugin-data key for task paths that currently own Google Calendar events */
+const GOOGLE_CALENDAR_EVENT_INDEX_KEY = "googleCalendarEventIndex";
+
+/** How often to retry queued Google Calendar deletions */
+const DELETION_QUEUE_PROCESSOR_INTERVAL_MS = 60000;
+
+type CalendarEventPayload = {
+	summary: string;
+	description?: string;
+	start: { date?: string; dateTime?: string; timeZone?: string };
+	end: { date?: string; dateTime?: string; timeZone?: string };
+	colorId?: string;
+	reminders?: {
+		useDefault: boolean;
+		overrides?: Array<{ method: string; minutes: number }>;
+	};
+	recurrence?: string[];
+};
+
 /**
  * Service for syncing TaskNotes tasks to Google Calendar.
  * Handles creating, updating, and deleting calendar events when tasks change.
@@ -25,6 +47,7 @@ export class TaskCalendarSyncService {
 	private googleCalendarService: GoogleCalendarService;
 	private rateLimitChain: Promise<unknown> = Promise.resolve();
 	private lastApiCallAt = 0;
+	private deletionQueueProcessorInterval: ReturnType<typeof setInterval> | null = null;
 
 	/** Debounce timers for pending syncs, keyed by task path */
 	private pendingSyncs: Map<string, ReturnType<typeof setTimeout>> = new Map();
@@ -38,6 +61,12 @@ export class TaskCalendarSyncService {
 	/** Store the latest explicitly passed task object during debounce to avoid cache race conditions */
 	private pendingTasks: Map<string, TaskInfo> = new Map();
 
+	/** In-flight create operations keyed by task path to avoid duplicate Google events */
+	private pendingEventCreates: Map<string, Promise<string>> = new Map();
+
+	/** Event IDs written during this session, used while Obsidian metadata catches up */
+	private taskEventIdCache: Map<string, string> = new Map();
+
 	constructor(plugin: TaskNotesPlugin, googleCalendarService: GoogleCalendarService) {
 		this.plugin = plugin;
 		this.googleCalendarService = googleCalendarService;
@@ -50,9 +79,15 @@ export class TaskCalendarSyncService {
 		for (const timer of this.pendingSyncs.values()) {
 			clearTimeout(timer);
 		}
+		if (this.deletionQueueProcessorInterval) {
+			clearInterval(this.deletionQueueProcessorInterval);
+			this.deletionQueueProcessorInterval = null;
+		}
 		this.pendingSyncs.clear();
 		this.previousTaskState.clear();
 		this.pendingTasks.clear();
+		this.pendingEventCreates.clear();
+		this.taskEventIdCache.clear();
 	}
 
 	/**
@@ -121,6 +156,346 @@ export class TaskCalendarSyncService {
 	}
 
 	/**
+	 * Start retrying persisted calendar deletion work.
+	 */
+	startDeletionQueueProcessor(): void {
+		if (this.deletionQueueProcessorInterval) {
+			return;
+		}
+
+		this.processStartupDeletionRecovery().catch((error) => {
+			console.error("[TaskCalendarSync] Failed to process deletion queue:", error);
+		});
+
+		this.deletionQueueProcessorInterval = setInterval(() => {
+			this.processDeletionQueue().catch((error) => {
+				console.error("[TaskCalendarSync] Failed to process deletion queue:", error);
+			});
+		}, DELETION_QUEUE_PROCESSOR_INTERVAL_MS);
+	}
+
+	private isDeletionQueueReady(): boolean {
+		const settings = this.plugin.settings.googleCalendarExport;
+		const isConnected = this.googleCalendarService.getAvailableCalendars().length > 0;
+		return !!settings?.enabled && !!settings?.syncOnTaskDelete && isConnected;
+	}
+
+	private getDeletionQueueKey(item: Pick<PendingGoogleCalendarDeletion, "calendarId" | "eventId">): string {
+		return `${item.calendarId}::${item.eventId}`;
+	}
+
+	private isTaskCalendarEligible(task: TaskInfo): boolean {
+		if (task.archived) {
+			return false;
+		}
+
+		const settings = this.plugin.settings.googleCalendarExport;
+		switch (settings.syncTrigger) {
+			case "scheduled":
+				return !!task.scheduled;
+			case "due":
+				return !!task.due;
+			case "both":
+				return !!task.scheduled || !!task.due;
+			default:
+				return false;
+		}
+	}
+
+	private async getDeletionQueue(): Promise<PendingGoogleCalendarDeletion[]> {
+		const data = await this.plugin.loadData();
+		return data?.[GOOGLE_CALENDAR_DELETION_QUEUE_KEY] || [];
+	}
+
+	private async saveDeletionQueue(queue: PendingGoogleCalendarDeletion[]): Promise<void> {
+		const data = (await this.plugin.loadData()) || {};
+		data[GOOGLE_CALENDAR_DELETION_QUEUE_KEY] = queue;
+		await this.plugin.saveData(data);
+	}
+
+	private async getEventIndex(): Promise<GoogleCalendarEventIndexEntry[]> {
+		const data = await this.plugin.loadData();
+		return data?.[GOOGLE_CALENDAR_EVENT_INDEX_KEY] || [];
+	}
+
+	private async saveEventIndex(index: GoogleCalendarEventIndexEntry[]): Promise<void> {
+		const data = (await this.plugin.loadData()) || {};
+		data[GOOGLE_CALENDAR_EVENT_INDEX_KEY] = index;
+		await this.plugin.saveData(data);
+	}
+
+	private async upsertEventIndex(
+		taskPath: string,
+		calendarId: string,
+		eventId: string
+	): Promise<void> {
+		const index = await this.getEventIndex();
+		const key = this.getDeletionQueueKey({ calendarId, eventId });
+		const filteredIndex = index.filter((item) => this.getDeletionQueueKey(item) !== key);
+
+		filteredIndex.push({
+			taskPath,
+			calendarId,
+			eventId,
+			updatedAt: Date.now(),
+		});
+
+		await this.saveEventIndex(filteredIndex);
+	}
+
+	private async removeEventIndexForTask(taskPath: string): Promise<void> {
+		const index = await this.getEventIndex();
+		const filteredIndex = index.filter((item) => item.taskPath !== taskPath);
+
+		if (filteredIndex.length !== index.length) {
+			await this.saveEventIndex(filteredIndex);
+		}
+	}
+
+	private async removeEventIndexForEvent(calendarId: string, eventId: string): Promise<void> {
+		const index = await this.getEventIndex();
+		const key = this.getDeletionQueueKey({ calendarId, eventId });
+		const filteredIndex = index.filter((item) => this.getDeletionQueueKey(item) !== key);
+
+		if (filteredIndex.length !== index.length) {
+			await this.saveEventIndex(filteredIndex);
+		}
+	}
+
+	private getErrorStatus(error: any): number | undefined {
+		return error?.status ?? error?.statusCode;
+	}
+
+	private isAlreadyDeletedError(error: any): boolean {
+		const status = this.getErrorStatus(error);
+		return status === 404 || status === 410;
+	}
+
+	private getErrorMessage(error: any): string {
+		if (error instanceof Error) {
+			return error.message;
+		}
+		if (error?.message) {
+			return String(error.message);
+		}
+		return String(error);
+	}
+
+	private async removeFromDeletionQueue(calendarId: string, eventId: string): Promise<void> {
+		const queue = await this.getDeletionQueue();
+		const key = this.getDeletionQueueKey({ calendarId, eventId });
+		const filteredQueue = queue.filter((item) => this.getDeletionQueueKey(item) !== key);
+
+		if (filteredQueue.length !== queue.length) {
+			await this.saveDeletionQueue(filteredQueue);
+		}
+	}
+
+	private async queueCalendarDeletion(
+		taskPath: string,
+		calendarId: string,
+		eventId: string,
+		error?: any,
+		attempted = false
+	): Promise<void> {
+		const now = Date.now();
+		const queue = await this.getDeletionQueue();
+		const key = this.getDeletionQueueKey({ calendarId, eventId });
+		const existing = queue.find((item) => this.getDeletionQueueKey(item) === key);
+		const lastError = error ? this.getErrorMessage(error) : undefined;
+
+		if (existing) {
+			existing.taskPath = taskPath;
+			if (attempted) {
+				existing.attempts += 1;
+				existing.lastAttemptAt = now;
+			}
+			if (lastError) {
+				existing.lastError = lastError;
+			}
+		} else {
+			queue.push({
+				taskPath,
+				calendarId,
+				eventId,
+				createdAt: now,
+				attempts: attempted ? 1 : 0,
+				lastAttemptAt: attempted ? now : undefined,
+				lastError,
+			});
+		}
+
+		await this.saveDeletionQueue(queue);
+	}
+
+	private async deleteOrQueueCalendarEvent(
+		taskPath: string,
+		calendarId: string,
+		eventId: string
+	): Promise<boolean> {
+		if (!this.plugin.settings.googleCalendarExport.syncOnTaskDelete) {
+			return true;
+		}
+
+		if (!this.isDeletionQueueReady()) {
+			await this.queueCalendarDeletion(
+				taskPath,
+				calendarId,
+				eventId,
+				new Error("Google Calendar sync is not ready")
+			);
+			return false;
+		}
+
+		try {
+			await this.withGoogleRateLimit(() =>
+				this.googleCalendarService.deleteEvent(calendarId, eventId)
+			);
+			await this.removeFromDeletionQueue(calendarId, eventId);
+			return true;
+		} catch (error: any) {
+			if (this.isAlreadyDeletedError(error)) {
+				await this.removeFromDeletionQueue(calendarId, eventId);
+				return true;
+			}
+
+			console.error("[TaskCalendarSync] Failed to delete event:", taskPath, error);
+			await this.queueCalendarDeletion(taskPath, calendarId, eventId, error, true);
+			return false;
+		}
+	}
+
+	private async clearTaskEventIdIfMatching(item: PendingGoogleCalendarDeletion): Promise<void> {
+		const task = await this.plugin.cacheManager.getTaskInfo(item.taskPath);
+		if (task?.googleCalendarEventId === item.eventId) {
+			await this.removeTaskEventId(item.taskPath);
+		}
+	}
+
+	private async isQueuedDeletionStillNeeded(
+		item: PendingGoogleCalendarDeletion
+	): Promise<boolean> {
+		const task = await this.plugin.cacheManager.getTaskInfo(item.taskPath);
+		if (!task) {
+			return true;
+		}
+
+		const currentEventId = this.getTaskEventId(task);
+		if (currentEventId !== item.eventId) {
+			return true;
+		}
+
+		return !this.isTaskCalendarEligible(task);
+	}
+
+	async processStartupDeletionRecovery(): Promise<void> {
+		await this.recoverDeletedTaskEventsFromIndex();
+		await this.processDeletionQueue();
+	}
+
+	async recoverDeletedTaskEventsFromIndex(): Promise<void> {
+		if (!this.plugin.settings.googleCalendarExport.syncOnTaskDelete) {
+			return;
+		}
+
+		const targetCalendarId = this.plugin.settings.googleCalendarExport.targetCalendarId;
+		if (!targetCalendarId) {
+			return;
+		}
+
+		const tasks = await this.plugin.cacheManager.getAllTasks();
+		const activeTasksByEvent = new Map<string, TaskInfo>();
+
+		for (const task of tasks) {
+			const eventId = this.getTaskEventId(task);
+			if (!eventId) {
+				continue;
+			}
+
+			const key = this.getDeletionQueueKey({
+				calendarId: targetCalendarId,
+				eventId,
+			});
+			activeTasksByEvent.set(key, task);
+			await this.upsertEventIndex(task.path, targetCalendarId, eventId);
+		}
+
+		const index = await this.getEventIndex();
+		for (const item of index) {
+			const activeTask = activeTasksByEvent.get(this.getDeletionQueueKey(item));
+			if (activeTask && this.isTaskCalendarEligible(activeTask)) {
+				continue;
+			}
+
+			await this.queueCalendarDeletion(
+				activeTask?.path || item.taskPath,
+				item.calendarId,
+				item.eventId,
+				activeTask
+					? new Error("Indexed task no longer meets calendar sync criteria")
+					: new Error("Indexed task file no longer exists")
+			);
+		}
+	}
+
+	async processDeletionQueue(): Promise<{ deleted: number; failed: number; remaining: number }> {
+		const results = { deleted: 0, failed: 0, remaining: 0 };
+		const queue = await this.getDeletionQueue();
+
+		if (queue.length === 0) {
+			return results;
+		}
+
+		if (!this.isDeletionQueueReady()) {
+			results.remaining = queue.length;
+			return results;
+		}
+
+		const dedupedQueue = new Map<string, PendingGoogleCalendarDeletion>();
+		for (const item of queue) {
+			dedupedQueue.set(this.getDeletionQueueKey(item), item);
+		}
+
+		const remainingItems: PendingGoogleCalendarDeletion[] = [];
+
+		for (const item of dedupedQueue.values()) {
+			try {
+				const deletionStillNeeded = await this.isQueuedDeletionStillNeeded(item);
+				if (!deletionStillNeeded) {
+					continue;
+				}
+
+				await this.withGoogleRateLimit(() =>
+					this.googleCalendarService.deleteEvent(item.calendarId, item.eventId)
+				);
+				await this.clearTaskEventIdIfMatching(item);
+				await this.removeEventIndexForEvent(item.calendarId, item.eventId);
+				results.deleted++;
+			} catch (error: any) {
+				if (this.isAlreadyDeletedError(error)) {
+					await this.clearTaskEventIdIfMatching(item);
+					await this.removeEventIndexForEvent(item.calendarId, item.eventId);
+					results.deleted++;
+					continue;
+				}
+
+				results.failed++;
+				remainingItems.push({
+					...item,
+					attempts: item.attempts + 1,
+					lastAttemptAt: Date.now(),
+					lastError: this.getErrorMessage(error),
+				});
+				console.error("[TaskCalendarSync] Failed to retry queued event deletion:", item, error);
+			}
+		}
+
+		results.remaining = remainingItems.length;
+		await this.saveDeletionQueue(remainingItems);
+		return results;
+	}
+
+	/**
 	 * Determine if a task should be synced based on settings and task properties
 	 */
 	shouldSyncTask(task: TaskInfo): boolean {
@@ -148,7 +523,7 @@ export class TaskCalendarSyncService {
 	 * Get the Google Calendar event ID from the task's frontmatter
 	 */
 	getTaskEventId(task: TaskInfo): string | undefined {
-		return task.googleCalendarEventId;
+		return task.googleCalendarEventId || this.taskEventIdCache.get(task.path);
 	}
 
 	/**
@@ -181,6 +556,12 @@ export class TaskCalendarSyncService {
 		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter) => {
 			frontmatter[fieldName] = eventId;
 		});
+		this.taskEventIdCache.set(taskPath, eventId);
+
+		const targetCalendarId = this.plugin.settings.googleCalendarExport.targetCalendarId;
+		if (targetCalendarId) {
+			await this.upsertEventIndex(taskPath, targetCalendarId, eventId);
+		}
 	}
 
 	/**
@@ -190,6 +571,8 @@ export class TaskCalendarSyncService {
 		const file = this.plugin.app.vault.getAbstractFileByPath(taskPath);
 		if (!(file instanceof TFile)) {
 			console.warn(`Cannot remove event ID: file not found at ${taskPath}`);
+			this.taskEventIdCache.delete(taskPath);
+			await this.removeEventIndexForTask(taskPath);
 			return;
 		}
 
@@ -197,6 +580,8 @@ export class TaskCalendarSyncService {
 		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter) => {
 			delete frontmatter[fieldName];
 		});
+		this.taskEventIdCache.delete(taskPath);
+		await this.removeEventIndexForTask(taskPath);
 	}
 
 	/**
@@ -522,18 +907,7 @@ export class TaskCalendarSyncService {
 	/**
 	 * Convert a task to a Google Calendar event payload
 	 */
-	private taskToCalendarEvent(task: TaskInfo, clearRecurrence?: boolean): {
-		summary: string;
-		description?: string;
-		start: { date?: string; dateTime?: string; timeZone?: string };
-		end: { date?: string; dateTime?: string; timeZone?: string };
-		colorId?: string;
-		reminders?: {
-			useDefault: boolean;
-			overrides?: Array<{ method: string; minutes: number }>;
-		};
-		recurrence?: string[];
-	} | null {
+	private taskToCalendarEvent(task: TaskInfo, clearRecurrence?: boolean): CalendarEventPayload | null {
 		const eventDate = this.getEventDate(task);
 		if (!eventDate) return null;
 
@@ -563,18 +937,7 @@ export class TaskCalendarSyncService {
 		};
 		const end = this.getEventEnd(adjustedStartInfo, task);
 
-		const event: {
-			summary: string;
-			description?: string;
-			start: { date?: string; dateTime?: string; timeZone?: string };
-			end: { date?: string; dateTime?: string; timeZone?: string };
-			colorId?: string;
-			reminders?: {
-				useDefault: boolean;
-				overrides?: Array<{ method: string; minutes: number }>;
-			};
-			recurrence?: string[];
-		} = {
+		const event: CalendarEventPayload = {
 			summary: this.applyTitleTemplate(task),
 			start,
 			end,
@@ -670,6 +1033,33 @@ export class TaskCalendarSyncService {
 		return event;
 	}
 
+	private async createCalendarEventForTask(
+		task: TaskInfo,
+		eventData: CalendarEventPayload,
+		calendarId: string
+	): Promise<string> {
+		const createdEvent = await this.withGoogleRateLimit(() =>
+			this.googleCalendarService.createEvent(
+				calendarId,
+				{
+					...eventData,
+					isAllDay: !!eventData.start.date,
+				}
+			)
+		);
+
+		// Extract the actual event ID from the ICSEvent ID format.
+		// Format is "google-{calendarId}-{eventId}". Calendar IDs can contain
+		// hyphens, so strip the known prefix.
+		const prefix = `google-${calendarId}-`;
+		const eventId = createdEvent.id.startsWith(prefix)
+			? createdEvent.id.slice(prefix.length)
+			: createdEvent.id;
+
+		await this.saveTaskEventId(task.path, eventId);
+		return eventId;
+	}
+
 	/**
 	 * Sync a task to Google Calendar (create or update)
 	 */
@@ -680,6 +1070,7 @@ export class TaskCalendarSyncService {
 
 		const settings = this.plugin.settings.googleCalendarExport;
 		const existingEventId = this.getTaskEventId(task);
+		const targetCalendarId = settings.targetCalendarId;
 
 		try {
 			// Check if recurrence was removed (previous had recurrence, current doesn't)
@@ -691,37 +1082,39 @@ export class TaskCalendarSyncService {
 				return;
 			}
 
+			if (!targetCalendarId) {
+				console.warn("[TaskCalendarSync] Cannot sync task without target calendar:", task.path);
+				return;
+			}
+
 			if (existingEventId) {
 				// Update existing event
 				await this.withGoogleRateLimit(() =>
 					this.googleCalendarService.updateEvent(
-						settings.targetCalendarId,
+						targetCalendarId,
 						existingEventId,
 						eventData
 					)
 				);
 			} else {
-				// Create new event — pass structured start/end objects to preserve timeZone
-				const createdEvent = await this.withGoogleRateLimit(() =>
-					this.googleCalendarService.createEvent(
-						settings.targetCalendarId,
-						{
-							...eventData,
-							isAllDay: !!eventData.start.date,
-						}
-					)
-				);
+				const pendingCreate = this.pendingEventCreates.get(task.path);
+				if (pendingCreate) {
+					const eventId = await pendingCreate;
+					await this.withGoogleRateLimit(() =>
+						this.googleCalendarService.updateEvent(targetCalendarId, eventId, eventData)
+					);
+					return;
+				}
 
-				// Extract the actual event ID from the ICSEvent ID format
-				// Format is "google-{calendarId}-{eventId}"
-				// Calendar IDs can contain hyphens, so strip the known prefix
-				const prefix = `google-${settings.targetCalendarId}-`;
-				const eventId = createdEvent.id.startsWith(prefix)
-					? createdEvent.id.slice(prefix.length)
-					: createdEvent.id;
-
-				// Save the event ID to the task's frontmatter
-				await this.saveTaskEventId(task.path, eventId);
+				const createPromise = this.createCalendarEventForTask(task, eventData, targetCalendarId);
+				this.pendingEventCreates.set(task.path, createPromise);
+				try {
+					await createPromise;
+				} finally {
+					if (this.pendingEventCreates.get(task.path) === createPromise) {
+						this.pendingEventCreates.delete(task.path);
+					}
+				}
 			}
 		} catch (error: any) {
 			// Check if it's a 404 error (event was deleted externally)
@@ -942,24 +1335,18 @@ export class TaskCalendarSyncService {
 			return true;
 		}
 
-		let deleteFailed = false;
-
-		try {
-			await this.withGoogleRateLimit(() =>
-				this.googleCalendarService.deleteEvent(
-					settings.targetCalendarId,
-					existingEventId
-				)
-			);
-		} catch (error: any) {
-			// 404 or 410 means event is already gone - that's fine
-			if (error.status !== 404 && error.status !== 410) {
-				deleteFailed = true;
-				console.error("[TaskCalendarSync] Failed to delete event:", task.path, error);
-			}
+		const targetCalendarId = settings.targetCalendarId;
+		if (!targetCalendarId) {
+			console.warn("[TaskCalendarSync] Cannot delete task event without target calendar:", task.path);
+			return false;
 		}
 
-		if (deleteFailed) {
+		const deleted = await this.deleteOrQueueCalendarEvent(
+			task.path,
+			targetCalendarId,
+			existingEventId
+		);
+		if (!deleted) {
 			return false;
 		}
 
@@ -971,24 +1358,41 @@ export class TaskCalendarSyncService {
 	/**
 	 * Delete a task's calendar event by path (used when task is being deleted)
 	 */
-	async deleteTaskFromCalendarByPath(taskPath: string, eventId: string): Promise<void> {
+	async deleteTaskFromCalendarByPath(
+		taskPath: string,
+		eventId?: string,
+		...additionalEventIds: Array<string | undefined>
+	): Promise<boolean> {
 		if (!this.plugin.settings.googleCalendarExport.syncOnTaskDelete) {
-			return;
+			return true;
 		}
 
 		const settings = this.plugin.settings.googleCalendarExport;
+		const eventIds = [eventId, ...additionalEventIds].filter(
+			(id): id is string => typeof id === "string" && id.length > 0
+		);
 
-		try {
-			await this.withGoogleRateLimit(() =>
-				this.googleCalendarService.deleteEvent(settings.targetCalendarId, eventId)
-			);
-		} catch (error: any) {
-			// 404 or 410 means event is already gone - that's fine
-			if (error.status !== 404 && error.status !== 410) {
-				console.error("[TaskCalendarSync] Failed to delete event:", taskPath, error);
-			}
+		if (eventIds.length === 0) {
+			return true;
 		}
-		// No need to remove from frontmatter since the task file is being deleted
+
+		const targetCalendarId = settings.targetCalendarId;
+		if (!targetCalendarId) {
+			console.warn("[TaskCalendarSync] Cannot delete task events without target calendar:", taskPath);
+			return false;
+		}
+
+		const results: boolean[] = [];
+		for (const id of eventIds) {
+			const deleted = await this.deleteOrQueueCalendarEvent(taskPath, targetCalendarId, id);
+			if (deleted) {
+				await this.removeEventIndexForEvent(targetCalendarId, id);
+			}
+			results.push(deleted);
+		}
+
+		// No need to remove from frontmatter since the task file is being deleted.
+		return results.every(Boolean);
 	}
 
 	// handleTaskPathChange is no longer needed - event ID is stored in frontmatter
@@ -1046,7 +1450,7 @@ export class TaskCalendarSyncService {
 	 * Remove all task-event links and optionally delete events.
 	 * Iterates over all tasks and removes the googleCalendarEventId from frontmatter.
 	 */
-	async unlinkAllTasks(deleteEvents: boolean = false): Promise<void> {
+	async unlinkAllTasks(deleteEvents = false): Promise<void> {
 		const settings = this.plugin.settings.googleCalendarExport;
 		const tasks = await this.plugin.cacheManager.getAllTasks();
 		let unlinkedCount = 0;
@@ -1058,15 +1462,20 @@ export class TaskCalendarSyncService {
 
 			const eventId = task.googleCalendarEventId;
 			if (deleteEvents) {
-				try {
-					await this.withGoogleRateLimit(() =>
-						this.googleCalendarService.deleteEvent(
-							settings.targetCalendarId,
-							eventId
-						)
-					);
-				} catch (error) {
-					console.warn(`[TaskCalendarSync] Failed to delete event for ${task.path}:`, error);
+				const targetCalendarId = settings.targetCalendarId;
+				if (!targetCalendarId) {
+					console.warn(`[TaskCalendarSync] Cannot delete event without target calendar for ${task.path}`);
+					continue;
+				}
+
+				const deleted = await this.deleteOrQueueCalendarEvent(
+					task.path,
+					targetCalendarId,
+					eventId
+				);
+				if (!deleted) {
+					console.warn(`[TaskCalendarSync] Event deletion queued; keeping link for ${task.path}`);
+					continue;
 				}
 			}
 

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -750,6 +750,13 @@ export class TaskCalendarSyncService {
 			.trim();
 	}
 
+	private getCalendarEventTitle(task: TaskInfo): string {
+		const title = this.applyTitleTemplate(task);
+		return this.plugin.statusManager.isCompletedStatus(task.status)
+			? `✓ ${title}`
+			: title;
+	}
+
 	/**
 	 * Build the event description from task properties
 	 */
@@ -1080,7 +1087,7 @@ export class TaskCalendarSyncService {
 		const end = this.getEventEnd(adjustedStartInfo, task);
 
 		const event: CalendarEventPayload = {
-			summary: this.applyTitleTemplate(task),
+			summary: this.getCalendarEventTitle(task),
 			start,
 			end,
 		};
@@ -1468,7 +1475,6 @@ export class TaskCalendarSyncService {
 
 		try {
 			// Update the event title to indicate completion
-			const completedTitle = `✓ ${this.applyTitleTemplate(task)}`;
 			const description = settings.includeDescription
 				? this.buildEventDescription(task)
 				: undefined;
@@ -1478,7 +1484,7 @@ export class TaskCalendarSyncService {
 					settings.targetCalendarId,
 					existingEventId,
 					{
-						summary: completedTitle,
+						summary: this.getCalendarEventTitle(task),
 						description,
 					}
 				)

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -1234,7 +1234,7 @@ export class TaskService {
 			}
 
 			// Delete from Google Calendar first (before file deletion, so we have the event ID)
-			if (this.plugin.taskCalendarSyncService?.isEnabled() && task.googleCalendarEventId) {
+			if (this.plugin.taskCalendarSyncService && task.googleCalendarEventId) {
 				try {
 					await this.plugin.taskCalendarSyncService
 						.deleteTaskFromCalendarByPath(task.path, task.googleCalendarEventId);

--- a/src/services/task-service/TaskCreationService.ts
+++ b/src/services/task-service/TaskCreationService.ts
@@ -1,4 +1,4 @@
-import { Notice, TFile, normalizePath, stringifyYaml } from "obsidian";
+import { TFile, stringifyYaml } from "obsidian";
 import {
 	EVENT_TASK_UPDATED,
 	IWebhookNotifier,
@@ -219,7 +219,7 @@ export class TaskCreationService {
 			}
 
 			if (
-				plugin.taskCalendarSyncService?.isEnabled() &&
+				plugin.taskCalendarSyncService &&
 				plugin.settings.googleCalendarExport.syncOnTaskCreate
 			) {
 				plugin.taskCalendarSyncService.syncTaskToCalendar(taskInfo).catch((error) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -847,6 +847,23 @@ export interface PendingAutoArchive {
 	statusValue: string;
 }
 
+export interface PendingGoogleCalendarDeletion {
+	taskPath: string;
+	calendarId: string;
+	eventId: string;
+	createdAt: number;
+	attempts: number;
+	lastAttemptAt?: number;
+	lastError?: string;
+}
+
+export interface GoogleCalendarEventIndexEntry {
+	taskPath: string;
+	calendarId: string;
+	eventId: string;
+	updatedAt: number;
+}
+
 // Webhook notification interface for loose coupling
 export interface IWebhookNotifier {
 	triggerWebhook(event: WebhookEvent, data: any): Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -864,6 +864,14 @@ export interface GoogleCalendarEventIndexEntry {
 	updatedAt: number;
 }
 
+export interface PendingGoogleCalendarSync {
+	taskPath: string;
+	requestedAt: number;
+	attempts: number;
+	lastAttemptAt?: number;
+	lastError?: string;
+}
+
 // Webhook notification interface for loose coupling
 export interface IWebhookNotifier {
 	triggerWebhook(event: WebhookEvent, data: any): Promise<void>;

--- a/tests/services/GoogleCalendarService.test.ts
+++ b/tests/services/GoogleCalendarService.test.ts
@@ -422,6 +422,47 @@ describe('GoogleCalendarService', () => {
 			);
 		});
 
+		test('should restore cancelled events when updating existing event IDs', async () => {
+			mockRequestUrl.mockResolvedValueOnce({
+				status: 200,
+				json: {
+					id: 'event1',
+					status: 'cancelled',
+					summary: 'Deleted Task',
+					start: { date: '2026-04-29' },
+					end: { date: '2026-04-30' }
+				},
+				text: '',
+				arrayBuffer: new ArrayBuffer(0),
+				headers: {}
+			});
+
+			mockRequestUrl.mockResolvedValueOnce({
+				status: 200,
+				json: {
+					id: 'event1',
+					status: 'confirmed',
+					summary: 'Restored Task',
+					start: { date: '2026-04-29' },
+					end: { date: '2026-04-30' },
+					htmlLink: 'https://calendar.google.com/event'
+				},
+				text: '',
+				arrayBuffer: new ArrayBuffer(0),
+				headers: {}
+			});
+
+			await service.updateEvent('primary', 'event1', {
+				summary: 'Restored Task',
+				start: { date: '2026-04-29' },
+				end: { date: '2026-04-30' }
+			});
+
+			const requestBody = JSON.parse(mockRequestUrl.mock.calls[1][0].body as string);
+			expect(requestBody.status).toBe('confirmed');
+			expect(requestBody.summary).toBe('Restored Task');
+		});
+
 		test('should handle converting timed event to all-day', async () => {
 			const updates = {
 				start: '2025-10-23',

--- a/tests/services/TaskCalendarSyncService.test.ts
+++ b/tests/services/TaskCalendarSyncService.test.ts
@@ -14,16 +14,21 @@ describe("TaskCalendarSyncService", () => {
                 googleCalendarExport: {
                     syncOnTaskUpdate: true,
                     syncOnTaskComplete: true,
+                    enabled: true,
                     targetCalendarId: "test-calendar",
                     eventTitleTemplate: "{{title}}",
                     includeDescription: false,
+                    syncTrigger: "scheduled",
+                    createAsAllDay: true,
+                    defaultEventDuration: 60,
                 }
             },
             cacheManager: {
                 getTaskInfo: jest.fn()
             },
             statusManager: {
-                getStatusConfig: jest.fn().mockReturnValue({ label: "Todo" })
+                getStatusConfig: jest.fn().mockReturnValue({ label: "Todo" }),
+                isCompletedStatus: jest.fn((status?: string) => status === "done")
             },
             priorityManager: {
                 getPriorityConfig: jest.fn().mockReturnValue({ label: "High" })
@@ -34,6 +39,7 @@ describe("TaskCalendarSyncService", () => {
         };
 
         mockGoogleCalendarService = {
+            getAvailableCalendars: jest.fn().mockReturnValue([{ id: "test-calendar" }]),
             updateEvent: jest.fn().mockResolvedValue({}),
             createEvent: jest.fn().mockResolvedValue({ id: "test-id" })
         };
@@ -114,6 +120,22 @@ describe("TaskCalendarSyncService", () => {
                 summary: "✓ Task Title",
                 description: undefined
             }
+        );
+    });
+
+    it("should mark already-completed tasks when a later schedule change creates a calendar event", () => {
+        const event = syncService.taskToCalendarEvent({
+            path: "test/path.md",
+            title: "Task Title",
+            status: "done",
+            scheduled: "2026-04-29"
+        } as TaskInfo);
+
+        expect(event).toEqual(
+            expect.objectContaining({
+                summary: "✓ Task Title",
+                start: { date: "2026-04-29" }
+            })
         );
     });
 });

--- a/tests/services/TaskCalendarSyncService.test.ts
+++ b/tests/services/TaskCalendarSyncService.test.ts
@@ -13,7 +13,10 @@ describe("TaskCalendarSyncService", () => {
             settings: {
                 googleCalendarExport: {
                     syncOnTaskUpdate: true,
+                    syncOnTaskComplete: true,
                     targetCalendarId: "test-calendar",
+                    eventTitleTemplate: "{{title}}",
+                    includeDescription: false,
                 }
             },
             cacheManager: {
@@ -77,5 +80,40 @@ describe("TaskCalendarSyncService", () => {
         // Assert: It should execute only once, and pass the explicit secondPayload, not the stale cache!
         expect(syncService.executeTaskUpdate).toHaveBeenCalledTimes(1);
         expect(syncService.executeTaskUpdate).toHaveBeenCalledWith(secondPayload);
+    });
+
+    it("should cancel a pending status update before syncing completion", async () => {
+        syncService.withGoogleRateLimit = (fn: () => Promise<unknown>) => fn();
+
+        const taskPath = "test/path.md";
+        const somedayPayload: TaskInfo = {
+            path: taskPath,
+            title: "Task Title",
+            status: "someday",
+            scheduled: "2026-04-29",
+            googleCalendarEventId: "event-1"
+        };
+        const donePayload: TaskInfo = {
+            ...somedayPayload,
+            status: "done"
+        };
+
+        syncService.updateTaskInCalendar(somedayPayload);
+        await syncService.completeTaskInCalendar(donePayload);
+
+        jest.advanceTimersByTime(500);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(syncService.executeTaskUpdate).not.toHaveBeenCalled();
+        expect(mockGoogleCalendarService.updateEvent).toHaveBeenCalledTimes(1);
+        expect(mockGoogleCalendarService.updateEvent).toHaveBeenCalledWith(
+            "test-calendar",
+            "event-1",
+            {
+                summary: "✓ Task Title",
+                description: undefined
+            }
+        );
     });
 });

--- a/tests/unit/issues/issue-google-calendar-archive-reliability.test.ts
+++ b/tests/unit/issues/issue-google-calendar-archive-reliability.test.ts
@@ -31,6 +31,7 @@ const createGoogleCleanupEnabledPlugin = () =>
 describe("Google Calendar archive reliability", () => {
 	it("preserves the Google Calendar event ID when deletion fails so cleanup can be retried", async () => {
 		const frontmatter: Record<string, any> = {};
+		const pluginData: Record<string, any> = {};
 		const plugin: any = {
 			settings: {
 				googleCalendarExport: {
@@ -83,6 +84,14 @@ describe("Google Calendar archive reliability", () => {
 				getTaskInfo: jest.fn().mockResolvedValue(null),
 				getAllTasks: jest.fn().mockResolvedValue([]),
 			},
+			loadData: jest.fn().mockImplementation(async () => pluginData),
+			saveData: jest.fn().mockImplementation(async (data: Record<string, any>) => {
+				const nextData = { ...data };
+				for (const key of Object.keys(pluginData)) {
+					delete pluginData[key];
+				}
+				Object.assign(pluginData, nextData);
+			}),
 		};
 		const googleCalendarService = {
 			getAvailableCalendars: jest.fn().mockReturnValue([{ id: "primary", name: "Primary" }]),
@@ -105,6 +114,13 @@ describe("Google Calendar archive reliability", () => {
 
 		expect(deleted).toBe(false);
 		expect(frontmatter.googleCalendarEventId).toBe("master-event-id");
+		expect(pluginData.googleCalendarDeletionQueue).toEqual([
+			expect.objectContaining({
+				calendarId: "primary",
+				eventId: "master-event-id",
+				taskPath: "TaskNotes/Tasks/archive-me.md",
+			}),
+		]);
 	});
 
 	it("keeps an auto-archive queue item pending when Google cleanup is still incomplete after archiving", async () => {

--- a/tests/unit/issues/issue-google-calendar-delete-retry-queue.test.ts
+++ b/tests/unit/issues/issue-google-calendar-delete-retry-queue.test.ts
@@ -48,6 +48,14 @@ const createPlugin = (pluginData: Record<string, any> = {}, calendarSettings = {
 		}
 		Object.assign(pluginData, nextData);
 	});
+	plugin.statusManager = {
+		...plugin.statusManager,
+		getStatusConfig: jest.fn().mockReturnValue(null),
+	};
+	plugin.priorityManager = {
+		...plugin.priorityManager,
+		getPriorityConfig: jest.fn().mockReturnValue(null),
+	};
 
 	return plugin;
 };
@@ -328,5 +336,181 @@ describe("Google Calendar deletion retry queue", () => {
 				eventId: "active-event",
 			}),
 		]);
+	});
+
+	it("queues scheduled task sync when Google Calendar is not connected", async () => {
+		const pluginData: Record<string, any> = {};
+		const plugin = createPlugin(pluginData);
+		const googleCalendarService = createGoogleCalendarService({
+			getAvailableCalendars: jest.fn().mockReturnValue([]),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const synced = await syncService.syncTaskToCalendar(
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/offline-scheduled.md",
+				scheduled: "2026-04-29",
+			})
+		);
+
+		expect(synced).toBe(false);
+		expect(googleCalendarService.createEvent).not.toHaveBeenCalled();
+		expect(pluginData.googleCalendarSyncQueue).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/offline-scheduled.md",
+				attempts: 0,
+				lastError: "Google Calendar sync is not ready",
+			}),
+		]);
+	});
+
+	it("queues due-date task sync when the calendar trigger is configured for due dates", async () => {
+		const pluginData: Record<string, any> = {};
+		const plugin = createPlugin(pluginData, { syncTrigger: "due" });
+		const googleCalendarService = createGoogleCalendarService({
+			getAvailableCalendars: jest.fn().mockReturnValue([]),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const synced = await syncService.syncTaskToCalendar(
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/offline-due.md",
+				due: "2026-04-30",
+			})
+		);
+
+		expect(synced).toBe(false);
+		expect(pluginData.googleCalendarSyncQueue).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/offline-due.md",
+			}),
+		]);
+	});
+
+	it("queues task sync when the calendar trigger is configured for scheduled or due dates", async () => {
+		const pluginData: Record<string, any> = {};
+		const plugin = createPlugin(pluginData, { syncTrigger: "both" });
+		const googleCalendarService = createGoogleCalendarService({
+			getAvailableCalendars: jest.fn().mockReturnValue([]),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const synced = await syncService.syncTaskToCalendar(
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/offline-both.md",
+				due: "2026-05-01",
+			})
+		);
+
+		expect(synced).toBe(false);
+		expect(pluginData.googleCalendarSyncQueue).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/offline-both.md",
+			}),
+		]);
+	});
+
+	it("replays queued task sync by creating the current task event after reconnect", async () => {
+		const pluginData = {
+			googleCalendarSyncQueue: [
+				{
+					taskPath: "TaskNotes/Tasks/replay-create.md",
+					requestedAt: 1,
+					attempts: 0,
+					lastError: "Google Calendar sync is not ready",
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		plugin.cacheManager.getTaskInfo = jest.fn().mockResolvedValue(
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/replay-create.md",
+				scheduled: "2026-04-29",
+			})
+		);
+		const googleCalendarService = createGoogleCalendarService({
+			createEvent: jest.fn().mockResolvedValue({ id: "google-primary-created-event-id" }),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const result = await syncService.processPendingSyncQueue();
+
+		expect(result).toEqual({ synced: 1, failed: 0, deleted: 0, dropped: 0, remaining: 0 });
+		expect(googleCalendarService.createEvent).toHaveBeenCalledWith(
+			"primary",
+			expect.objectContaining({
+				start: { date: "2026-04-29" },
+			})
+		);
+		expect(pluginData.googleCalendarSyncQueue).toEqual([]);
+		expect(pluginData.googleCalendarEventIndex).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/replay-create.md",
+				calendarId: "primary",
+				eventId: "created-event-id",
+			}),
+		]);
+	});
+
+	it("replays queued task sync by updating the current task event after reconnect", async () => {
+		const pluginData = {
+			googleCalendarSyncQueue: [
+				{
+					taskPath: "TaskNotes/Tasks/replay-update.md",
+					requestedAt: 1,
+					attempts: 0,
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		plugin.cacheManager.getTaskInfo = jest.fn().mockResolvedValue(
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/replay-update.md",
+				scheduled: "2026-05-02",
+				googleCalendarEventId: "existing-event-id",
+			})
+		);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const result = await syncService.processPendingSyncQueue();
+
+		expect(result).toEqual({ synced: 1, failed: 0, deleted: 0, dropped: 0, remaining: 0 });
+		expect(googleCalendarService.updateEvent).toHaveBeenCalledWith(
+			"primary",
+			"existing-event-id",
+			expect.objectContaining({
+				start: { date: "2026-05-02" },
+			})
+		);
+		expect(pluginData.googleCalendarSyncQueue).toEqual([]);
+	});
+
+	it("replays queued task sync by deleting the event when the task no longer has the configured date", async () => {
+		const pluginData = {
+			googleCalendarSyncQueue: [
+				{
+					taskPath: "TaskNotes/Tasks/replay-delete.md",
+					requestedAt: 1,
+					attempts: 0,
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		plugin.cacheManager.getTaskInfo = jest.fn().mockResolvedValue(
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/replay-delete.md",
+				scheduled: undefined,
+				googleCalendarEventId: "event-to-delete",
+			})
+		);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const result = await syncService.processPendingSyncQueue();
+
+		expect(result).toEqual({ synced: 0, failed: 0, deleted: 1, dropped: 0, remaining: 0 });
+		expect(googleCalendarService.deleteEvent).toHaveBeenCalledWith("primary", "event-to-delete");
+		expect(pluginData.googleCalendarSyncQueue).toEqual([]);
 	});
 });

--- a/tests/unit/issues/issue-google-calendar-delete-retry-queue.test.ts
+++ b/tests/unit/issues/issue-google-calendar-delete-retry-queue.test.ts
@@ -292,6 +292,42 @@ describe("Google Calendar deletion retry queue", () => {
 		expect(googleCalendarService.deleteEvent).not.toHaveBeenCalled();
 	});
 
+	it("cleans up an older indexed event when the same task receives a replacement event id", async () => {
+		const pluginData = {
+			googleCalendarEventIndex: [
+				{
+					taskPath: "TaskNotes/Tasks/status-race.md",
+					calendarId: "primary",
+					eventId: "old-event",
+					updatedAt: 1,
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		const googleCalendarService = createGoogleCalendarService({
+			createEvent: jest.fn().mockResolvedValue({ id: "google-primary-new-event" }),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const synced = await syncService.syncTaskToCalendar(
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/status-race.md",
+				scheduled: "2026-04-29",
+			})
+		);
+
+		expect(synced).toBe(true);
+		expect(googleCalendarService.deleteEvent).toHaveBeenCalledWith("primary", "old-event");
+		expect(pluginData.googleCalendarDeletionQueue).toBeUndefined();
+		expect(pluginData.googleCalendarEventIndex).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/status-race.md",
+				calendarId: "primary",
+				eventId: "new-event",
+			}),
+		]);
+	});
+
 	it("drops queued cleanup without deleting Google events when the task still exists and remains calendar-eligible", async () => {
 		const pluginData = {
 			googleCalendarDeletionQueue: [

--- a/tests/unit/issues/issue-google-calendar-delete-retry-queue.test.ts
+++ b/tests/unit/issues/issue-google-calendar-delete-retry-queue.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, jest } from "@jest/globals";
+
+import { TaskCalendarSyncService } from "../../../src/services/TaskCalendarSyncService";
+import { EventNotFoundError } from "../../../src/services/errors";
+import { PluginFactory, TaskFactory } from "../../helpers/mock-factories";
+
+jest.mock("obsidian", () => ({
+	Notice: jest.fn(),
+	TFile: class MockTFile {
+		path: string;
+
+		constructor(path = "") {
+			this.path = path;
+		}
+	},
+}));
+
+const createPlugin = (pluginData: Record<string, any> = {}, calendarSettings = {}) => {
+	const basePlugin = PluginFactory.createMockPlugin();
+	const plugin = PluginFactory.createMockPlugin({
+		settings: {
+			...basePlugin.settings,
+			googleCalendarExport: {
+				enabled: true,
+				targetCalendarId: "primary",
+				syncOnTaskCreate: true,
+				syncOnTaskUpdate: true,
+				syncOnTaskComplete: true,
+				syncOnTaskDelete: true,
+				eventTitleTemplate: "{{title}}",
+				includeDescription: false,
+				eventColorId: null,
+				syncTrigger: "scheduled",
+				createAsAllDay: true,
+				defaultEventDuration: 60,
+				includeObsidianLink: false,
+				defaultReminderMinutes: null,
+				...calendarSettings,
+			},
+		},
+	});
+
+	plugin.loadData = jest.fn().mockImplementation(async () => pluginData);
+	plugin.saveData = jest.fn().mockImplementation(async (data: Record<string, any>) => {
+		const nextData = { ...data };
+		for (const key of Object.keys(pluginData)) {
+			delete pluginData[key];
+		}
+		Object.assign(pluginData, nextData);
+	});
+
+	return plugin;
+};
+
+const createGoogleCalendarService = (overrides: Record<string, any> = {}) => ({
+	getAvailableCalendars: jest.fn().mockReturnValue([{ id: "primary", name: "Primary" }]),
+	createEvent: jest.fn(),
+	updateEvent: jest.fn(),
+	deleteEvent: jest.fn().mockResolvedValue(undefined),
+	...overrides,
+});
+
+describe("Google Calendar deletion retry queue", () => {
+	it("persists failed task-file deletion cleanup so it survives plugin restarts", async () => {
+		const pluginData: Record<string, any> = {};
+		const plugin = createPlugin(pluginData);
+		const deleteError = Object.assign(new Error("temporary Google failure"), { status: 500 });
+		const googleCalendarService = createGoogleCalendarService({
+			deleteEvent: jest.fn().mockRejectedValue(deleteError),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const deleted = await syncService.deleteTaskFromCalendarByPath(
+			"TaskNotes/Tasks/delete-me.md",
+			"primary-event-id"
+		);
+
+		expect(deleted).toBe(false);
+		expect(pluginData.googleCalendarDeletionQueue).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/delete-me.md",
+				calendarId: "primary",
+				eventId: "primary-event-id",
+				attempts: 1,
+				lastError: "temporary Google failure",
+			}),
+		]);
+	});
+
+	it("dedupes queued cleanup by calendar and event id while preserving retry metadata", async () => {
+		const pluginData: Record<string, any> = {};
+		const plugin = createPlugin(pluginData);
+		const googleCalendarService = createGoogleCalendarService({
+			deleteEvent: jest
+				.fn()
+				.mockRejectedValueOnce(Object.assign(new Error("first failure"), { status: 500 }))
+				.mockRejectedValueOnce(Object.assign(new Error("second failure"), { status: 500 })),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		await syncService.deleteTaskFromCalendarByPath("TaskNotes/Tasks/a.md", "event-1");
+		await syncService.deleteTaskFromCalendarByPath("TaskNotes/Tasks/a.md", "event-1");
+
+		expect(pluginData.googleCalendarDeletionQueue).toHaveLength(1);
+		expect(pluginData.googleCalendarDeletionQueue[0]).toEqual(
+			expect.objectContaining({
+				calendarId: "primary",
+				eventId: "event-1",
+				attempts: 2,
+				lastError: "second failure",
+			})
+		);
+	});
+
+	it("retries persisted cleanup and clears the queue after a later successful deletion", async () => {
+		const pluginData = {
+			googleCalendarDeletionQueue: [
+				{
+					taskPath: "TaskNotes/Tasks/delete-me.md",
+					calendarId: "primary",
+					eventId: "event-1",
+					createdAt: 1,
+					attempts: 1,
+					lastAttemptAt: 1,
+					lastError: "temporary Google failure",
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const result = await syncService.processDeletionQueue();
+
+		expect(result).toEqual({ deleted: 1, failed: 0, remaining: 0 });
+		expect(googleCalendarService.deleteEvent).toHaveBeenCalledWith("primary", "event-1");
+		expect(pluginData.googleCalendarDeletionQueue).toEqual([]);
+	});
+
+	it("treats already-deleted Google events as successful cleanup", async () => {
+		const pluginData = {
+			googleCalendarDeletionQueue: [
+				{
+					taskPath: "TaskNotes/Tasks/delete-me.md",
+					calendarId: "primary",
+					eventId: "missing-event",
+					createdAt: 1,
+					attempts: 1,
+					lastAttemptAt: 1,
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		const googleCalendarService = createGoogleCalendarService({
+			deleteEvent: jest.fn().mockRejectedValue(new EventNotFoundError("missing-event")),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const result = await syncService.processDeletionQueue();
+
+		expect(result).toEqual({ deleted: 1, failed: 0, remaining: 0 });
+		expect(pluginData.googleCalendarDeletionQueue).toEqual([]);
+	});
+
+	it("queues deletion from a previous frontmatter event id when sync is not ready", async () => {
+		const pluginData: Record<string, any> = {};
+		const plugin = createPlugin(pluginData);
+		const googleCalendarService = createGoogleCalendarService({
+			getAvailableCalendars: jest.fn().mockReturnValue([]),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const deleted = await syncService.deleteTaskFromCalendarByPath(
+			"TaskNotes/Tasks/external-delete.md",
+			"event-from-prev-cache"
+		);
+
+		expect(deleted).toBe(false);
+		expect(googleCalendarService.deleteEvent).not.toHaveBeenCalled();
+		expect(pluginData.googleCalendarDeletionQueue).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/external-delete.md",
+				calendarId: "primary",
+				eventId: "event-from-prev-cache",
+				attempts: 0,
+				lastError: "Google Calendar sync is not ready",
+			}),
+		]);
+	});
+
+	it("queues primary and recurring exception event ids together when both are supplied", async () => {
+		const pluginData: Record<string, any> = {};
+		const plugin = createPlugin(pluginData);
+		const googleCalendarService = createGoogleCalendarService({
+			deleteEvent: jest
+				.fn()
+				.mockRejectedValue(Object.assign(new Error("temporary Google failure"), { status: 500 })),
+		});
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const deleted = await syncService.deleteTaskFromCalendarByPath(
+			"TaskNotes/Tasks/recurring.md",
+			"primary-event-id",
+			"exception-event-id"
+		);
+
+		expect(deleted).toBe(false);
+		expect(pluginData.googleCalendarDeletionQueue).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ eventId: "primary-event-id", calendarId: "primary" }),
+				expect.objectContaining({ eventId: "exception-event-id", calendarId: "primary" }),
+			])
+		);
+	});
+
+	it("recovers cleanup for indexed task events whose files were deleted while Obsidian was closed", async () => {
+		const pluginData = {
+			googleCalendarEventIndex: [
+				{
+					taskPath: "TaskNotes/Tasks/deleted-while-closed.md",
+					calendarId: "primary",
+					eventId: "event-from-index",
+					updatedAt: 1,
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		plugin.cacheManager.getAllTasks = jest.fn().mockResolvedValue([]);
+		plugin.cacheManager.getTaskInfo = jest.fn().mockResolvedValue(null);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		await syncService.recoverDeletedTaskEventsFromIndex();
+
+		expect(pluginData.googleCalendarDeletionQueue).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/deleted-while-closed.md",
+				calendarId: "primary",
+				eventId: "event-from-index",
+				lastError: "Indexed task file no longer exists",
+			}),
+		]);
+
+		const result = await syncService.processDeletionQueue();
+
+		expect(result).toEqual({ deleted: 1, failed: 0, remaining: 0 });
+		expect(googleCalendarService.deleteEvent).toHaveBeenCalledWith("primary", "event-from-index");
+		expect(pluginData.googleCalendarDeletionQueue).toEqual([]);
+		expect(pluginData.googleCalendarEventIndex).toEqual([]);
+	});
+
+	it("updates the event index instead of deleting events when an indexed task moved while Obsidian was closed", async () => {
+		const pluginData = {
+			googleCalendarEventIndex: [
+				{
+					taskPath: "TaskNotes/Tasks/old-path.md",
+					calendarId: "primary",
+					eventId: "moved-event",
+					updatedAt: 1,
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		plugin.cacheManager.getAllTasks = jest.fn().mockResolvedValue([
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/new-path.md",
+				scheduled: "2026-04-29",
+				googleCalendarEventId: "moved-event",
+			}),
+		]);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		await syncService.recoverDeletedTaskEventsFromIndex();
+
+		expect(pluginData.googleCalendarDeletionQueue).toBeUndefined();
+		expect(pluginData.googleCalendarEventIndex).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/new-path.md",
+				calendarId: "primary",
+				eventId: "moved-event",
+			}),
+		]);
+		expect(googleCalendarService.deleteEvent).not.toHaveBeenCalled();
+	});
+
+	it("drops queued cleanup without deleting Google events when the task still exists and remains calendar-eligible", async () => {
+		const pluginData = {
+			googleCalendarDeletionQueue: [
+				{
+					taskPath: "TaskNotes/Tasks/still-active.md",
+					calendarId: "primary",
+					eventId: "active-event",
+					createdAt: 1,
+					attempts: 1,
+					lastAttemptAt: 1,
+					lastError: "previous delete failure",
+				},
+			],
+			googleCalendarEventIndex: [
+				{
+					taskPath: "TaskNotes/Tasks/still-active.md",
+					calendarId: "primary",
+					eventId: "active-event",
+					updatedAt: 1,
+				},
+			],
+		};
+		const plugin = createPlugin(pluginData);
+		plugin.cacheManager.getTaskInfo = jest.fn().mockResolvedValue(
+			TaskFactory.createTask({
+				path: "TaskNotes/Tasks/still-active.md",
+				scheduled: "2026-04-29",
+				googleCalendarEventId: "active-event",
+			})
+		);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		const result = await syncService.processDeletionQueue();
+
+		expect(result).toEqual({ deleted: 0, failed: 0, remaining: 0 });
+		expect(googleCalendarService.deleteEvent).not.toHaveBeenCalled();
+		expect(pluginData.googleCalendarDeletionQueue).toEqual([]);
+		expect(pluginData.googleCalendarEventIndex).toEqual([
+			expect.objectContaining({
+				taskPath: "TaskNotes/Tasks/still-active.md",
+				eventId: "active-event",
+			}),
+		]);
+	});
+});

--- a/tests/unit/issues/issue-google-calendar-duplicate-investigation.test.ts
+++ b/tests/unit/issues/issue-google-calendar-duplicate-investigation.test.ts
@@ -55,6 +55,7 @@ const createPlugin = (frontmatter: Record<string, any>) => ({
 	},
 	statusManager: {
 		getStatusConfig: jest.fn().mockReturnValue(null),
+		isCompletedStatus: jest.fn((status?: string) => status === "done"),
 	},
 	i18n: {
 		translate: jest.fn((key: string) => key),

--- a/tests/unit/issues/issue-google-calendar-duplicate-investigation.test.ts
+++ b/tests/unit/issues/issue-google-calendar-duplicate-investigation.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { TFile } from "obsidian";
+
+import { TaskCalendarSyncService } from "../../../src/services/TaskCalendarSyncService";
+import { TaskInfo } from "../../../src/types";
+
+jest.mock("obsidian", () => ({
+	Notice: jest.fn(),
+	TFile: class MockTFile {
+		path: string;
+
+		constructor(path = "") {
+			this.path = path;
+		}
+	},
+}));
+
+const createPlugin = (frontmatter: Record<string, any>) => ({
+	settings: {
+		googleCalendarExport: {
+			enabled: true,
+			targetCalendarId: "primary",
+			syncOnTaskCreate: true,
+			syncOnTaskUpdate: true,
+			syncOnTaskComplete: true,
+			syncOnTaskDelete: true,
+			eventTitleTemplate: "{{title}}",
+			includeDescription: false,
+			eventColorId: null,
+			syncTrigger: "scheduled",
+			createAsAllDay: true,
+			defaultEventDuration: 60,
+			includeObsidianLink: false,
+			defaultReminderMinutes: null,
+		},
+	},
+	app: {
+		vault: {
+			getAbstractFileByPath: jest.fn().mockImplementation((path: string) => new TFile(path)),
+			getName: jest.fn().mockReturnValue("MyVault"),
+		},
+		fileManager: {
+			processFrontMatter: jest
+				.fn()
+				.mockImplementation(async (_file: TFile, fn: (fm: Record<string, any>) => void) => {
+					fn(frontmatter);
+				}),
+		},
+	},
+	fieldMapper: {
+		toUserField: jest.fn((field: string) => field),
+	},
+	priorityManager: {
+		getPriorityConfig: jest.fn().mockReturnValue(null),
+	},
+	statusManager: {
+		getStatusConfig: jest.fn().mockReturnValue(null),
+	},
+	i18n: {
+		translate: jest.fn((key: string) => key),
+	},
+	cacheManager: {
+		getTaskInfo: jest.fn().mockResolvedValue(null),
+		getAllTasks: jest.fn().mockResolvedValue([]),
+	},
+	loadData: jest.fn().mockResolvedValue({}),
+	saveData: jest.fn().mockResolvedValue(undefined),
+});
+
+describe("Google Calendar duplicate investigation", () => {
+	it("does not create duplicate events when two syncs race before the event id reaches task metadata", async () => {
+		const frontmatter: Record<string, any> = {};
+		const plugin = createPlugin(frontmatter);
+		const googleCalendarService = {
+			getAvailableCalendars: jest.fn().mockReturnValue([{ id: "primary", name: "Primary" }]),
+			createEvent: jest
+				.fn()
+				.mockResolvedValue({ id: "google-primary-created-event-id" }),
+			updateEvent: jest.fn().mockResolvedValue(undefined),
+			deleteEvent: jest.fn().mockResolvedValue(undefined),
+		};
+		const syncService = new TaskCalendarSyncService(plugin as any, googleCalendarService as any);
+		const task: TaskInfo = {
+			path: "TaskNotes/Tasks/race.md",
+			title: "Race",
+			status: "open",
+			priority: "normal",
+			scheduled: "2026-04-29",
+			archived: false,
+		};
+
+		await Promise.all([
+			syncService.syncTaskToCalendar(task),
+			syncService.syncTaskToCalendar(task),
+		]);
+
+		expect(googleCalendarService.createEvent).toHaveBeenCalledTimes(1);
+		expect(frontmatter.googleCalendarEventId).toBe("created-event-id");
+	});
+
+	it("updates the newly created event when a follow-up sync still has stale task metadata", async () => {
+		const frontmatter: Record<string, any> = {};
+		const plugin = createPlugin(frontmatter);
+		const googleCalendarService = {
+			getAvailableCalendars: jest.fn().mockReturnValue([{ id: "primary", name: "Primary" }]),
+			createEvent: jest
+				.fn()
+				.mockResolvedValue({ id: "google-primary-created-event-id" }),
+			updateEvent: jest.fn().mockResolvedValue(undefined),
+			deleteEvent: jest.fn().mockResolvedValue(undefined),
+		};
+		const syncService = new TaskCalendarSyncService(plugin as any, googleCalendarService as any);
+		const task: TaskInfo = {
+			path: "TaskNotes/Tasks/stale.md",
+			title: "Stale",
+			status: "open",
+			priority: "normal",
+			scheduled: "2026-04-29",
+			archived: false,
+		};
+
+		await syncService.syncTaskToCalendar(task);
+		await syncService.syncTaskToCalendar({
+			...task,
+			scheduled: "2026-04-30",
+		});
+
+		expect(googleCalendarService.createEvent).toHaveBeenCalledTimes(1);
+		expect(googleCalendarService.updateEvent).toHaveBeenCalledWith(
+			"primary",
+			"created-event-id",
+			expect.objectContaining({
+				start: { date: "2026-04-30" },
+			})
+		);
+	});
+
+	it("uses the existing event id when rescheduling a task that already has Google metadata", async () => {
+		const frontmatter: Record<string, any> = {};
+		const plugin = createPlugin(frontmatter);
+		const googleCalendarService = {
+			getAvailableCalendars: jest.fn().mockReturnValue([{ id: "primary", name: "Primary" }]),
+			createEvent: jest.fn().mockResolvedValue({ id: "google-primary-new-event-id" }),
+			updateEvent: jest.fn().mockResolvedValue(undefined),
+			deleteEvent: jest.fn().mockResolvedValue(undefined),
+		};
+		const syncService = new TaskCalendarSyncService(plugin as any, googleCalendarService as any);
+
+		await syncService.syncTaskToCalendar({
+			path: "TaskNotes/Tasks/reschedule.md",
+			title: "Reschedule",
+			status: "open",
+			priority: "normal",
+			scheduled: "2026-04-30",
+			archived: false,
+			googleCalendarEventId: "existing-event-id",
+		});
+
+		expect(googleCalendarService.createEvent).not.toHaveBeenCalled();
+		expect(googleCalendarService.updateEvent).toHaveBeenCalledWith(
+			"primary",
+			"existing-event-id",
+			expect.objectContaining({
+				start: { date: "2026-04-30" },
+			})
+		);
+	});
+
+	it("does not leave a failed create in flight and allows a later retry", async () => {
+		const frontmatter: Record<string, any> = {};
+		const plugin = createPlugin(frontmatter);
+		const googleCalendarService = {
+			getAvailableCalendars: jest.fn().mockReturnValue([{ id: "primary", name: "Primary" }]),
+			createEvent: jest
+				.fn()
+				.mockRejectedValueOnce(new Error("create failed"))
+				.mockResolvedValueOnce({ id: "google-primary-created-event-id" }),
+			updateEvent: jest.fn().mockResolvedValue(undefined),
+			deleteEvent: jest.fn().mockResolvedValue(undefined),
+		};
+		const syncService = new TaskCalendarSyncService(plugin as any, googleCalendarService as any);
+		const task: TaskInfo = {
+			path: "TaskNotes/Tasks/retry.md",
+			title: "Retry",
+			status: "open",
+			priority: "normal",
+			scheduled: "2026-04-29",
+			archived: false,
+		};
+
+		await syncService.syncTaskToCalendar(task);
+		await syncService.syncTaskToCalendar(task);
+
+		expect(googleCalendarService.createEvent).toHaveBeenCalledTimes(2);
+		expect(frontmatter.googleCalendarEventId).toBe("created-event-id");
+	});
+});


### PR DESCRIPTION
## Maintainer note
Ready to merge. This is the highest-priority active Google Calendar data-integrity fix. It is distinct from #1802, but both PRs touch cleanup paths. If #1802 lands first, this PR should be rebased so the persisted deletion/index recovery also covers #1802's detached exception event IDs. If this lands first, #1802 should be rebased so detached exception cleanup routes through this retry-safe delete path. #1832 and #1844 are independent except for routine rebase conflicts.

## Summary

This PR hardens TaskNotes Google Calendar task sync around the failure modes that can orphan, miss, hide, stale, or duplicate calendar events:

- persist failed Google Calendar task-event deletions in plugin data and retry them after restart/reconnect
- keep a persisted exported-event index so startup can queue cleanup for task files deleted while Obsidian was closed
- persist pending task sync requests while Google Calendar is not ready, then replay the current task state after reconnect
- preserve the existing calendar date model: `scheduled`, `due`, or `both`, using the configured `syncTrigger`
- route UI, batch, API/MCP/TaskService, archive/unlink, and metadata-delete cleanup through the retry-safe delete path
- treat 404/410 deletes as successful cleanup and dedupe queued work by calendar/event id
- restore deleted-but-addressable Google event tombstones (`status: cancelled`) when syncing an existing event ID
- prevent duplicate Google events when concurrent syncs race before the newly created event ID reaches Obsidian metadata
- clean up an older indexed event when a task receives a replacement event id
- prevent pending intermediate status updates from overwriting the final completed-event state when users quickly cycle a task to done
- mark Google Calendar events as completed whenever the synced task is already complete, including when a completed task is scheduled later

The sync invariant remains simple: tasks belong on Google Calendar based on the existing configured date trigger. This does not add status filtering or completed-task busy/free behavior.

## Root Cause

Deleted task files could lose their `googleCalendarEventId` before Google cleanup succeeded, especially when Google sync was not connected/ready. Task create/update/reschedule work could also be skipped while Google Calendar was unavailable instead of being replayed later. Google can retain deleted events as `status: cancelled` tombstones that still return from direct event lookup but are hidden from ordinary calendar views, so updating an existing event ID needs to restore it to `confirmed`.

There were also status and create/update race paths: direct `syncTaskToCalendar` calls for the same unsynced task could both create a Google event before the frontmatter event ID write became visible through metadata; a debounced intermediate status update could run after a later completion update; and a task that was already complete before it became calendar-eligible could be synced through the ordinary create/update path without the completed title marker.

## Validation

- `npm test -- tests/services/TaskCalendarSyncService.test.ts tests/unit/issues/issue-google-calendar-delete-retry-queue.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build:test`
- `obsidian plugin:reload id=tasknotes vault=test`

