### PR TITLE
fix #1968: prevent inline task widget collapse on mobile

### DIFF
--- a/styles/task-card-bem.css
+++ b/styles/task-card-bem.css
@@ -24,6 +24,11 @@
     /* Interactions & Accessibility - Smooth transitions */
     transition: background-color var(--tn-transition-fast), box-shadow var(--tn-transition-fast), border-color var(--tn-transition-fast);
     outline: none;
+}
+
+/* Scoped to full card layout: inline/compact must not establish an inline-size
+   container (collapses the mobile inline-flex widget to 0 width). */
+.tasknotes-plugin .task-card:not(.task-card--layout-inline):not(.task-card--layout-compact) {
     container: tn-task-card / inline-size;
 }
 


### PR DESCRIPTION
## Problem

Fix: #1968
On mobile, the inline TaskNotes widget (a `[[task]]` link rendered in the editor) collapses: the task **title is invisible** and a **large empty vertical gap** appears between the widget and the following line. Only the status dot and ⋮ menu show.

## Root cause

Commit 26ba6535 ("Improve mobile task card layout") added a container context to **every** card:

```css
.tasknotes-plugin .task-card { container: tn-task-card / inline-size; }
```

- On **desktop**, the inline widget is `display: inline`, where `inline-size` containment is **inert** → renders fine.
- On **mobile/touch**, the same commit makes the inline widget `display: inline-flex`. That **activates** the containment: the card now computes its width while *ignoring its contents*, collapsing the card (and its title) to **0px wide**.
- The title then wraps one character per line. `overflow: hidden` clips it horizontally (title invisible), while its height inflates the flex parents and the CodeMirror line → the large empty gap.

## Fix

Scope the container to the **full** card layout only. The single `@container tn-task-card` query already targets `:not(.task-card--layout-inline):not(.task-card--layout-compact)`, so this changes no responsive behaviour:

```css
.tasknotes-plugin .task-card:not(.task-card--layout-inline):not(.task-card--layout-compact) {
    container: tn-task-card / inline-size;
}
```

## Verification

Measured in real Chromium with the exact widget DOM + plugin CSS under `body.is-mobile`:

| Metric | Before | After |
|---|---|---|
| Inline widget line height | 854.8px | **46px** |
| Title text size | 13.3 × 845.5px (clipped, invisible) | **313.6 × 17px (visible)** |
| Desktop inline widget | — | unchanged |

`stylelint styles/task-card-bem.css` passes; existing `issue-190` mobile CSS test passes.