### PR TITLE
support file protocol for remote ics

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,6 +16,8 @@ Example:
 ```
 ## Fixed
 
+- Remote ICS subscriptions now support `file://` URLs and read directly from vault files when the path is inside the current vault.
+
 - (#768) Fixed calendar view appearing empty in week and day views due to invalid time configuration values
   - Added time validation in settings UI with proper error messages and debouncing
   - Prevents "Cannot read properties of null (reading 'years')" error from FullCalendar

--- a/src/services/ICSSubscriptionService.ts
+++ b/src/services/ICSSubscriptionService.ts
@@ -332,18 +332,24 @@ export class ICSSubscriptionService extends EventEmitter {
 					throw new Error("Remote subscription missing URL");
 				}
 
-				const response = await requestUrl({
-					url: subscription.url,
-					method: "GET",
-					headers: {
-						Accept: "text/calendar,*/*;q=0.1",
-						"Accept-Language": "en-US,en;q=0.9",
-						"User-Agent":
-							"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-					},
-				});
+				if (this.isFileProtocolUrl(subscription.url)) {
+					const filePath = this.fileUrlToPath(subscription.url);
+					const normalizedFilePath = this.normalizeLocalICSFilePath(filePath);
+					icsData = await this.readLocalICSFile(normalizedFilePath);
+				} else {
+					const response = await requestUrl({
+						url: subscription.url,
+						method: "GET",
+						headers: {
+							Accept: "text/calendar,*/*;q=0.1",
+							"Accept-Language": "en-US,en;q=0.9",
+							"User-Agent":
+								"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+						},
+					});
 
-				icsData = response.text;
+					icsData = response.text;
+				}
 			} else if (subscription.type === "local") {
 				if (!subscription.filePath) {
 					throw new Error("Local subscription missing file path");
@@ -806,6 +812,36 @@ export class ICSSubscriptionService extends EventEmitter {
 			.trim()
 			.replace(/\\/g, "/")
 			.replace(/^\.\/+/u, "");
+	}
+
+	private isFileProtocolUrl(url: string): boolean {
+		try {
+			return new URL(url).protocol === "file:";
+		} catch {
+			return false;
+		}
+	}
+
+	private fileUrlToPath(fileUrl: string): string {
+		let parsedUrl: URL;
+		try {
+			parsedUrl = new URL(fileUrl);
+		} catch {
+			throw new Error(`Invalid file URL: ${fileUrl}`);
+		}
+
+		if (parsedUrl.protocol !== "file:") {
+			throw new Error(`URL is not a file URL: ${fileUrl}`);
+		}
+
+		const decodedPath = decodeURIComponent(parsedUrl.pathname);
+		const normalizedPath = this.normalizePathSeparators(decodedPath);
+
+		if (/^\/[A-Za-z]:\//u.test(normalizedPath)) {
+			return normalizedPath.slice(1);
+		}
+
+		return normalizedPath;
 	}
 
 	private isAbsoluteFilePath(filePath: string): boolean {

--- a/src/settings/components/CardComponent.ts
+++ b/src/settings/components/CardComponent.ts
@@ -882,7 +882,7 @@ export function normalizeCalendarUrl(url: string): string {
 /**
  * Creates a URL input with validation styling.
  *
- * Accepts http://, https://, webcal://, and webcals:// protocols.
+ * Accepts http://, https://, webcal://, webcals://, and file:// protocols.
  * The webcal protocols are commonly used for calendar subscriptions
  * (especially Apple Calendar) and are automatically normalized to
  * http/https when the URL is saved.
@@ -895,8 +895,8 @@ export function createCardUrlInput(placeholder?: string, value?: string): HTMLIn
 	input.addClass("tasknotes-settings__card-input");
 
 	// Add pattern validation to accept calendar URL protocols
-	input.pattern = "^(https?|webcals?)://.*";
-	input.title = "Enter an HTTP://, HTTPS://, webcal://, or webcals:// URL";
+	input.pattern = "^(https?|webcals?|file)://.*";
+	input.title = "Enter an HTTP://, HTTPS://, webcal://, webcals://, or file:// URL";
 
 	if (placeholder) {
 		input.placeholder = placeholder;

--- a/tests/unit/components/CardComponent.normalizeUrl.test.ts
+++ b/tests/unit/components/CardComponent.normalizeUrl.test.ts
@@ -44,6 +44,12 @@ describe('normalizeCalendarUrl', () => {
 		expect(output).toBe('https://example.com/calendar.ics');
 	});
 
+	it('should not modify file:// URLs', () => {
+		const input = 'file:///home/user/Calendar.ics';
+		const output = normalizeCalendarUrl(input);
+		expect(output).toBe('file:///home/user/Calendar.ics');
+	});
+
 	it('should handle Apple iCloud calendar URLs', () => {
 		const input = 'webcal://p01-caldav.icloud.com/published/2/MTY3NDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI';
 		const output = normalizeCalendarUrl(input);

--- a/tests/unit/issues/issue-remote-file-protocol-ics.test.ts
+++ b/tests/unit/issues/issue-remote-file-protocol-ics.test.ts
@@ -1,0 +1,95 @@
+import { ICSSubscriptionService } from '../../../src/services/ICSSubscriptionService';
+
+jest.mock('obsidian', () => ({
+	Notice: jest.fn(),
+	requestUrl: jest.fn(),
+	TFile: class TFile {
+		path: string;
+		extension: string;
+		constructor(path: string) {
+			this.path = path;
+			this.extension = path.split('.').pop() || '';
+		}
+	}
+}));
+
+jest.mock('ical.js', () => ({
+	...jest.requireActual('ical.js')
+}));
+
+describe('Remote ICS file:// protocol support', () => {
+	let service: ICSSubscriptionService;
+	let mockPlugin: any;
+	const { TFile, requestUrl } = require('obsidian');
+
+	beforeEach(() => {
+		mockPlugin = {
+			loadData: jest.fn().mockResolvedValue({ icsSubscriptions: [] }),
+			saveData: jest.fn().mockResolvedValue(undefined),
+			app: {
+				vault: {
+					getAbstractFileByPath: jest.fn(),
+					cachedRead: jest.fn(),
+					getFiles: jest.fn().mockReturnValue([]),
+					on: jest.fn(),
+					offref: jest.fn(),
+					adapter: {
+						getBasePath: jest.fn().mockReturnValue('/home/photon/Vault')
+					}
+				}
+			},
+			i18n: {
+				translate: jest.fn((key: string) => key)
+			}
+		};
+
+		service = new ICSSubscriptionService(mockPlugin);
+		requestUrl.mockReset();
+	});
+
+	afterEach(() => {
+		service.destroy();
+	});
+
+	it('reads file:// remote subscriptions from vault files without network fetch', async () => {
+		const absolutePath = '/home/photon/Vault/Calendars/Team Calendar.ics';
+		const fileUrl = 'file:///home/photon/Vault/Calendars/Team%20Calendar.ics';
+		const vaultRelativePath = 'Calendars/Team Calendar.ics';
+
+		const mockFile = new TFile(vaultRelativePath);
+		mockFile.extension = 'ics';
+
+		mockPlugin.app.vault.getAbstractFileByPath.mockImplementation((resolvedPath: string) => {
+			if (resolvedPath === vaultRelativePath) {
+				return mockFile;
+			}
+			if (resolvedPath === absolutePath) {
+				return null;
+			}
+			return null;
+		});
+
+		mockPlugin.app.vault.cachedRead.mockResolvedValue(
+			'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:test-file-protocol\nDTSTART:20260610T120000Z\nDTEND:20260610T130000Z\nSUMMARY:File Protocol Event\nEND:VEVENT\nEND:VCALENDAR'
+		);
+
+		await service.initialize();
+
+		const subscription = await service.addSubscription({
+			name: 'File Protocol Calendar',
+			url: fileUrl,
+			type: 'remote',
+			enabled: true,
+			color: '#42a5f5',
+			refreshInterval: 60
+		});
+
+		expect(requestUrl).not.toHaveBeenCalled();
+		expect(mockPlugin.app.vault.getAbstractFileByPath).toHaveBeenCalledWith(vaultRelativePath);
+		expect(service.getLastError(subscription.id)).toBeUndefined();
+
+		const events = service.getAllEvents();
+		expect(events).toHaveLength(1);
+		expect(events[0].title).toBe('File Protocol Event');
+	});
+});


### PR DESCRIPTION
## What
- add support for `file://` URLs on remote ICS subscriptions
- route `file://` remote URLs through local vault file reading logic
- extend URL input validation to allow `file://` URLs
- add regression tests for file protocol remote subscriptions and URL normalization
- document the fix in unreleased notes

## Validation
- `npm run build:test` (build passed; `obsidian vault=test plugin:reload id=tasknotes` failed locally with "Vault not found.")
- `npm run lint`
- `npx jest --runInBand tests/unit/components/CardComponent.normalizeUrl.test.ts tests/unit/issues/issue-remote-file-protocol-ics.test.ts`