### PR TITLE
fix(subtasks): use parent basename in Create subtask project link

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -28,3 +28,4 @@ Example:
 
 - (#1911) Fixed recurrence choices starting from today instead of the selected calendar date when creating a task from Calendar view.
   - Thanks to @mikhailmarka for reporting.
+- (#1912) Fixed "Create subtask" inserting the full path of the parent task (e.g. `[[Tasks/Parent Task]]`) into the Projects field instead of just the basename (`[[Parent Task]]`). The link now matches the form used by "Add as Subtask" and other project-link generators.

--- a/src/services/taskRelationshipActions.ts
+++ b/src/services/taskRelationshipActions.ts
@@ -144,7 +144,14 @@ export function buildSubtaskCreationPrePopulatedValues(
 	const shouldInheritParentProperties = Boolean(
 		plugin.settings.taskCreationDefaults?.inheritParentTaskProperties
 	);
-	const projectReference = buildStableFileLink(plugin, parentFile);
+	const projectReference = generateLink(
+		plugin.app,
+		parentFile,
+		parentTask.path,
+		"",
+		"",
+		plugin.settings.useFrontmatterMarkdownLinks
+	);
 	const parentTags = Array.isArray(parentTask.tags) ? parentTask.tags : [];
 	const parentProjects = shouldInheritParentProperties
 		? Array.isArray(parentTask.projects)

--- a/tests/unit/issues/issue-1710-subtask-inherit-project.test.ts
+++ b/tests/unit/issues/issue-1710-subtask-inherit-project.test.ts
@@ -48,7 +48,7 @@ describe("issue #1710 subtask project inheritance", () => {
 			parentFile
 		);
 
-		expect(values.projects).toEqual(["[[Tasks/Build login page]]"]);
+		expect(values.projects).toEqual(["[[Build login page]]"]);
 		expect(values.contexts).toBeUndefined();
 		expect(values.priority).toBeUndefined();
 		expect(values.tags).toBeUndefined();
@@ -68,7 +68,7 @@ describe("issue #1710 subtask project inheritance", () => {
 
 		expect(values.projects).toEqual([
 			"[[Projects/YGPT Dashboard]]",
-			"[[Tasks/Build login page]]",
+			"[[Build login page]]",
 		]);
 	});
 
@@ -80,7 +80,7 @@ describe("issue #1710 subtask project inheritance", () => {
 			parentFile
 		);
 
-		expect(values.projects).toEqual(["[[Tasks/Build login page]]"]);
+		expect(values.projects).toEqual(["[[Build login page]]"]);
 	});
 
 	it("does not duplicate the parent link if it is already one of the parent projects", () => {
@@ -92,14 +92,14 @@ describe("issue #1710 subtask project inheritance", () => {
 				},
 			}) as never,
 			createParentTask({
-				projects: ["[[Projects/YGPT Dashboard]]", "[[Tasks/Build login page]]"],
+				projects: ["[[Projects/YGPT Dashboard]]", "[[Build login page]]"],
 			}),
 			parentFile
 		);
 
 		expect(values.projects).toEqual([
 			"[[Projects/YGPT Dashboard]]",
-			"[[Tasks/Build login page]]",
+			"[[Build login page]]",
 		]);
 	});
 
@@ -129,7 +129,7 @@ describe("issue #1710 subtask project inheritance", () => {
 		);
 		expect(values.projects).toEqual([
 			"[[Areas/YGPT Dashboard]]",
-			"[[Tasks/Build login page]]",
+			"[[Build login page]]",
 		]);
 	});
 });

--- a/tests/unit/issues/issue-1785-subtask-inherits-parent-metadata.test.ts
+++ b/tests/unit/issues/issue-1785-subtask-inherits-parent-metadata.test.ts
@@ -49,7 +49,7 @@ describe("issue #1785 subtask metadata prefill", () => {
 			parentFile
 		);
 
-		expect(values.projects).toEqual(["[[Client A]]", "[[Tasks/Parent task]]"]);
+		expect(values.projects).toEqual(["[[Client A]]", "[[Parent task]]"]);
 		expect(values.contexts).toEqual(["office", "calls"]);
 		expect(values.priority).toBe("high");
 		expect(values.tags).toEqual(["client-a", "urgent"]);
@@ -90,7 +90,7 @@ describe("issue #1785 subtask metadata prefill", () => {
 		);
 
 		expect(values).toEqual({
-			projects: ["[[Tasks/Parent task]]"],
+			projects: ["[[Parent task]]"],
 		});
 	});
 });

