### PR TITLE
fix(reminder-modal): make the relative/absolute tab toggle switch fields

### DIFF
--- a/styles/reminder-modal.css
+++ b/styles/reminder-modal.css
@@ -325,6 +325,22 @@ body.is-mobile .tasknotes-plugin .reminder-modal__action-btn svg {
     display: none;
 }
 
+/* The relative/absolute tab toggle (ReminderModal.updateFormVisibility) switches
+   fields by adding the generic .tn-static-display-{none,block} utility classes.
+   Those are single-class (0-1-0) and lose to the scoped base rules above
+   (.tasknotes-plugin .{relative,absolute}-fields, 0-2-0), so without these
+   overrides the toggle has no effect and the Absolute tab appears to do nothing.
+   Scope the toggle to these containers so it wins, keeping flex layout when shown. */
+.tasknotes-plugin .relative-fields.tn-static-display-none-6b99de8b,
+.tasknotes-plugin .absolute-fields.tn-static-display-none-6b99de8b {
+    display: none;
+}
+
+.tasknotes-plugin .relative-fields.tn-static-display-block-2a1b75c9,
+.tasknotes-plugin .absolute-fields.tn-static-display-block-2a1b75c9 {
+    display: flex;
+}
+
 /* Form controls - Match Task Modal Details Section */
 .tasknotes-plugin .reminder-modal__form .setting-item {
     padding: var(--size-4-2) 0;


### PR DESCRIPTION
## What

Fixes the **Absolute** tab in the reminder modal doing nothing — absolute
reminders couldn't be created from the UI. Closes #2079.

## Why

`ReminderModal.updateFormVisibility()` switches the visible field group by adding
the generic `.tn-static-display-none-…` / `.tn-static-display-block-…` utility
classes. Those have single-class specificity (0-1-0), but the container base rules
in `styles/reminder-modal.css` are `.tasknotes-plugin .{relative,absolute}-fields`
(0-2-0) and include `display: flex` / `display: none`. The base rules win, so the
JS toggle has no visible effect.

## How

Add scoped overrides so the toggle classes win on these two containers, and use
`display: flex` for the shown state to preserve the existing flex-column layout
(plain `block` would drop the `gap` spacing). CSS-only; no behavior/logic change.

## Test plan

- Reproduced on 4.11.0: Absolute tab does nothing.
- With this change: open a task → add reminder → toggle Relative ⇄ Absolute,
  fields now switch correctly.
- Add an absolute reminder (date + time) → saved with `type: absolute`.
- Relative path unchanged; default (Relative) still shown on open.

## Note for maintainer

This references the generated `tn-static-display-*` class names directly, matching
how `ReminderModal.ts` already uses them. If you'd prefer not to depend on the
generated hashes, an alternative is a small semantic state class toggled in the
component instead — happy to switch to that approach if you'd rather.
