### PR TITLE
fix(bases): parse generated normalized relationship filter for task defaults (#2043)

### DIFF
--- a/src/bases/basesFilterDefaults.ts
+++ b/src/bases/basesFilterDefaults.ts
@@ -116,6 +116,23 @@ function applyFilterRuleDefault(
 		return;
 	}
 
+	// Generated relationship views (e.g. the default Subtasks tab) normalize each
+	// link before comparing, producing a rule such as:
+	//   file.hasLink(this.file) && list(note.projects).map(...).contains(this.file.asLink())
+	// The generic matcher below cannot reduce that prefix to a field name, so detect
+	// the normalized list/map form explicitly and recover the wrapped property.
+	const mappedListContainsCurrentFileMatch = trimmedRule.match(
+		/(?:^|&&\s*)(list\((?:note\.|task\.)?[\w-]+\))\.map\([\s\S]*\)\.contains\(this\.file\.asLink\(\)\)$/
+	);
+	if (mappedListContainsCurrentFileMatch) {
+		const property = normalizeFilterProperty(mappedListContainsCurrentFileMatch[1], options);
+		const currentFileLink = resolveCurrentFileLink(options.currentFileLink);
+		if (property && currentFileLink) {
+			addFrontmatterDefault(defaults, property, currentFileLink, options.fieldMapper);
+		}
+		return;
+	}
+
 	const currentFileContainsMatch = trimmedRule.match(
 		/^(.+?)\.contains\(this\.file\.asLink\(\)\)$/
 	);

--- a/tests/unit/bases/basesFilterDefaults.test.ts
+++ b/tests/unit/bases/basesFilterDefaults.test.ts
@@ -124,4 +124,51 @@ describe("Bases filter defaults", () => {
 
 		expect(defaults).toEqual({});
 	});
+
+	it("extracts the project default from the generated normalized relationship filter", () => {
+		// This is the filter the default Subtasks relationship view generates.
+		const generatedSubtasksFilter =
+			'file.hasLink(this.file) && list(note.projects).map(file(value.replace(/^\\[[^\\]]+\\]\\((.*)\\)$/, "$1").replace(/%20/g, " ")).asLink()).contains(this.file.asLink())';
+
+		const defaults = extractBasesFilterDefaults({
+			config: {
+				query: {
+					filters: {
+						conjunction: "and",
+						filters: [
+							{ rule: { text: 'file.hasTag("task")' } },
+							{ rule: { text: generatedSubtasksFilter } },
+						],
+					},
+				},
+			},
+			fieldMapper: createFieldMapper(),
+			taskTag: "task",
+			currentFileLink: "[[Current]]",
+		});
+
+		expect(defaults).toEqual({
+			projects: ["[[Current]]"],
+		});
+	});
+
+	it("honors field mapping for the generated normalized relationship filter", () => {
+		const generatedSubtasksFilter =
+			'file.hasLink(this.file) && list(note.projectLinks).map(file(value.replace(/^\\[[^\\]]+\\]\\((.*)\\)$/, "$1").replace(/%20/g, " ")).asLink()).contains(this.file.asLink())';
+
+		const defaults = extractBasesFilterDefaults({
+			config: {
+				filters: {
+					rule: { text: generatedSubtasksFilter },
+				},
+			},
+			fieldMapper: createFieldMapper({ projects: "projectLinks" }),
+			taskTag: "task",
+			currentFileLink: "[[Current]]",
+		});
+
+		expect(defaults).toEqual({
+			projectLinks: ["[[Current]]"],
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Fixes the default Subtasks "+" button not assigning the current project (see #2043). This is a follow-up to #1657: the filter-defaults parser added in 4.8.0 handles simple user-authored filters, but not the more complex filter that TaskNotes generates by default for relationship views.

## Problem

Creating a task via the column "+" button derives the new task's frontmatter from the view filter through `extractBasesFilterDefaults`. The default Subtasks relationship view (generated in `src/templates/defaultBasesFiles.ts`) normalizes each project link before comparing, producing:

```
file.hasLink(this.file) && list(note.projects).map(file(value.replace(/^\[[^\]]+\]\((.*)\)$/, "$1").replace(/%20/g, " ")).asLink()).contains(this.file.asLink())
```

`normalizeFilterProperty` cannot reduce that prefix to the field name `projects`, so it returns `null`, no `projects` default is applied, and the created task immediately drops out of the view.

## Change

`applyFilterRuleDefault` now detects the normalized `list(note.PROP).map(...).contains(this.file.asLink())` form (with an optional `... && ` prefix) and recovers the wrapped property via the existing `normalizeFilterProperty` (which already unwraps `list(...)` and `note.`/`task.`). The current note link is then pre-filled as the project, so the new task stays in the view.

The change is targeted: it only triggers on the `list(...).map(...).contains(this.file.asLink())` shape and falls through to the existing generic matcher otherwise. Field mapping is respected (the property is resolved through `fieldMapper`).

## Tests

Added two regression tests in `tests/unit/bases/basesFilterDefaults.test.ts`:
- extracts `projects` from the exact generated Subtasks filter;
- honors a custom `projects` field mapping for the same shape.

`npx jest tests/unit/bases/` passes (39 suites, 232 tests). Pre-existing typecheck errors about a build-generated `../releaseNotes` module are unrelated to this change.
