### PR TITLE
Use plain text Google Calendar descriptions

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -23,3 +23,7 @@ Example:
 ```
 
 -->
+
+## Fixed
+
+- Google Calendar task descriptions now use mobile-friendly plain text for Obsidian links and display labels for wiki-style project/context links.

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -266,12 +266,12 @@ export class TaskCalendarSyncService {
 
 		// Add contexts
 		if (task.contexts && task.contexts.length > 0) {
-			parts.push(t("contexts", { value: task.contexts.map((c) => `@${c}`).join(", ") }));
+			parts.push(t("contexts", { value: task.contexts.map((c) => `@${this.toCalendarDescriptionLabel(c)}`).join(", ") }));
 		}
 
 		// Add projects
 		if (task.projects && task.projects.length > 0) {
-			parts.push(t("projects", { value: task.projects.join(", ") }));
+			parts.push(t("projects", { value: task.projects.map((p) => this.toCalendarDescriptionLabel(p)).join(", ") }));
 		}
 
 		// Add separator before link
@@ -285,12 +285,26 @@ export class TaskCalendarSyncService {
 			const vaultName = this.plugin.app.vault.getName();
 			const encodedPath = encodeURIComponent(task.path);
 			const obsidianUri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodedPath}`;
-			// Google Calendar renders HTML in descriptions, so use an anchor tag
 			const linkText = t("openInObsidian");
-			parts.push(`<a href="${obsidianUri}">${linkText}</a>`);
+			parts.push(`${linkText}: ${obsidianUri}`);
 		}
 
 		return parts.join("\n");
+	}
+
+	private toCalendarDescriptionLabel(value: string): string {
+		return value
+			.replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, "$2")
+			.replace(/\[\[([^\]]+)\]\]/g, (_match, target: string) => this.basenameForDisplay(target))
+			.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
+			.trim();
+	}
+
+	private basenameForDisplay(target: string): string {
+		const withoutHeading = target.split("#")[0];
+		const withoutExtension = withoutHeading.replace(/\.md$/i, "");
+		const basename = withoutExtension.split("/").pop();
+		return basename || withoutExtension || target;
 	}
 
 	/**

--- a/tests/services/TaskCalendarSyncService.test.ts
+++ b/tests/services/TaskCalendarSyncService.test.ts
@@ -14,19 +14,38 @@ describe("TaskCalendarSyncService", () => {
                 googleCalendarExport: {
                     syncOnTaskUpdate: true,
                     targetCalendarId: "test-calendar",
+                    includeObsidianLink: true,
                 }
+            },
+            app: {
+                vault: {
+                    getName: jest.fn().mockReturnValue("Martin OS"),
+                },
             },
             cacheManager: {
                 getTaskInfo: jest.fn()
             },
             statusManager: {
-                getStatusConfig: jest.fn().mockReturnValue({ label: "Todo" })
+                getStatusConfig: jest.fn((status: string) => ({ label: status === "ready" ? "Ready" : "Todo" }))
             },
             priorityManager: {
-                getPriorityConfig: jest.fn().mockReturnValue({ label: "High" })
+                getPriorityConfig: jest.fn((priority: string) => ({ label: priority === "2-high" ? "High" : "Medium" }))
             },
             i18n: {
-                translate: jest.fn().mockReturnValue("Untitled Task")
+                translate: jest.fn((key: string, params?: Record<string, string | number>) => {
+                    const translations: Record<string, string> = {
+                        "settings.integrations.googleCalendarExport.eventDescription.untitledTask": "Untitled Task",
+                        "settings.integrations.googleCalendarExport.eventDescription.priority": "Priority: {value}",
+                        "settings.integrations.googleCalendarExport.eventDescription.status": "Status: {value}",
+                        "settings.integrations.googleCalendarExport.eventDescription.scheduled": "Scheduled: {value}",
+                        "settings.integrations.googleCalendarExport.eventDescription.timeEstimate": "Time Estimate: {value}",
+                        "settings.integrations.googleCalendarExport.eventDescription.contexts": "Contexts: {value}",
+                        "settings.integrations.googleCalendarExport.eventDescription.projects": "Projects: {value}",
+                        "settings.integrations.googleCalendarExport.eventDescription.openInObsidian": "Open in Obsidian",
+                    };
+                    const translation = translations[key] || key;
+                    return translation.replace(/\{(\w+)\}/g, (_match, name) => String(params?.[name] ?? ""));
+                })
             }
         };
 
@@ -77,5 +96,39 @@ describe("TaskCalendarSyncService", () => {
         // Assert: It should execute only once, and pass the explicit secondPayload, not the stale cache!
         expect(syncService.executeTaskUpdate).toHaveBeenCalledTimes(1);
         expect(syncService.executeTaskUpdate).toHaveBeenCalledWith(secondPayload);
+    });
+
+    it("should build plain-text calendar descriptions for external calendar clients", () => {
+        const description = syncService.buildEventDescription({
+            path: "1 Tasks/Tasks/Download first personal data export batch.md",
+            title: "Download first personal data export batch",
+            status: "ready",
+            priority: "2-high",
+            scheduled: "2026-04-29",
+            timeEstimate: 180,
+            projects: [
+                "[[0 Collect personal data exports for vault intelligence|Collect personal data exports for vault intelligence]]",
+                "[[Projects/Nested Project.md]]",
+                "[Markdown Project](Projects/Markdown%20Project.md)",
+            ],
+            contexts: ["[[People/Martin Ball|Martin Ball]]", "admin"],
+        } as TaskInfo);
+
+        expect(description).toContain("Priority: High");
+        expect(description).toContain("Status: Ready");
+        expect(description).toContain("Scheduled: 2026-04-29");
+        expect(description).toContain("Time Estimate: 3h 0m");
+        expect(description).toContain("Contexts: @Martin Ball, @admin");
+        expect(description).toContain(
+            "Projects: Collect personal data exports for vault intelligence, Nested Project, Markdown Project"
+        );
+        expect(description).toContain(
+            "Open in Obsidian: obsidian://open?vault=Martin%20OS&file=1%20Tasks%2FTasks%2FDownload%20first%20personal%20data%20export%20batch.md"
+        );
+        expect(description).not.toContain("[[");
+        expect(description).not.toContain("]]");
+        expect(description).not.toContain("<a ");
+        expect(description).not.toContain("</a>");
+        expect(description).not.toContain("](");
     });
 });


### PR DESCRIPTION
## Maintainer note
Ready to merge independently. This PR only changes Google Calendar task description formatting. If #1843 lands first, the expected follow-up is a small rebase around `TaskCalendarSyncService`/description tests, preserving the plain-text output and visible Obsidian URI.

## Summary
- render Google Calendar task descriptions as plain text instead of HTML anchors
- strip Obsidian wiki/markdown link syntax from project and context labels
- keep the Obsidian URI visible so clients that do not support custom-scheme anchors do not show broken HTML

## Testing
- npm test -- tests/services/TaskCalendarSyncService.test.ts --runInBand
- npm run typecheck
- npm run build:test
- npm run lint -- --quiet
- obsidian plugin:reload id=tasknotes vault=test
