### PR TITLE
fix(date-time-picker): focus natural language input first when enabled (issue #2046)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -59,3 +59,6 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 - (#2040, #2041) Stopped newly created tasks from filling the Google Calendar
   retry queue when calendar export is disabled. Thanks to @chmac for reporting
   and fixing this.
+- (#2046, #2051) The date and time picker now focuses the natural-language input
+  when it is enabled, making keyboard-driven quick actions ready for immediate
+  typing. Thanks to @DevOps-Toast for reporting this and @ther12k for fixing it.

--- a/src/modals/DateTimePickerModal.ts
+++ b/src/modals/DateTimePickerModal.ts
@@ -122,7 +122,14 @@ export class DateTimePickerModal extends Modal {
 		this.updateSelectButtonState();
 
 		window.setTimeout(() => {
-			this.dateInput?.focus();
+			// Prefer the natural language input when it is enabled and rendered,
+			// so keyboard users land on the NLP box first (matches user expectation
+			// from Quick Actions). Fall back to the date input otherwise.
+			if (this.canUseNaturalLanguageInput() && this.naturalLanguageInput) {
+				this.naturalLanguageInput.focus();
+			} else {
+				this.dateInput?.focus();
+			}
 		}, 100);
 	}
 

--- a/tests/unit/issues/issue-2046-nlp-input-autofocus.test.ts
+++ b/tests/unit/issues/issue-2046-nlp-input-autofocus.test.ts
@@ -1,0 +1,117 @@
+import { DateTimePickerModal } from "../../../src/modals/DateTimePickerModal";
+import type TaskNotesPlugin from "../../../src/main";
+
+/**
+ * Regression test for issue #2046:
+ * "Quick Actions for Task Under Cursor 'Set due date' autofocuses incorrectly"
+ *
+ * Expected behavior:
+ *   When the user opens the date/time picker from Quick Actions (or any
+ *   keyboard-driven path) and natural language input is enabled, the
+ *   natural language input should receive initial focus — NOT the date
+ *   input. When NLP is disabled, fall back to the date input.
+ */
+
+function makeNLPEnabledPlugin(): TaskNotesPlugin {
+	return {
+		settings: { enableNaturalLanguageInput: true },
+	} as unknown as TaskNotesPlugin;
+}
+
+describe("Issue #2046: DateTimePickerModal focuses natural language input first when enabled", () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it("focuses the natural language input when NLP is enabled and rendered", () => {
+		const onSelect = jest.fn();
+		const plugin = makeNLPEnabledPlugin();
+
+		const modal = new DateTimePickerModal({} as any, {
+			currentDate: null,
+			onSelect,
+			plugin,
+		});
+
+		modal.open();
+
+		const nlpInput = modal.contentEl.querySelector<HTMLInputElement>(
+			"input.date-time-picker-modal__nlp-input"
+		);
+		const dateInput = modal.contentEl.querySelector<HTMLInputElement>(
+			'input[type="date"].date-time-picker-modal__date-input'
+		);
+		expect(nlpInput).toBeTruthy();
+		expect(dateInput).toBeTruthy();
+
+		const nlpFocus = jest.spyOn(nlpInput!, "focus");
+		const dateFocus = jest.spyOn(dateInput!, "focus");
+
+		jest.advanceTimersByTime(150);
+
+		expect(nlpFocus).toHaveBeenCalled();
+		expect(dateFocus).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the date input when NLP is disabled", () => {
+		const onSelect = jest.fn();
+		const plugin = {
+			settings: { enableNaturalLanguageInput: false },
+		} as unknown as TaskNotesPlugin;
+
+		const modal = new DateTimePickerModal({} as any, {
+			currentDate: null,
+			onSelect,
+			plugin,
+		});
+
+		modal.open();
+
+		const nlpInput = modal.contentEl.querySelector<HTMLInputElement>(
+			"input.date-time-picker-modal__nlp-input"
+		);
+		const dateInput = modal.contentEl.querySelector<HTMLInputElement>(
+			'input[type="date"].date-time-picker-modal__date-input'
+		);
+		expect(nlpInput).toBeFalsy();
+		expect(dateInput).toBeTruthy();
+
+		const dateFocus = jest.spyOn(dateInput!, "focus");
+
+		jest.advanceTimersByTime(150);
+
+		expect(dateFocus).toHaveBeenCalled();
+	});
+
+	it("does not throw if NLP is enabled but the input ref is not assigned", () => {
+		// Defensive: if the render pipeline ever changes and the ref is not
+		// assigned, focus should still fall back to the date input rather than
+		// crashing the modal.
+		const onSelect = jest.fn();
+		const plugin = makeNLPEnabledPlugin();
+
+		const modal = new DateTimePickerModal({} as any, {
+			currentDate: null,
+			onSelect,
+			plugin,
+		});
+
+		modal.open();
+
+		(
+			modal as unknown as { naturalLanguageInput: HTMLInputElement | null }
+		).naturalLanguageInput = null;
+
+		const dateInput = modal.contentEl.querySelector<HTMLInputElement>(
+			'input[type="date"].date-time-picker-modal__date-input'
+		);
+		const dateFocus = jest.spyOn(dateInput!, "focus");
+
+		expect(() => jest.advanceTimersByTime(150)).not.toThrow();
+		expect(dateFocus).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

When opening the date/time picker from **Quick Actions** (or any keyboard-driven path), the date input was always receiving initial focus, even when the user had natural language input enabled in settings. This is jarring because the NLP box is the more discoverable entry point when it is rendered.

## Changes

- `src/modals/DateTimePickerModal.ts`: in `onOpen()`, prefer `naturalLanguageInput.focus()` when `canUseNaturalLanguageInput()` returns true and the element has been rendered. Fall back to the existing `dateInput.focus()` behavior otherwise, preserving the previous UX for users with NLP disabled.

## Tests

Adds `tests/unit/issues/issue-2046-nlp-input-autofocus.test.ts` covering three cases:

- NLP enabled → NLP input receives focus, date input does not
- NLP disabled → date input receives focus, NLP input not rendered
- Defensive: NLP enabled but ref missing → date input still receives focus (no throw)

All three pass. `npx tsc -noEmit --skipLibCheck` clean. `jest tests/unit/issues` all pass.

## Verification

```bash
npm install
node generate-release-notes-import.mjs
npx tsc -noEmit --skipLibCheck
npx jest tests/unit/issues/issue-2046-nlp-input-autofocus.test.ts --no-coverage
```

## Closes

Fixes #2046