### PR TITLE
Fix Google Calendar Obsidian link escaping

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -31,3 +31,8 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 ```
 
 -->
+
+## Fixed
+
+- Fixed Obsidian links in Google Calendar event descriptions so the note path survives HTML entity handling.
+  - Thanks to @martin-forge for reporting and fixing.

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -1741,11 +1741,11 @@ export class TaskCalendarSyncService {
 			parts.push("---");
 		}
 
-		// Add Obsidian link (as HTML anchor for clickability in Google Calendar)
+		// Google Calendar descriptions are HTML-capable, so keep the plain URL HTML-safe.
 		if (settings.includeObsidianLink) {
 			const vaultName = this.plugin.app.vault.getName();
 			const encodedPath = encodeURIComponent(task.path);
-			const obsidianUri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodedPath}`;
+			const obsidianUri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&amp;file=${encodedPath}`;
 			const linkText = t("openInObsidian");
 			parts.push(`${linkText}: ${obsidianUri}`);
 		}

--- a/tests/services/TaskCalendarSyncService.test.ts
+++ b/tests/services/TaskCalendarSyncService.test.ts
@@ -149,8 +149,9 @@ describe("TaskCalendarSyncService", () => {
             "Projects: Quarterly Planning, Nested Project, Markdown Project"
         );
         expect(description).toContain(
-            "Open in Obsidian: obsidian://open?vault=Example%20Vault&file=Tasks%2FPrepare%20quarterly%20planning%20notes.md"
+            "Open in Obsidian: obsidian://open?vault=Example%20Vault&amp;file=Tasks%2FPrepare%20quarterly%20planning%20notes.md"
         );
+        expect(description).not.toContain("&file=");
         expect(description).not.toContain("[[");
         expect(description).not.toContain("]]");
         expect(description).not.toContain("<a ");


### PR DESCRIPTION
## Summary
- Escape the Obsidian URI query separator in Google Calendar sync descriptions as `&amp;file=`.
- Keep the link plain text and update the focused service test plus release note.

## Why
Google Calendar descriptions are HTML-capable. Leaving the raw `&file=` separator in the description can be handled as an HTML entity boundary by Calendar clients, which breaks the Obsidian open link path parameter.

## Testing
- `npm test -- --runTestsByPath tests/services/TaskCalendarSyncService.test.ts`
- `npm run build:test`
- `npm run lint`
- Upstream CI passed: docs, test (20), and build-test.