### PR TITLE
Show projected Pomodoro end time

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -32,4 +32,10 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 -->
 
+## Added
+
+- (#2006) Display the projected local finish time while a Pomodoro is running
+  - Updates with the remaining duration and respects the configured 12- or 24-hour time format
+  - Thanks to @abbiefalls90 for suggesting and implementing this
+
 ## Fixed

--- a/i18n.manifest.json
+++ b/i18n.manifest.json
@@ -241,7 +241,7 @@
   "views.pomodoro.status.breakLength.long": "bd3027fa569ea15ca76d84db21c67e2d514c1a5a",
   "views.pomodoro.status.breakComplete": "d24e08419023f1502239bd96fb6dd07257e67fff",
   "views.pomodoro.meta.ready": "274149c3614f7ee9ed9bb23e44767da6575a4199",
-  "views.pomodoro.meta.running": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
+  "views.pomodoro.meta.running": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
   "views.pomodoro.meta.paused": "782cf2acb237b4450d523ab710518df4ff376d9d",
   "views.pomodoro.meta.breakReady": "7db1ec1cf1c195406d4485263cbca986500a6fb4",
   "views.pomodoro.timer.editLabel": "fa34a26449e0fc61c8aa0a7bac16428da72c49a6",

--- a/i18n.state.json
+++ b/i18n.state.json
@@ -969,8 +969,8 @@
       "translation": "16713ea637a4ce641361be12f1595445ec1a6e81"
     },
     "views.pomodoro.meta.running": {
-      "source": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
-      "translation": "8d3b30330335b7958eebbe56ffa91e1133529d59"
+      "source": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
+      "translation": "58f17f420d700d2818902e7b7e584cb3b2fad74d"
     },
     "views.pomodoro.meta.paused": {
       "source": "782cf2acb237b4450d523ab710518df4ff376d9d",
@@ -9759,8 +9759,8 @@
       "translation": "cbf23818d3fb38dff361b0bf24be395701ab2d27"
     },
     "views.pomodoro.meta.running": {
-      "source": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
-      "translation": "9814a08efc5d2924c050cebfd0038ddbed4f152d"
+      "source": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
+      "translation": "4c1f95e5f97ecf82c6ea6015110eeead560fc6d5"
     },
     "views.pomodoro.meta.paused": {
       "source": "782cf2acb237b4450d523ab710518df4ff376d9d",
@@ -18549,8 +18549,8 @@
       "translation": "1539b41940445cda818d18a80760edc14bfacdfc"
     },
     "views.pomodoro.meta.running": {
-      "source": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
-      "translation": "6852c5e46be1b4cf44ff49cfde080770a0902584"
+      "source": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
+      "translation": "4f26534c928c93e064ca63c83fa5656d6e81cd76"
     },
     "views.pomodoro.meta.paused": {
       "source": "782cf2acb237b4450d523ab710518df4ff376d9d",
@@ -27339,8 +27339,8 @@
       "translation": "c9ce0d746fe64f817f395032492ad8d53cc5c8dd"
     },
     "views.pomodoro.meta.running": {
-      "source": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
-      "translation": "f1f1d71d6f886f1401d2096fbd0336a8d6f148b9"
+      "source": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
+      "translation": "f379e78f50ac99d3d0916bbb5fe5fcafbf8a7d4f"
     },
     "views.pomodoro.meta.paused": {
       "source": "782cf2acb237b4450d523ab710518df4ff376d9d",
@@ -36129,8 +36129,8 @@
       "translation": "caf860c62725598a30b68c286d4e4ca2078715a1"
     },
     "views.pomodoro.meta.running": {
-      "source": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
-      "translation": "ea0a1d3b04be54e9b9ab1d7fcccdf9b4d1c4af70"
+      "source": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
+      "translation": "4c729da42419a731f34708fb1fefe6890a5f9ef5"
     },
     "views.pomodoro.meta.paused": {
       "source": "782cf2acb237b4450d523ab710518df4ff376d9d",
@@ -44919,8 +44919,8 @@
       "translation": "327e5666303665ad1a445f93a4bfd9890ea7678c"
     },
     "views.pomodoro.meta.running": {
-      "source": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
-      "translation": "2cc99f1f9007592abb0431b9e069641e5e2eca74"
+      "source": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
+      "translation": "dfef246292583c9b7ede6a00560124a893420823"
     },
     "views.pomodoro.meta.paused": {
       "source": "782cf2acb237b4450d523ab710518df4ff376d9d",
@@ -53709,8 +53709,8 @@
       "translation": "ec646a5c0990b1b7582b985ba6cb40c6c988f940"
     },
     "views.pomodoro.meta.running": {
-      "source": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
-      "translation": "103d24df6af5f3380558c47775d4280a781384a3"
+      "source": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
+      "translation": "ef4921326d32e9506b13201e1a402f2e2144e437"
     },
     "views.pomodoro.meta.paused": {
       "source": "782cf2acb237b4450d523ab710518df4ff376d9d",
@@ -62499,8 +62499,8 @@
       "translation": "d2163afa710658cd7f6adf70186537b457274853"
     },
     "views.pomodoro.meta.running": {
-      "source": "f1885aa4adca1b4282dcf023d4e9e3b91cf0f757",
-      "translation": "abb2c80301aa592a14ddd38481206b84035f22b5"
+      "source": "7c0265e6d539c3ed03013eac3d78b24c814cbd37",
+      "translation": "3c12cb7c4b71f4d68c0368f421b7bb44b7f95efd"
     },
     "views.pomodoro.meta.paused": {
       "source": "782cf2acb237b4450d523ab710518df4ff376d9d",

--- a/src/i18n/resources/de.ts
+++ b/src/i18n/resources/de.ts
@@ -360,7 +360,7 @@ export const de: TranslationTree = {
 			statsLabel: "heute abgeschlossen",
 			meta: {
 				ready: "{time} geplant · {count} heute abgeschlossen",
-				running: "{time} verbleibend",
+				running: "{time} verbleibend · Endet um {endTime}",
 				paused: "{type} pausiert · {time} verbleibend",
 				breakReady: "{type} bereit · {time} geplant"
 			},

--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -348,7 +348,7 @@ export const en: TranslationTree = {
 			},
 			meta: {
 				ready: "{time} planned · {count} completed today",
-				running: "{time} left",
+				running: "{time} left · Ends at {endTime}",
 				paused: "{type} paused · {time} left",
 				breakReady: "{type} ready · {time} planned",
 			},

--- a/src/i18n/resources/es.ts
+++ b/src/i18n/resources/es.ts
@@ -360,7 +360,7 @@ export const es: TranslationTree = {
 			statsLabel: "completadas hoy",
 			meta: {
 				ready: "{time} planificado · {count} completados hoy",
-				running: "Quedan {time}",
+				running: "Quedan {time} · Termina a las {endTime}",
 				paused: "{type} en pausa · quedan {time}",
 				breakReady: "{type} listo · {time} planificado"
 			},

--- a/src/i18n/resources/fr.ts
+++ b/src/i18n/resources/fr.ts
@@ -360,7 +360,7 @@ export const fr: TranslationTree = {
 			statsLabel: "terminées aujourd'hui",
 			meta: {
 				ready: "{time} prévu · {count} terminés aujourd’hui",
-				running: "{time} restant",
+				running: "{time} restant · Se termine à {endTime}",
 				paused: "{type} en pause · {time} restant",
 				breakReady: "{type} prêt · {time} prévu"
 			},

--- a/src/i18n/resources/ja.ts
+++ b/src/i18n/resources/ja.ts
@@ -360,7 +360,7 @@ export const ja: TranslationTree = {
 			statsLabel: "今日完了",
 			meta: {
 				ready: "{time} 予定 · 今日 {count} 完了",
-				running: "残り {time}",
+				running: "残り {time} · {endTime} に終了",
 				paused: "{type} 一時停止中 · 残り {time}",
 				breakReady: "{type} 準備完了 · {time} 予定"
 			},

--- a/src/i18n/resources/ko.ts
+++ b/src/i18n/resources/ko.ts
@@ -360,7 +360,7 @@ export const ko: TranslationTree = {
 			statsLabel: "오늘 완료",
 			meta: {
 				ready: "{time} 예정 · 오늘 {count}개 완료",
-				running: "{time} 남음",
+				running: "{time} 남음 · {endTime}에 종료",
 				paused: "{type} 일시 중지 · {time} 남음",
 				breakReady: "{type} 준비됨 · {time} 예정"
 			},

--- a/src/i18n/resources/pt.ts
+++ b/src/i18n/resources/pt.ts
@@ -360,7 +360,7 @@ export const pt: TranslationTree = {
 			statsLabel: "concluídos hoje",
 			meta: {
 				ready: "{time} planejado · {count} concluídos hoje",
-				running: "{time} restante",
+				running: "{time} restante · Termina às {endTime}",
 				paused: "{type} pausado · {time} restante",
 				breakReady: "{type} pronto · {time} planejado"
 			},

--- a/src/i18n/resources/ru.ts
+++ b/src/i18n/resources/ru.ts
@@ -360,7 +360,7 @@ export const ru: TranslationTree = {
 			statsLabel: "завершено сегодня",
 			meta: {
 				ready: "{time} запланировано · {count} завершено сегодня",
-				running: "Осталось {time}",
+				running: "Осталось {time} · Завершится в {endTime}",
 				paused: "{type} на паузе · осталось {time}",
 				breakReady: "{type} готово · {time} запланировано"
 			},

--- a/src/i18n/resources/zh.ts
+++ b/src/i18n/resources/zh.ts
@@ -360,7 +360,7 @@ export const zh: TranslationTree = {
 			statsLabel: "今日完成",
 			meta: {
 				ready: "已计划 {time} · 今天已完成 {count} 个",
-				running: "剩余 {time}",
+				running: "剩余 {time} · 将于 {endTime} 结束",
 				paused: "{type} 已暂停 · 剩余 {time}",
 				breakReady: "{type} 已就绪 · 已计划 {time}"
 			},

--- a/src/utils/pomodoroTime.ts
+++ b/src/utils/pomodoroTime.ts
@@ -76,6 +76,17 @@ export function getSessionCompletionTimeMs(
 	return null;
 }
 
+export function getProjectedPomodoroEndTimeMs(
+	secondsRemaining: number,
+	nowMs = Date.now()
+): number {
+	const remainingSeconds = Number.isFinite(secondsRemaining)
+		? Math.max(0, Math.floor(secondsRemaining))
+		: 0;
+
+	return nowMs + remainingSeconds * 1000;
+}
+
 export function formatLocalTimestamp(timestampMs: number): string {
 	const date = new Date(timestampMs);
 	const timezoneOffset = -date.getTimezoneOffset();

--- a/src/views/PomodoroView.ts
+++ b/src/views/PomodoroView.ts
@@ -13,11 +13,13 @@ import {
 } from "../types";
 import { openTaskSelector } from "../modals/TaskSelectorWithCreateModal";
 import { createTaskCard } from "../ui/TaskCard";
+import { formatTime } from "../utils/dateUtils";
 import { convertInternalToUserProperties } from "../utils/propertyMapping";
 import { getTaskWithInstanceStatus, isTaskInstanceCompleted } from "../utils/taskInstanceStatus";
 import {
 	formatPomodoroTime,
 	getActiveElapsedSeconds,
+	getProjectedPomodoroEndTimeMs,
 	getSessionProgressRatio,
 	parsePomodoroDurationInput,
 } from "../utils/pomodoroTime";
@@ -1170,6 +1172,10 @@ export class PomodoroView extends ItemView {
 			if (state.isRunning) {
 				text = this.t("views.pomodoro.meta.running", {
 					time: formattedTime,
+					endTime: formatTime(
+						new Date(getProjectedPomodoroEndTimeMs(state.timeRemaining)),
+						this.plugin.settings.calendarViewSettings.timeFormat
+					),
 				});
 			} else {
 				text = this.t("views.pomodoro.meta.paused", {

--- a/tests/unit/utils/pomodoroTime.test.ts
+++ b/tests/unit/utils/pomodoroTime.test.ts
@@ -1,6 +1,7 @@
 import {
 	formatPomodoroTime,
 	getActiveElapsedSeconds,
+	getProjectedPomodoroEndTimeMs,
 	getSessionCompletionTimeMs,
 	getSessionProgressRatio,
 	getSessionRemainingSeconds,
@@ -77,5 +78,15 @@ describe("pomodoroTime", () => {
 		expect(getSessionCompletionTimeMs(current, lateWake)).toBe(
 			Date.parse("2026-05-16T09:25:00.000Z")
 		);
+	});
+
+	it("projects the visible Pomodoro end time from remaining seconds", () => {
+		const now = Date.parse("2026-06-08T14:10:30.000Z");
+
+		expect(getProjectedPomodoroEndTimeMs(15 * 60 + 30, now)).toBe(
+			Date.parse("2026-06-08T14:26:00.000Z")
+		);
+		expect(getProjectedPomodoroEndTimeMs(-1, now)).toBe(now);
+		expect(getProjectedPomodoroEndTimeMs(Number.NaN, now)).toBe(now);
 	});
 });


### PR DESCRIPTION
## Summary

- display the projected local finish time while a Pomodoro is running
- derive the finish time from the existing in-memory remaining duration without persisting new metadata
- respect the configured 12- or 24-hour time format and update translations

Closes #2006

## Testing

- `npm test -- --runInBand tests/unit/utils/pomodoroTime.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run build:test`
- `npm run i18n:verify`
- `npm run i18n:check-usage`
- `npm test -- --runInBand` completed with 612 suites passing and 11 existing suites failing; the same 21 failures reproduce on untouched `upstream/main` in this environment

Obsidian CLI runtime reload was not available because no vault named `test` is registered on this machine.