### PR TITLE
feat: add setting to hide subtasks from task list root

### DIFF
--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -1566,6 +1566,11 @@ export const en: TranslationTree = {
 					name: "Show expandable subtasks",
 					description: "Allow expanding/collapsing subtask sections in task cards",
 				},
+				hideRootSubtasks: {
+					name: "Hide subtasks in list root",
+					description:
+						"In task list views, hide tasks that belong to a parent project from the root level. Subtasks remain visible when their parent is expanded.",
+				},
 				expandSubtasksByDefault: {
 					name: "Expand subtasks by default",
 					description: "Show project subtasks expanded when task cards are rendered",

--- a/src/main.ts
+++ b/src/main.ts
@@ -261,6 +261,7 @@ export default class TaskNotesPlugin extends Plugin {
 		});
 
 		await this.loadSettings();
+		document.body.classList.toggle("tasknotes-hide-root-subtasks", this.settings.hideRootSubtasks);
 		this.performanceProfiler = createTaskNotesPerformanceProfiler({
 			isEnabled: () => this.settings?.enableDebugLogging === true,
 			logger: createTaskNotesLogger({
@@ -590,6 +591,7 @@ export default class TaskNotesPlugin extends Plugin {
 	}
 
 	onunload() {
+		document.body.classList.remove("tasknotes-hide-root-subtasks");
 		void cleanupPluginRuntime(this);
 	}
 

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -329,6 +329,7 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	// Task card expandable subtasks defaults
 	showExpandableSubtasks: true,
 	expandSubtasksByDefault: false,
+	hideRootSubtasks: false,
 	// Subtask chevron position default
 	subtaskChevronPosition: "right",
 	// Filter toolbar layout defaults

--- a/src/settings/tabs/appearanceTab.ts
+++ b/src/settings/tabs/appearanceTab.ts
@@ -815,6 +815,19 @@ export function renderAppearanceTab(
 			}
 
 			group.addSetting((setting) =>
+				void configureToggleSetting(setting, {
+					name: translate("settings.appearance.uiElements.hideRootSubtasks.name"),
+					desc: translate("settings.appearance.uiElements.hideRootSubtasks.description"),
+					getValue: () => plugin.settings.hideRootSubtasks,
+					setValue: async (value: boolean) => {
+						plugin.settings.hideRootSubtasks = value;
+						document.body.classList.toggle("tasknotes-hide-root-subtasks", value);
+						save();
+					},
+				})
+			);
+
+			group.addSetting((setting) =>
 				void configureDropdownSetting(setting, {
 					name: translate("settings.appearance.uiElements.viewsButtonAlignment.name"),
 					desc: translate(

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -180,6 +180,8 @@ export interface TaskNotesSettings {
 	showExpandableSubtasks: boolean;
 	// Expand project subtasks by default when task cards render
 	expandSubtasksByDefault: boolean;
+	// Hide subtasks from root of task list views (only show under expanded parent)
+	hideRootSubtasks: boolean;
 	// Subtask chevron position in task cards
 	subtaskChevronPosition: "left" | "right";
 	// Filter toolbar layout


### PR DESCRIPTION
## Summary

Closes #1715

Adds a **"Hide subtasks in list root"** toggle in Settings → Appearance (alongside the existing expandable subtasks options). When enabled, tasks that belong to a parent project are hidden from the root level of task list views — they remain visible only when their parent task is expanded.

## Implementation

Pure CSS, no JS-level deduplication required. The feature works by toggling a `tasknotes-hide-root-subtasks` class on `document.body`, which activates this rule in `task-list-view.css`:

\`\`\`css
body.tasknotes-hide-root-subtasks .tasknotes-plugin
  .task-card:has(.task-card__project-link):not(:has(.task-card__subtasks)):not(.task-card__subtasks .task-card) {
    display: none;
}
\`\`\`

The three-part selector:
- `:has(.task-card__project-link)` — matches tasks that belong to a parent
- `:not(:has(.task-card__subtasks))` — excludes expanded parent tasks (which have a subtasks container), preventing them from being hidden
- `:not(.task-card__subtasks .task-card)` — excludes subtasks already nested under an expanded parent, so they still show in the fold-out

## Changes

- `src/types/settings.ts` — adds `hideRootSubtasks: boolean`
- `src/settings/defaults.ts` — defaults to `false` (opt-in)
- `src/settings/tabs/appearanceTab.ts` — adds toggle with body class side-effect
- `src/main.ts` — applies/removes body class on load/unload
- `src/i18n/resources/en.ts` — adds English strings
- `styles/task-list-view.css` — adds the CSS rule

## Test plan

- [ ] Enable the setting — subtasks at root level disappear
- [ ] Expand a parent task — subtasks appear in the fold-out as expected
- [ ] Collapse the parent — subtasks return to hidden
- [ ] Disable the setting — root-level subtasks reappear
- [ ] Reload Obsidian with setting enabled — body class applied on startup, subtasks hidden immediately