--- a/tests/unit/issues/issue-1912-create-subtask-uses-parent-basename.test.ts
+++ b/tests/unit/issues/issue-1912-create-subtask-uses-parent-basename.test.ts
@@ -1,0 +1,85 @@
+import { App, TFile } from "obsidian";
+import { buildSubtaskCreationPrePopulatedValues } from "../../../src/services/taskRelationshipActions";
+import type { TaskInfo } from "../../../src/types";
+import { MockObsidian } from "../../__mocks__/obsidian";
+
+jest.mock("obsidian");
+
+const createMockApp = (mockApp: unknown): App => mockApp as App;
+
+function createParentTask(overrides: Partial<TaskInfo> = {}): TaskInfo {
+	return {
+		title: "Parent Task",
+		status: "open",
+		path: "Tasks/Parent Task.md",
+		archived: false,
+		tags: [],
+		contexts: [],
+		projects: [],
+		...overrides,
+	};
+}
+
+function createPlugin(settings: Record<string, unknown> = {}) {
+	return {
+		app: createMockApp(MockObsidian.createMockApp()),
+		settings: {
+			taskTag: "task",
+			taskIdentificationMethod: "tag",
+			useFrontmatterMarkdownLinks: false,
+			taskCreationDefaults: {
+				inheritParentTaskProperties: false,
+			},
+			...settings,
+		},
+	};
+}
+
+describe("issue #1912 Create subtask should use parent basename, not full path", () => {
+	beforeEach(() => {
+		MockObsidian.reset();
+	});
+
+	it("populates the project link with [[basename]] instead of [[Folder/basename]]", () => {
+		const parentFile = new TFile("Tasks/Parent Task.md");
+		const values = buildSubtaskCreationPrePopulatedValues(
+			createPlugin() as never,
+			createParentTask(),
+			parentFile
+		);
+
+		// The parent link in projects must match what the "Add as subtask" action
+		// produces (which uses generateLink + fileToLinktext, i.e. basename when unique).
+		// Before the fix the link was the full path: "[[Tasks/Parent Task]]".
+		expect(values.projects).toEqual(["[[Parent Task]]"]);
+	});
+
+	it("works the same way for parents in nested folders", () => {
+		const parentFile = new TFile("Work/Projects/Big Project.md");
+		const values = buildSubtaskCreationPrePopulatedValues(
+			createPlugin() as never,
+			createParentTask({
+				path: "Work/Projects/Big Project.md",
+				title: "Big Project",
+			}),
+			parentFile
+		);
+
+		expect(values.projects).toEqual(["[[Big Project]]"]);
+	});
+
+	it("uses markdown link format when useFrontmatterMarkdownLinks is enabled", () => {
+		const parentFile = new TFile("Tasks/Parent Task.md");
+		const values = buildSubtaskCreationPrePopulatedValues(
+			createPlugin({ useFrontmatterMarkdownLinks: true }) as never,
+			createParentTask(),
+			parentFile
+		);
+
+		// Markdown link variant should still resolve via Obsidian's link generator
+		// and produce a usable link rather than a raw-path wikilink.
+		expect(values.projects).toHaveLength(1);
+		expect(values.projects?.[0]).toMatch(/Parent Task/);
+		expect(values.projects?.[0]).not.toMatch(/^\[\[Tasks\//);
+	});
+});


### PR DESCRIPTION
Fixes #1912.

The "Create subtask" context menu pre-populated the new task's Projects field with the parent task's full vault path (e.g. \`[[Tasks/Parent Task]]\`), while every other entry point ("Add as Subtask", manual project assignment, the standalone task modal) writes the shortest unique link (\`[[Parent Task]]\`).

The regression was introduced when \`buildSubtaskCreationPrePopulatedValues\` was changed to use \`buildStableFileLink\` (which uses \`file.path\`). Switched back to \`generateLink\`, so the wikilink form goes through \`metadataCache.fileToLinktext\` like the rest of the codebase.

Added a regression test (\`issue-1912-create-subtask-uses-parent-basename.test.ts\`) and updated the existing \`#1710\` and \`#1785\` expectations that had locked in the wrong path.

Verified with \`npx jest --testPathPatterns="1710|1785|1912|relationshipActions"\` (12/12 pass), \`npm run typecheck\`, and \`npm run lint:ts\`.