### PR TITLE
Prevent duplicate Google Calendar task creates

### DIFF
--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -95,6 +95,12 @@ function isAlreadyDeletedError(error: unknown): boolean {
  * Handles creating, updating, and deleting calendar events when tasks change.
  */
 export class TaskCalendarSyncService {
+	/** In-flight create operations keyed by calendar and task path to avoid duplicate Google events */
+	private static pendingEventCreates: Map<string, Promise<string>> = new Map();
+
+	/** Event IDs written during this session, used while Obsidian metadata catches up */
+	private static taskEventIdCache: Map<string, string> = new Map();
+
 	private plugin: TaskNotesPlugin;
 	private googleCalendarService: GoogleCalendarService;
 	private rateLimitChain: Promise<unknown> = Promise.resolve();
@@ -114,12 +120,6 @@ export class TaskCalendarSyncService {
 	/** Store the latest explicitly passed task object during debounce to avoid cache race conditions */
 	private pendingTasks: Map<string, TaskInfo> = new Map();
 
-	/** In-flight create operations keyed by task path to avoid duplicate Google events */
-	private pendingEventCreates: Map<string, Promise<string>> = new Map();
-
-	/** Event IDs written during this session, used while Obsidian metadata catches up */
-	private taskEventIdCache: Map<string, string> = new Map();
-
 	/** Detached recurring exception event IDs written during this session */
 	private taskExceptionEventIdCache: Map<string, string> = new Map();
 
@@ -129,6 +129,44 @@ export class TaskCalendarSyncService {
 	constructor(plugin: TaskNotesPlugin, googleCalendarService: GoogleCalendarService) {
 		this.plugin = plugin;
 		this.googleCalendarService = googleCalendarService;
+	}
+
+	private static getTaskCalendarCacheKey(taskPath: string, calendarId?: string): string {
+		return calendarId ? `${calendarId}::${taskPath}` : taskPath;
+	}
+
+	private static clearTaskEventIdCache(taskPath: string, calendarId?: string): void {
+		if (calendarId) {
+			TaskCalendarSyncService.taskEventIdCache.delete(
+				TaskCalendarSyncService.getTaskCalendarCacheKey(taskPath, calendarId)
+			);
+			return;
+		}
+
+		TaskCalendarSyncService.taskEventIdCache.delete(
+			TaskCalendarSyncService.getTaskCalendarCacheKey(taskPath)
+		);
+		for (const key of Array.from(TaskCalendarSyncService.taskEventIdCache.keys())) {
+			if (key.endsWith(`::${taskPath}`)) {
+				TaskCalendarSyncService.taskEventIdCache.delete(key);
+			}
+		}
+	}
+
+	private static clearSharedGoogleCalendarSyncState(): void {
+		TaskCalendarSyncService.pendingEventCreates.clear();
+		TaskCalendarSyncService.taskEventIdCache.clear();
+	}
+
+	static clearSharedGoogleCalendarSyncStateForTests(): void {
+		TaskCalendarSyncService.clearSharedGoogleCalendarSyncState();
+	}
+
+	private getTaskEventIdCacheKey(taskPath: string, calendarId?: string): string {
+		return TaskCalendarSyncService.getTaskCalendarCacheKey(
+			taskPath,
+			calendarId || this.plugin.settings.googleCalendarExport.targetCalendarId
+		);
 	}
 
 	/**
@@ -146,8 +184,7 @@ export class TaskCalendarSyncService {
 		this.pendingSyncs.clear();
 		this.previousTaskState.clear();
 		this.pendingTasks.clear();
-		this.pendingEventCreates.clear();
-		this.taskEventIdCache.clear();
+		TaskCalendarSyncService.clearSharedGoogleCalendarSyncState();
 		this.taskExceptionEventIdCache.clear();
 		this.calendarFingerprints = null;
 	}
@@ -1042,7 +1079,12 @@ export class TaskCalendarSyncService {
 	 * Get the Google Calendar event ID from the task's frontmatter
 	 */
 	getTaskEventId(task: TaskInfo): string | undefined {
-		return task.googleCalendarEventId || this.taskEventIdCache.get(task.path);
+		return (
+			task.googleCalendarEventId ||
+			TaskCalendarSyncService.taskEventIdCache.get(
+				this.getTaskEventIdCacheKey(task.path)
+			)
+		);
 	}
 
 	/**
@@ -1103,7 +1145,11 @@ export class TaskCalendarSyncService {
 	/**
 	 * Save the Google Calendar event ID to the task's frontmatter
 	 */
-	private async saveTaskEventId(taskPath: string, eventId: string): Promise<void> {
+	private async saveTaskEventId(
+		taskPath: string,
+		eventId: string,
+		calendarId?: string
+	): Promise<void> {
 		const file = this.plugin.app.vault.getAbstractFileByPath(taskPath);
 		if (!(file instanceof TFile)) {
 			tasknotesLogger.warn(`Cannot save event ID: file not found at ${taskPath}`, {
@@ -1117,9 +1163,13 @@ export class TaskCalendarSyncService {
 		await processVaultFrontMatter(this.plugin.app, file, (frontmatter) => {
 			frontmatter[fieldName] = eventId;
 		});
-		this.taskEventIdCache.set(taskPath, eventId);
+		TaskCalendarSyncService.taskEventIdCache.set(
+			this.getTaskEventIdCacheKey(taskPath, calendarId),
+			eventId
+		);
 
-		const targetCalendarId = this.plugin.settings.googleCalendarExport.targetCalendarId;
+		const targetCalendarId =
+			calendarId || this.plugin.settings.googleCalendarExport.targetCalendarId;
 		if (targetCalendarId) {
 			await this.upsertEventIndex(taskPath, targetCalendarId, eventId);
 		}
@@ -1135,7 +1185,7 @@ export class TaskCalendarSyncService {
 				category: "provider",
 				operation: "remove-event-id-file-not-found",
 			});
-			this.taskEventIdCache.delete(taskPath);
+			TaskCalendarSyncService.clearTaskEventIdCache(taskPath);
 			await this.removeEventIndexForTask(taskPath);
 			return;
 		}
@@ -1144,7 +1194,7 @@ export class TaskCalendarSyncService {
 		await processVaultFrontMatter(this.plugin.app, file, (frontmatter) => {
 			delete frontmatter[fieldName];
 		});
-		this.taskEventIdCache.delete(taskPath);
+		TaskCalendarSyncService.clearTaskEventIdCache(taskPath);
 		await this.removeEventIndexForTask(taskPath);
 	}
 
@@ -1824,7 +1874,7 @@ export class TaskCalendarSyncService {
 			? createdEvent.id.slice(prefix.length)
 			: createdEvent.id;
 
-		await this.saveTaskEventId(task.path, eventId);
+		await this.saveTaskEventId(task.path, eventId, calendarId);
 		return eventId;
 	}
 
@@ -2039,7 +2089,12 @@ export class TaskCalendarSyncService {
 					)
 				);
 			} else {
-				const pendingCreate = this.pendingEventCreates.get(task.path);
+				const createCacheKey = this.getTaskEventIdCacheKey(
+					task.path,
+					targetCalendarId
+				);
+				const pendingCreate =
+					TaskCalendarSyncService.pendingEventCreates.get(createCacheKey);
 				if (pendingCreate) {
 					const eventId = await pendingCreate;
 					await this.withGoogleRateLimit(() =>
@@ -2051,12 +2106,18 @@ export class TaskCalendarSyncService {
 						eventData,
 						targetCalendarId
 					);
-					this.pendingEventCreates.set(task.path, createPromise);
+					TaskCalendarSyncService.pendingEventCreates.set(
+						createCacheKey,
+						createPromise
+					);
 					try {
 						await createPromise;
 					} finally {
-						if (this.pendingEventCreates.get(task.path) === createPromise) {
-							this.pendingEventCreates.delete(task.path);
+						if (
+							TaskCalendarSyncService.pendingEventCreates.get(createCacheKey) ===
+							createPromise
+						) {
+							TaskCalendarSyncService.pendingEventCreates.delete(createCacheKey);
 						}
 					}
 				}

--- a/tests/unit/issues/issue-google-calendar-duplicate-sync.test.ts
+++ b/tests/unit/issues/issue-google-calendar-duplicate-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest } from "@jest/globals";
+import { beforeEach, describe, it, expect, jest } from "@jest/globals";
 import { TFile } from "obsidian";
 
 import { TaskCalendarSyncService } from "../../../src/services/TaskCalendarSyncService";
@@ -69,6 +69,10 @@ const createPlugin = (frontmatter: Record<string, any>) => ({
 });
 
 describe("Google Calendar duplicate sync prevention", () => {
+	beforeEach(() => {
+		TaskCalendarSyncService.clearSharedGoogleCalendarSyncStateForTests();
+	});
+
 	it("does not create duplicate events when two syncs race before the event id reaches task metadata", async () => {
 		const frontmatter: Record<string, any> = {};
 		const plugin = createPlugin(frontmatter);
@@ -134,6 +138,45 @@ describe("Google Calendar duplicate sync prevention", () => {
 				start: { date: "2026-04-30" },
 			})
 		);
+	});
+
+	it("does not create duplicate events when two independent sync services race for the same task", async () => {
+		const frontmatter: Record<string, any> = {};
+		const firstPlugin = createPlugin(frontmatter);
+		const secondPlugin = createPlugin(frontmatter);
+		const googleCalendarService = {
+			getAvailableCalendars: jest.fn().mockReturnValue([{ id: "primary", name: "Primary" }]),
+			createEvent: jest
+				.fn()
+				.mockResolvedValueOnce({ id: "google-primary-first-event-id" })
+				.mockResolvedValueOnce({ id: "google-primary-second-event-id" }),
+			updateEvent: jest.fn().mockResolvedValue(undefined),
+			deleteEvent: jest.fn().mockResolvedValue(undefined),
+		};
+		const firstSyncService = new TaskCalendarSyncService(
+			firstPlugin as any,
+			googleCalendarService as any
+		);
+		const secondSyncService = new TaskCalendarSyncService(
+			secondPlugin as any,
+			googleCalendarService as any
+		);
+		const task: TaskInfo = {
+			path: "TaskNotes/Tasks/cross-instance-race.md",
+			title: "Cross-instance race",
+			status: "open",
+			priority: "normal",
+			scheduled: "2026-04-29",
+			archived: false,
+		};
+
+		await Promise.all([
+			firstSyncService.syncTaskToCalendar(task),
+			secondSyncService.syncTaskToCalendar(task),
+		]);
+
+		expect(googleCalendarService.createEvent).toHaveBeenCalledTimes(1);
+		expect(frontmatter.googleCalendarEventId).toBe("first-event-id");
 	});
 
 	it("does not leave a failed create in flight and allows a later retry", async () => {


### PR DESCRIPTION
## Summary

Fixes a Google Calendar export race where two independent `TaskCalendarSyncService` instances can both create an event for the same task before either instance can observe the persisted `googleCalendarEventId`.

- Shares in-flight main-event creates across sync service instances with a calendar/task cache key.
- Shares newly created main event IDs across instances while Obsidian metadata catches up.
- Adds a regression test that runs two independent sync services concurrently against the same task and asserts only one Google Calendar event is created.

## Root cause

`pendingEventCreates` and the session event ID cache were instance fields. That protected duplicate creates inside one service instance, but not across stale or overlapping service contexts. A second service could miss the first service's pending create and issue its own `createEvent`, leaving one Google Calendar event orphaned after local frontmatter was overwritten by the later ID.

## Tests

- `npm test -- issue-google-calendar-duplicate-sync --runInBand`
- `npm test -- --runInBand tests/services/TaskCalendarSyncService.test.ts tests/unit/issues/issue-google-calendar-duplicate-sync.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `vault-python 7 System/Scripts/vault/scan_public_pr.py --repo /Users/martin/Developer/tasknotes-main --base origin/main --head HEAD`