### PR TITLE
fix: correct MCP query tool operators & fully enrich schemas (#1943)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -26,14 +26,18 @@ Example:
 
 ## Fixed
 
+- (#1943) Fixed MCP Service `tasknotes_query_tasks` operator instructions to align with valid filter operators.
+    - Corrected the description of the `operator` field to list valid operators (`is`, `is-not`, `contains`, `is-before`, `is-after`, `is-empty`).
+    - Streamlined the zod inputSchema of `tasknotes_query_tasks` to reuse the described `filterConditionSchema`.
+    - Thanks to @jordankbartos for reporting.
 - (#781, #1085) Fixed Outlook-published ICS calendar events appearing at the wrong time when their feed used Windows timezone names without matching timezone definitions.
-  - Thanks to @chrlaney for reporting and @mjkrasny for confirming the Outlook timezone case.
+    - Thanks to @chrlaney for reporting and @mjkrasny for confirming the Outlook timezone case.
 - (#1696) Fixed Google Calendar export for scheduled recurring tasks when a single occurrence is moved to a different date.
-  - Keeps the recurring master event on its original rule, excludes the original occurrence date, and syncs the moved occurrence as a detached event.
-  - Thanks to @martin-forge for reporting and contributing the fix.
+    - Keeps the recurring master event on its original rule, excludes the original occurrence date, and syncs the moved occurrence as a detached event.
+    - Thanks to @martin-forge for reporting and contributing the fix.
 - (#1912) Fixed "Create subtask" inserting the full path of the parent task in the Projects field instead of using the normal Obsidian link text.
-  - Thanks to @pkuehne for reporting and @benmartinek for confirming.
+    - Thanks to @pkuehne for reporting and @benmartinek for confirming.
 - (#1921) Fixed Google Calendar and auto-archive side effects falling stale after direct task file edits.
-  - Reconciles lifecycle-relevant frontmatter changes through the existing task file update event, with a first-run fingerprint baseline to avoid bulk startup API writes.
-  - Periodic recovery also cleans up indexed Google Calendar events whose task files were deleted or replaced while TaskNotes was running.
-  - Thanks to @martin-forge for reporting and contributing the fix.
+    - Reconciles lifecycle-relevant frontmatter changes through the existing task file update event, with a first-run fingerprint baseline to avoid bulk startup API writes.
+    - Periodic recovery also cleans up indexed Google Calendar events whose task files were deleted or replaced while TaskNotes was running.
+    - Thanks to @martin-forge for reporting and contributing the fix.

--- a/src/services/MCPService.ts
+++ b/src/services/MCPService.ts
@@ -474,7 +474,7 @@ export class MCPService {
 			operator: z
 				.string()
 				.describe(
-					"Filter operator (e.g. 'is', 'is_not', 'contains', 'before', 'after', 'is_empty')"
+					"Filter operator (e.g. 'is', 'is-not', 'contains', 'is-before', 'is-after', 'is-empty')"
 				),
 			value: z.union([z.string(), z.array(z.string()), z.number(), z.boolean(), z.null()]),
 		}) as z.ZodType<FilterCondition>;
@@ -496,24 +496,7 @@ export class MCPService {
 				inputSchema: {
 					conjunction: z.enum(["and", "or"]).describe("How to combine filter conditions"),
 					children: z
-						.array(
-							z.union([
-								z.object({
-									type: z.literal("condition"),
-									id: z.string(),
-									property: z.string(),
-									operator: z.string(),
-									value: z.union([
-										z.string(),
-										z.array(z.string()),
-										z.number(),
-										z.boolean(),
-										z.null(),
-									]),
-								}),
-								filterGroupSchema,
-							])
-						)
+						.array(z.union([filterConditionSchema, filterGroupSchema]))
 						.describe("Filter conditions or nested groups"),
 					sortKey: z
 						.string()

--- a/src/services/MCPService.ts
+++ b/src/services/MCPService.ts
@@ -464,27 +464,37 @@ export class MCPService {
 
 		// Define the recursive filter schema
 		const filterConditionSchema: z.ZodType<FilterCondition> = z.object({
-			type: z.literal("condition"),
-			id: z.string(),
+			type: z.literal("condition").describe("Represents a single filter rule"),
+			id: z.string().describe("A unique identifier for this condition node"),
 			property: z
 				.string()
 				.describe(
-					"Filter property (e.g. 'status', 'priority', 'due', 'tags', 'projects', 'contexts')"
+					"The field to filter on. Standard properties: 'title', 'path', 'status', 'priority', 'tags', 'contexts', 'projects', 'blockedBy', 'blocking', 'due', 'scheduled', 'completedDate', 'dateCreated', 'dateModified', 'archived', 'hasSubtasks', 'dependencies.isBlocked', 'dependencies.isBlocking', 'timeEstimate', 'recurrence', 'status.isCompleted'. Use 'user:<fieldname>' for custom fields."
 				),
 			operator: z
 				.string()
 				.describe(
-					"Filter operator (e.g. 'is', 'is-not', 'contains', 'is-before', 'is-after', 'is-empty')"
+					"Comparison operator. Basic: 'is', 'is-not'. Text: 'contains', 'does-not-contain'. Date: 'is-before', 'is-after', 'is-on-or-before', 'is-on-or-after'. Existence: 'is-empty', 'is-not-empty'. Boolean: 'is-checked', 'is-not-checked'. Numeric: 'is-greater-than', 'is-less-than', 'is-greater-than-or-equal', 'is-less-than-or-equal'."
 				),
-			value: z.union([z.string(), z.array(z.string()), z.number(), z.boolean(), z.null()]),
+			value: z
+				.union([z.string(), z.array(z.string()), z.number(), z.boolean(), z.null()])
+				.describe(
+					"The value to compare against. For date properties, use YYYY-MM-DD or relative natural language date strings (e.g., 'tomorrow')."
+				),
 		}) as z.ZodType<FilterCondition>;
 
 		const filterGroupSchema: z.ZodType<FilterGroup> = z.lazy(() =>
 			z.object({
-				type: z.literal("group"),
-				id: z.string(),
-				conjunction: z.enum(["and", "or"]),
-				children: z.array(z.union([filterConditionSchema, filterGroupSchema])),
+				type: z.literal("group").describe("Represents a logical grouping of conditions"),
+				id: z.string().describe("A unique identifier for this group node"),
+				conjunction: z
+					.enum(["and", "or"])
+					.describe(
+						"Logical conjunction. Use 'and' if all children must match; 'or' if at least one must match"
+					),
+				children: z
+					.array(z.union([filterConditionSchema, filterGroupSchema]))
+					.describe("Nested condition or group nodes within this group"),
 			})
 		) as z.ZodType<FilterGroup>;
 
@@ -492,21 +502,32 @@ export class MCPService {
 			"tasknotes_query_tasks",
 			{
 				description:
-					"Query tasks using advanced filters with AND/OR logic, sorting, and grouping",
+					"Query tasks using advanced filters with AND/OR logic, sorting, and grouping. Always prefer using exact operators and properties specified in the schema.",
 				inputSchema: {
-					conjunction: z.enum(["and", "or"]).describe("How to combine filter conditions"),
+					conjunction: z
+						.enum(["and", "or"])
+						.describe(
+							"The logical conjunction used to join the top-level children filters"
+						),
 					children: z
 						.array(z.union([filterConditionSchema, filterGroupSchema]))
-						.describe("Filter conditions or nested groups"),
+						.describe("Top-level filter conditions or nested groups"),
 					sortKey: z
 						.string()
 						.optional()
-						.describe("Sort by field (e.g. 'due', 'priority', 'title', 'status')"),
-					sortDirection: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+						.describe(
+							"The property to sort tasks by (e.g. 'due', 'priority', 'title', 'status', 'timeEstimate', 'dateCreated', 'dateModified')"
+						),
+					sortDirection: z
+						.enum(["asc", "desc"])
+						.optional()
+						.describe("Direction to sort: 'asc' for ascending, 'desc' for descending"),
 					groupKey: z
 						.string()
 						.optional()
-						.describe("Group by field (e.g. 'priority', 'status', 'projects')"),
+						.describe(
+							"Group tasks by field (e.g. 'priority', 'status', 'projects', 'due', 'scheduled')"
+						),
 				},
 			},
 			async (args: QueryTasksArgs) => {


### PR DESCRIPTION
## Summary

This PR addresses the discrepancy in the Model Context Protocol (MCP) service query tool operators (as reported in #1943) and comprehensively enriches the tool descriptions to make the MCP server much more useful and robust for AI agents.

The implementation is structured as follows:

### 1. Minimal Fix & Alignment ([First Commit](https://github.com/callumalpass/tasknotes/pull/1944/commits/9608ed0ce6613190503feb8c99edec046c34ff96))
* **Operator List Correction:** Updated the description of the `operator` field in `src/services/MCPService.ts` to list actual valid kebab-case operators (`is`, `is-not`, `contains`, `is-before`, `is-after`, `is-empty`) instead of the incorrect ones (`is_not`, `before`, `after`, `is_empty`) that threw validation errors.
* **Schema Streamlining:** Replaced the duplicated inline condition object inside `tasknotes_query_tasks` with a direct reference to the described `filterConditionSchema`.
* **Documentation:** Updated `docs/releases/unreleased.md` acknowledging the issue and reporter.

### 2. Comprehensive Agent-Friendly Schema Enrichment ([Second Commit](https://github.com/callumalpass/tasknotes/pull/1944/commits/7bba8235ed8959b9b6b151ef1bfe21fbff21973b))
* **Filter Properties enumerated:** Added detailed descriptions of all standard properties (`title`, `path`, `status`, `priority`, `tags`, `contexts`, `projects`, `blockedBy`, `blocking`, `due`, `scheduled`, `completedDate`, `dateCreated`, `dateModified`, `archived`, `hasSubtasks`, `dependencies.isBlocked`, `dependencies.isBlocking`, `timeEstimate`, `recurrence`, `status.isCompleted`) to guide agents.
* **Operators described:** Grouped and explained the functional categories of all valid operators.
* **Sorting & Grouping keys:** Added explanatory descriptions for optional sorting and grouping parameters.

All linter checks, TypeScript compilation, and Jest unit tests pass cleanly.