### PR TITLE
Feature: JIRA issue import

### DIFF
--- a/src/commands/jiraImportCommand.ts
+++ b/src/commands/jiraImportCommand.ts
@@ -1,0 +1,50 @@
+import { Notice } from "obsidian";
+import type TaskNotesPlugin from "../main";
+import { JiraIssueAdapter } from "../integrations/jira/JiraIssueAdapter";
+import { showTextInputModal } from "../modals/TextInputModal";
+import { JiraImportError, JiraImportService } from "../services/JiraImportService";
+import { createTaskNotesLogger } from "../utils/tasknotesLogger";
+
+const tasknotesLogger = createTaskNotesLogger({ tag: "Commands/JiraImport" });
+
+export async function executeJiraImportCommand(plugin: TaskNotesPlugin): Promise<void> {
+	const issueKey = await showTextInputModal(plugin.app, {
+		title: plugin.i18n.translate("commands.importJiraIssue"),
+		placeholder: plugin.i18n.translate("commands.jiraIssueKeyPlaceholder"),
+		confirmText: plugin.i18n.translate("commands.jiraImportButton"),
+		cancelText: plugin.i18n.translate("common.cancel"),
+	});
+	if (!issueKey) return;
+
+	const service = new JiraImportService(
+		JiraIssueAdapter.fromApp(plugin.app),
+		plugin.taskService
+	);
+
+	try {
+		const task = await service.importIssue(issueKey);
+		new Notice(
+			plugin.i18n.translate("commands.jiraImportSuccess", {
+				title: task.title,
+			})
+		);
+	} catch (error) {
+		tasknotesLogger.error("Failed to import Jira issue", {
+			category: "provider",
+			operation: "importing-jira-issue",
+			error,
+		});
+
+		const noticeKey =
+			error instanceof JiraImportError
+				? {
+						"invalid-issue-key": "commands.jiraImportInvalidKey",
+						"dependency-unavailable": "commands.jiraImportMissingPlugin",
+						"fetch-failed": "commands.jiraImportFetchFailed",
+						"creation-failed": "commands.jiraImportCreationFailed",
+					}[error.code]
+				: "commands.jiraImportFetchFailed";
+		new Notice(plugin.i18n.translate(noticeKey));
+	}
+}
+

--- a/src/commands/jiraImportCommand.ts
+++ b/src/commands/jiraImportCommand.ts
@@ -18,7 +18,9 @@ export async function executeJiraImportCommand(plugin: TaskNotesPlugin): Promise
 
 	const service = new JiraImportService(
 		JiraIssueAdapter.fromApp(plugin.app),
-		plugin.taskService
+		plugin.taskService,
+		plugin.settings.jiraMapping,
+		plugin.settings.userFields ?? []
 	);
 
 	try {
@@ -47,4 +49,3 @@ export async function executeJiraImportCommand(plugin: TaskNotesPlugin): Promise
 		new Notice(plugin.i18n.translate(noticeKey));
 	}
 }
-

--- a/src/commands/jiraImportCommand.ts
+++ b/src/commands/jiraImportCommand.ts
@@ -20,7 +20,9 @@ export async function executeJiraImportCommand(plugin: TaskNotesPlugin): Promise
 		JiraIssueAdapter.fromApp(plugin.app),
 		plugin.taskService,
 		plugin.settings.jiraMapping,
-		plugin.settings.userFields ?? []
+		plugin.settings.userFields ?? [],
+		(taskData) =>
+			plugin.applyParentNoteProjectDefault(taskData, "task-creation") ?? taskData
 	);
 
 	try {

--- a/src/commands/taskNotesCommands.ts
+++ b/src/commands/taskNotesCommands.ts
@@ -3,6 +3,7 @@ import type TaskNotesPlugin from "../main";
 import type { TranslatedCommandDefinition } from "./types";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
 import { showConfirmationModal } from "../modals/ConfirmationModal";
+import { executeJiraImportCommand } from "./jiraImportCommand";
 
 const tasknotesLogger = createTaskNotesLogger({ tag: "Commands/TaskNotesCommands" });
 
@@ -95,6 +96,13 @@ export function createTaskNotesCommandDefinitions(
 			nameKey: "commands.createNewTask",
 			callback: (ctx) => {
 				ctx.openTaskCreationModal();
+			},
+		},
+		{
+			id: "import-jira-issue",
+			nameKey: "commands.importJiraIssue",
+			callback: async (ctx) => {
+				await executeJiraImportCommand(ctx);
 			},
 		},
 		{

--- a/src/i18n/resources/de.ts
+++ b/src/i18n/resources/de.ts
@@ -2238,6 +2238,16 @@ export const de: TranslationTree = {
 		openPomodoroStats: "Pomodoro-Statistiken öffnen",
 		openStatisticsView: "Aufgaben- & Projektstatistiken öffnen",
 		createNewTask: "Neue Aufgabe erstellen",
+		importJiraIssue: "Jira-Vorgang importieren",
+		jiraIssueKeyPlaceholder: "Vorgangsschlüssel, zum Beispiel PROJ-123",
+		jiraImportButton: "Importieren",
+		jiraImportMissingPlugin:
+			"Das Plugin obsidian-jira-issue ist nicht installiert, aktiviert oder kompatibel.",
+		jiraImportInvalidKey: "Gib einen gültigen Jira-Vorgangsschlüssel wie PROJ-123 ein.",
+		jiraImportFetchFailed: "Der Jira-Vorgang konnte nicht abgerufen werden.",
+		jiraImportCreationFailed:
+			"Der Jira-Vorgang wurde abgerufen, aber die Aufgabe konnte nicht erstellt werden.",
+		jiraImportSuccess: 'Aufgabe „{title}“ erstellt.',
 		convertCurrentNoteToTask: {
 			name: "Aktuelle Notiz in Aufgabe umwandeln",
 			noActiveFile: "Keine aktive Datei zum Umwandeln",

--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -1708,6 +1708,23 @@ export const en: TranslationTree = {
 			},
 		},
 		integrations: {
+			/* eslint-disable obsidianmd/ui/sentence-case-locale-module -- Jira and TaskNotes product names require canonical casing. */
+			jiraMapping: {
+				header: "Jira field mapping",
+				description:
+					"Choose how Jira values become TaskNotes properties. Paths read Jira JSON, templates interpolate $path tokens, and fixed values always apply the same value.",
+				reset: "Reset mappings",
+				sourcesHeader: "Property sources",
+				sourcesDescription:
+					"List properties can merge multiple sources. Time estimates are interpreted as Jira seconds and stored as TaskNotes minutes.",
+				userFieldsHeader: "User fields",
+				userFieldsDescription:
+					"Mappings use stable user-field IDs and continue working if their frontmatter keys are renamed.",
+				remapsHeader: "Value remapping",
+				remapsDescription:
+					"Translate Jira status, priority, and context names to the values configured in TaskNotes.",
+			},
+			/* eslint-enable obsidianmd/ui/sentence-case-locale-module -- End product-name-specific strings. */
 			mobileCalendar: {
 				disable: {
 					name: "Disable calendar integrations on mobile",

--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -2393,6 +2393,17 @@ export const en: TranslationTree = {
 		openPomodoroStats: "Open Pomodoro statistics",
 		openStatisticsView: "Open task & project statistics",
 		createNewTask: "Create new task",
+		/* eslint-disable obsidianmd/ui/sentence-case-locale-module -- Jira branding and example issue keys require canonical casing. */
+		importJiraIssue: "Import Jira issue",
+		jiraIssueKeyPlaceholder: "Issue key, for example PROJ-123",
+		jiraImportButton: "Import",
+		jiraImportMissingPlugin:
+			"The obsidian-jira-issue plugin is not installed, enabled, or compatible.",
+		jiraImportInvalidKey: "Enter a valid Jira issue key, such as PROJ-123.",
+		jiraImportFetchFailed: "Could not fetch that Jira issue.",
+		jiraImportCreationFailed: "The Jira issue was fetched, but the task could not be created.",
+		jiraImportSuccess: 'Created task "{title}".',
+		/* eslint-enable obsidianmd/ui/sentence-case-locale-module -- End Jira-specific canonical casing. */
 		convertCurrentNoteToTask: {
 			name: "Convert current note to task",
 			noActiveFile: "No active file to convert",

--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -1723,6 +1723,25 @@ export const en: TranslationTree = {
 				remapsHeader: "Value remapping",
 				remapsDescription:
 					"Translate Jira status, priority, and context names to the values configured in TaskNotes.",
+				preview: {
+					sampleIssue: "Sample issue",
+					sampleIssueDescription:
+						"Fetch an issue to preview the current mappings. The issue and key are not saved.",
+					issueKey: "Sample Jira issue key",
+					issueKeyPlaceholder: "PROJ-123",
+					fetch: "Fetch preview",
+					loading: "Loading…",
+					unknownError: "The Jira issue could not be loaded.",
+					resolvedValues: "Resolved values",
+					resolvedValuesDescription:
+						"These are the TaskNotes values produced by the current mappings.",
+					missing: "Not set",
+					invalid: "Invalid value",
+					rawJson: "Raw Jira issue JSON",
+					rawJsonDescription:
+						"Collapsed by default because Jira issues can contain sensitive information.",
+					truncated: "The raw JSON preview was truncated to keep settings responsive.",
+				},
 			},
 			/* eslint-enable obsidianmd/ui/sentence-case-locale-module -- End product-name-specific strings. */
 			mobileCalendar: {

--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -1740,6 +1740,9 @@ export const en: TranslationTree = {
 					rawJson: "Raw Jira issue JSON",
 					rawJsonDescription:
 						"Collapsed by default because Jira issues can contain sensitive information.",
+					copyRawJson: "Copy raw Jira issue JSON",
+					copySuccess: "Raw Jira issue JSON copied to clipboard",
+					copyFailure: "Failed to copy raw Jira issue JSON",
 					truncated: "The raw JSON preview was truncated to keep settings responsive.",
 				},
 			},

--- a/src/i18n/resources/es.ts
+++ b/src/i18n/resources/es.ts
@@ -2238,6 +2238,16 @@ export const es: TranslationTree = {
 		openPomodoroStats: "Abrir estadísticas de pomodoro",
 		openStatisticsView: "Abrir estadísticas de tareas y proyectos",
 		createNewTask: "Crear nueva tarea",
+		importJiraIssue: "Importar incidencia de Jira",
+		jiraIssueKeyPlaceholder: "Clave de incidencia, por ejemplo PROJ-123",
+		jiraImportButton: "Importar",
+		jiraImportMissingPlugin:
+			"El complemento obsidian-jira-issue no está instalado, activado o es incompatible.",
+		jiraImportInvalidKey: "Introduce una clave de Jira válida, como PROJ-123.",
+		jiraImportFetchFailed: "No se pudo obtener esa incidencia de Jira.",
+		jiraImportCreationFailed:
+			"Se obtuvo la incidencia de Jira, pero no se pudo crear la tarea.",
+		jiraImportSuccess: 'Se creó la tarea «{title}».',
 		convertCurrentNoteToTask: {
 			name: "Convertir nota actual en tarea",
 			noActiveFile: "No hay archivo activo para convertir",

--- a/src/i18n/resources/fr.ts
+++ b/src/i18n/resources/fr.ts
@@ -2238,6 +2238,16 @@ export const fr: TranslationTree = {
 		openPomodoroStats: "Ouvrir les statistiques Pomodoro",
 		openStatisticsView: "Ouvrir les statistiques tâches & projets",
 		createNewTask: "Créer une nouvelle tâche",
+		importJiraIssue: "Importer un ticket Jira",
+		jiraIssueKeyPlaceholder: "Clé du ticket, par exemple PROJ-123",
+		jiraImportButton: "Importer",
+		jiraImportMissingPlugin:
+			"Le module obsidian-jira-issue n’est pas installé, activé ou compatible.",
+		jiraImportInvalidKey: "Saisissez une clé Jira valide, comme PROJ-123.",
+		jiraImportFetchFailed: "Impossible de récupérer ce ticket Jira.",
+		jiraImportCreationFailed:
+			"Le ticket Jira a été récupéré, mais la tâche n’a pas pu être créée.",
+		jiraImportSuccess: 'Tâche « {title} » créée.',
 		convertCurrentNoteToTask: {
 			name: "Convertir la note actuelle en tâche",
 			noActiveFile: "Aucun fichier actif à convertir",

--- a/src/i18n/resources/ja.ts
+++ b/src/i18n/resources/ja.ts
@@ -2238,6 +2238,16 @@ export const ja: TranslationTree = {
 		openPomodoroStats: "ポモドーロ統計を開く",
 		openStatisticsView: "タスクとプロジェクト統計を開く",
 		createNewTask: "新しいタスクを作成",
+		importJiraIssue: "Jira 課題をインポート",
+		jiraIssueKeyPlaceholder: "課題キー（例: PROJ-123）",
+		jiraImportButton: "インポート",
+		jiraImportMissingPlugin:
+			"obsidian-jira-issue プラグインがインストール、有効化、または互換性のある状態ではありません。",
+		jiraImportInvalidKey: "PROJ-123 のような有効な Jira 課題キーを入力してください。",
+		jiraImportFetchFailed: "Jira 課題を取得できませんでした。",
+		jiraImportCreationFailed:
+			"Jira 課題は取得できましたが、タスクを作成できませんでした。",
+		jiraImportSuccess: "タスク「{title}」を作成しました。",
 		convertCurrentNoteToTask: {
 			name: "現在のノートをタスクに変換",
 			noActiveFile: "変換するアクティブなファイルがありません",

--- a/src/i18n/resources/ko.ts
+++ b/src/i18n/resources/ko.ts
@@ -2222,6 +2222,16 @@ export const ko: TranslationTree = {
 		openPomodoroStats: "뽀모도로 통계 열기",
 		openStatisticsView: "작업 및 프로젝트 통계 열기",
 		createNewTask: "새 작업 만들기",
+		importJiraIssue: "Jira 이슈 가져오기",
+		jiraIssueKeyPlaceholder: "이슈 키(예: PROJ-123)",
+		jiraImportButton: "가져오기",
+		jiraImportMissingPlugin:
+			"obsidian-jira-issue 플러그인이 설치 또는 활성화되지 않았거나 호환되지 않습니다.",
+		jiraImportInvalidKey: "PROJ-123과 같은 올바른 Jira 이슈 키를 입력하세요.",
+		jiraImportFetchFailed: "Jira 이슈를 가져올 수 없습니다.",
+		jiraImportCreationFailed:
+			"Jira 이슈를 가져왔지만 작업을 만들 수 없습니다.",
+		jiraImportSuccess: "작업 “{title}”을 만들었습니다.",
 		convertCurrentNoteToTask: {
 			name: "현재 노트를 작업으로 변환",
 			noActiveFile: "변환할 활성 파일이 없습니다",

--- a/src/i18n/resources/pt.ts
+++ b/src/i18n/resources/pt.ts
@@ -2240,6 +2240,16 @@ export const pt: TranslationTree = {
 		openPomodoroStats: "Abrir estatísticas pomodoro",
 		openStatisticsView: "Abrir estatísticas de tarefas e projetos",
 		createNewTask: "Criar nova tarefa",
+		importJiraIssue: "Importar item do Jira",
+		jiraIssueKeyPlaceholder: "Chave do item, por exemplo PROJ-123",
+		jiraImportButton: "Importar",
+		jiraImportMissingPlugin:
+			"O plugin obsidian-jira-issue não está instalado, ativado ou compatível.",
+		jiraImportInvalidKey: "Insira uma chave válida do Jira, como PROJ-123.",
+		jiraImportFetchFailed: "Não foi possível obter esse item do Jira.",
+		jiraImportCreationFailed:
+			"O item do Jira foi obtido, mas a tarefa não pôde ser criada.",
+		jiraImportSuccess: 'Tarefa "{title}" criada.',
 		convertCurrentNoteToTask: {
 			name: "Converter nota atual em tarefa",
 			noActiveFile: "Nenhum arquivo ativo para converter",

--- a/src/i18n/resources/ru.ts
+++ b/src/i18n/resources/ru.ts
@@ -2238,6 +2238,16 @@ export const ru: TranslationTree = {
 		openPomodoroStats: "Открыть статистику помодоро",
 		openStatisticsView: "Открыть статистику задач и проектов",
 		createNewTask: "Создать новую задачу",
+		importJiraIssue: "Импортировать задачу Jira",
+		jiraIssueKeyPlaceholder: "Ключ задачи, например PROJ-123",
+		jiraImportButton: "Импортировать",
+		jiraImportMissingPlugin:
+			"Плагин obsidian-jira-issue не установлен, не включён или несовместим.",
+		jiraImportInvalidKey: "Введите допустимый ключ Jira, например PROJ-123.",
+		jiraImportFetchFailed: "Не удалось получить задачу Jira.",
+		jiraImportCreationFailed:
+			"Задача Jira получена, но создать задачу TaskNotes не удалось.",
+		jiraImportSuccess: "Создана задача «{title}».",
 		convertCurrentNoteToTask: {
 			name: "Преобразовать текущую заметку в задачу",
 			noActiveFile: "Нет активного файла для преобразования",

--- a/src/i18n/resources/zh.ts
+++ b/src/i18n/resources/zh.ts
@@ -2238,6 +2238,16 @@ export const zh: TranslationTree = {
 		openPomodoroStats: "打开番茄钟统计",
 		openStatisticsView: "打开任务和项目统计",
 		createNewTask: "创建新任务",
+		importJiraIssue: "导入 Jira 问题",
+		jiraIssueKeyPlaceholder: "问题键，例如 PROJ-123",
+		jiraImportButton: "导入",
+		jiraImportMissingPlugin:
+			"obsidian-jira-issue 插件未安装、未启用或不兼容。",
+		jiraImportInvalidKey: "请输入有效的 Jira 问题键，例如 PROJ-123。",
+		jiraImportFetchFailed: "无法获取该 Jira 问题。",
+		jiraImportCreationFailed:
+			"已获取 Jira 问题，但无法创建任务。",
+		jiraImportSuccess: "已创建任务“{title}”。",
 		convertCurrentNoteToTask: {
 			name: "将当前笔记转换为任务",
 			noActiveFile: "没有可转换的活动文件",

--- a/src/integrations/jira/JiraFieldMapping.ts
+++ b/src/integrations/jira/JiraFieldMapping.ts
@@ -35,6 +35,13 @@ export interface JiraMappingTargetDefinition {
 	kind: "text" | "number" | "date" | "list";
 }
 
+export interface JiraMappingPreviewEntry {
+	id: string;
+	label: string;
+	status: "value" | "empty" | "missing" | "invalid";
+	value?: unknown;
+}
+
 export const JIRA_MAPPING_TARGETS: readonly JiraMappingTargetDefinition[] = [
 	{ id: "id", kind: "text" },
 	{ id: "title", kind: "text" },
@@ -411,4 +418,70 @@ export function mapJiraIssueWithSettings(
 	if (Object.keys(customFrontmatter).length) output.customFrontmatter = customFrontmatter;
 
 	return output;
+}
+
+/**
+ * Resolves every configured destination through the production mapper while retaining
+ * enough source information for the settings UI to distinguish empty and invalid values.
+ */
+export function buildJiraMappingPreview(
+	issue: JiraIssue,
+	settings: JiraFieldMappingSettings,
+	userFields: readonly UserMappedField[]
+): JiraMappingPreviewEntry[] {
+	const config = normalizeJiraMappingSettings(settings);
+	const mapped = mapJiraIssueWithSettings(issue, config, userFields);
+	const mappedFields = mapped as unknown as Record<string, unknown>;
+	const entries: JiraMappingPreviewEntry[] = [];
+
+	for (const target of JIRA_MAPPING_TARGETS) {
+		const sources = config.fields[target.id] ?? [];
+		const resolvedSources = sources
+			.map((source) => readSource(source, issue))
+			.filter((value) => value !== undefined && value !== null && value !== "");
+		const value = mappedFields[target.id];
+
+		if (value !== undefined) {
+			entries.push({
+				id: target.id,
+				label: target.id,
+				status: Array.isArray(value) && value.length === 0 ? "empty" : "value",
+				value,
+			});
+		} else if (target.kind === "list" && resolvedSources.length > 0) {
+			entries.push({ id: target.id, label: target.id, status: "empty", value: [] });
+		} else {
+			entries.push({
+				id: target.id,
+				label: target.id,
+				status: resolvedSources.length > 0 ? "invalid" : "missing",
+			});
+		}
+	}
+
+	for (const field of userFields) {
+		const sources = config.userFields[field.id] ?? [];
+		const resolvedSources = sources
+			.map((source) => readSource(source, issue))
+			.filter((value) => value !== undefined && value !== null && value !== "");
+		const value = mapped.customFrontmatter?.[field.key];
+		if (value !== undefined) {
+			entries.push({
+				id: field.id,
+				label: field.displayName,
+				status: Array.isArray(value) && value.length === 0 ? "empty" : "value",
+				value,
+			});
+		} else if (field.type === "list" && resolvedSources.length > 0) {
+			entries.push({ id: field.id, label: field.displayName, status: "empty", value: [] });
+		} else {
+			entries.push({
+				id: field.id,
+				label: field.displayName,
+				status: resolvedSources.length > 0 ? "invalid" : "missing",
+			});
+		}
+	}
+
+	return entries;
 }

--- a/src/integrations/jira/JiraFieldMapping.ts
+++ b/src/integrations/jira/JiraFieldMapping.ts
@@ -1,0 +1,414 @@
+import type { TaskCreationData } from "../../types";
+import type {
+	JiraBuiltInFieldId,
+	JiraEnumRemap,
+	JiraFieldMappingSettings,
+	JiraValueSource,
+	JiraValueSourceMode,
+	UserMappedField,
+} from "../../types/settings";
+import type { JiraIssue } from "./JiraIssueAdapter";
+
+const UNSAFE_PATH_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
+const SOURCE_MODES = new Set<JiraValueSourceMode>(["path", "template", "fixed", "off"]);
+const LIST_FIELDS = new Set<JiraBuiltInFieldId>(["tags", "projects", "contexts"]);
+const BUILT_IN_FIELDS: JiraBuiltInFieldId[] = [
+	"id",
+	"title",
+	"details",
+	"status",
+	"priority",
+	"due",
+	"scheduled",
+	"timeEstimate",
+	"dateCreated",
+	"dateModified",
+	"completedDate",
+	"recurrence",
+	"tags",
+	"projects",
+	"contexts",
+];
+
+export interface JiraMappingTargetDefinition {
+	id: JiraBuiltInFieldId;
+	kind: "text" | "number" | "date" | "list";
+}
+
+export const JIRA_MAPPING_TARGETS: readonly JiraMappingTargetDefinition[] = [
+	{ id: "id", kind: "text" },
+	{ id: "title", kind: "text" },
+	{ id: "details", kind: "text" },
+	{ id: "status", kind: "text" },
+	{ id: "priority", kind: "text" },
+	{ id: "due", kind: "date" },
+	{ id: "scheduled", kind: "date" },
+	{ id: "timeEstimate", kind: "number" },
+	{ id: "dateCreated", kind: "date" },
+	{ id: "dateModified", kind: "date" },
+	{ id: "completedDate", kind: "date" },
+	{ id: "recurrence", kind: "text" },
+	{ id: "tags", kind: "list" },
+	{ id: "projects", kind: "list" },
+	{ id: "contexts", kind: "list" },
+] as const;
+
+export function createDefaultJiraMappingSettings(): JiraFieldMappingSettings {
+	return {
+		version: 1,
+		fields: {
+			id: [{ mode: "path", value: "key" }],
+			title: [{ mode: "template", value: "$key $fields.summary" }],
+			details: [{ mode: "path", value: "fields.description" }],
+			status: [{ mode: "path", value: "fields.status.name" }],
+			priority: [{ mode: "path", value: "fields.priority.name" }],
+			due: [{ mode: "path", value: "fields.duedate" }],
+			scheduled: [{ mode: "off", value: "" }],
+			timeEstimate: [{ mode: "path", value: "fields.timeestimate" }],
+			dateCreated: [{ mode: "path", value: "fields.created" }],
+			dateModified: [{ mode: "path", value: "fields.updated" }],
+			completedDate: [{ mode: "path", value: "fields.resolutiondate" }],
+			recurrence: [{ mode: "off", value: "" }],
+			tags: [{ mode: "path", value: "fields.labels" }],
+			projects: [],
+			contexts: [],
+		},
+		userFields: {},
+		enumRemaps: {
+			status: [],
+			priority: [],
+			contexts: [],
+		},
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function readOwnProperty(value: unknown, key: string): unknown {
+	if (!isRecord(value) || UNSAFE_PATH_SEGMENTS.has(key)) return undefined;
+	return Object.prototype.hasOwnProperty.call(value, key) ? value[key] : undefined;
+}
+
+interface ParsedPathSegment {
+	key: string;
+	array: boolean;
+	index?: number;
+}
+
+function parsePathSegment(segment: string): ParsedPathSegment | null {
+	const match = /^([A-Za-z0-9_]+)(?:\[(\d*)\])?$/.exec(segment);
+	if (!match || UNSAFE_PATH_SEGMENTS.has(match[1])) return null;
+	if (match[2] === undefined) return { key: match[1], array: false };
+	if (match[2] === "") return { key: match[1], array: true };
+	return { key: match[1], array: false, index: Number(match[2]) };
+}
+
+/**
+ * Resolves Jira paths using own properties only. Empty brackets project across arrays,
+ * for example `fields.components[].name`.
+ */
+export function getJiraValueByPath(root: unknown, path: string): unknown {
+	const segments = path
+		.trim()
+		.split(".")
+		.map(parsePathSegment);
+	if (!segments.length || segments.some((segment) => !segment)) return undefined;
+
+	let values: unknown[] = [root];
+	let projected = false;
+	for (const parsed of segments) {
+		const segment = parsed as ParsedPathSegment;
+		const nextValues: unknown[] = [];
+		for (const value of values) {
+			const property = readOwnProperty(value, segment.key);
+			if (segment.array) {
+				if (Array.isArray(property)) {
+					nextValues.push(...property);
+					projected = true;
+				}
+			} else if (segment.index !== undefined) {
+				if (Array.isArray(property) && segment.index < property.length) {
+					nextValues.push(property[segment.index]);
+				}
+			} else if (property !== undefined) {
+				nextValues.push(property);
+			}
+		}
+		values = nextValues;
+		if (!values.length) return undefined;
+	}
+
+	return projected || values.length > 1 ? values.flat(Infinity) : values[0];
+}
+
+function stringifyTemplateValue(value: unknown): string {
+	if (Array.isArray(value)) return flattenList(value).join(", ");
+	if (value === null || value === undefined) return "";
+	if (typeof value === "object") return jiraRichTextToMarkdown(value) ?? "";
+	if (typeof value === "string") return value;
+	if (typeof value === "number" || typeof value === "boolean") return `${value}`;
+	return "";
+}
+
+export function renderJiraTemplate(template: string, issue: JiraIssue): string {
+	return template
+		.replace(
+			/\$([A-Za-z0-9_]+(?:\[(?:\d*)\])?(?:\.[A-Za-z0-9_]+(?:\[(?:\d*)\])?)*)/g,
+			(_match, path: string) =>
+				stringifyTemplateValue(
+					getJiraValueByPath(
+						issue,
+						path === "summary"
+							? "fields.summary"
+							: path === "description"
+								? "fields.description"
+								: path
+					)
+				)
+		)
+		.replace(/\\n/g, "\n")
+		.trim();
+}
+
+function readSource(source: JiraValueSource, issue: JiraIssue): unknown {
+	switch (source.mode) {
+		case "off":
+			return undefined;
+		case "fixed":
+			return source.value;
+		case "template":
+			return renderJiraTemplate(source.value, issue);
+		case "path":
+			return getJiraValueByPath(issue, source.value);
+	}
+}
+
+function flattenList(value: unknown): string[] {
+	const values = Array.isArray(value) ? value.flat(Infinity) : [value];
+	const strings = values
+		.filter(
+			(item): item is string | number | boolean =>
+				typeof item === "string" ||
+				typeof item === "number" ||
+				typeof item === "boolean"
+		)
+		.map((item) => String(item).trim())
+		.filter(Boolean);
+	return [...new Set(strings)];
+}
+
+export function jiraRichTextToMarkdown(value: unknown): string | undefined {
+	if (typeof value === "string") return value.trim() || undefined;
+	if (!isRecord(value)) return undefined;
+
+	const output: string[] = [];
+	const visit = (node: unknown): void => {
+		if (!isRecord(node)) return;
+		if (typeof node.text === "string") output.push(node.text);
+		if (Array.isArray(node.content)) {
+			for (const child of node.content) visit(child);
+			if (node.type === "paragraph" || node.type === "heading") output.push("\n");
+		}
+	};
+	visit(value);
+	return output.join("").trim() || undefined;
+}
+
+function firstResolvedSource(sources: JiraValueSource[], issue: JiraIssue): unknown {
+	for (const source of sources) {
+		const value = readSource(source, issue);
+		if (value !== undefined && value !== null && value !== "") return value;
+	}
+	return undefined;
+}
+
+function remapEnum(value: string | undefined, remaps: JiraEnumRemap[]): string | undefined {
+	if (!value) return undefined;
+	const normalized = value.toLocaleLowerCase();
+	const match = remaps.find((entry) =>
+		entry.jiraValues.some((incoming) => incoming.toLocaleLowerCase() === normalized)
+	);
+	return match?.taskValue || value;
+}
+
+function coerceText(value: unknown): string | undefined {
+	if (typeof value === "object" && value !== null) return jiraRichTextToMarkdown(value);
+	if (!["string", "number", "boolean"].includes(typeof value)) return undefined;
+	const text = String(value).trim();
+	return text || undefined;
+}
+
+function coerceNumber(value: unknown): number | undefined {
+	const number = typeof value === "number" ? value : Number(coerceText(value));
+	return Number.isFinite(number) ? number : undefined;
+}
+
+function coerceDate(value: unknown): string | undefined {
+	const text = coerceText(value);
+	if (!text || Number.isNaN(Date.parse(text))) return undefined;
+	return text;
+}
+
+function coerceBoolean(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	const text = coerceText(value)?.toLocaleLowerCase();
+	if (text === "true" || text === "yes" || text === "1") return true;
+	if (text === "false" || text === "no" || text === "0") return false;
+	return undefined;
+}
+
+function coerceUserField(value: unknown, field: UserMappedField): unknown {
+	switch (field.type) {
+		case "number":
+			return coerceNumber(value);
+		case "date":
+			return coerceDate(value);
+		case "boolean":
+			return coerceBoolean(value);
+		case "list":
+			return flattenList(value);
+		default:
+			return coerceText(value);
+	}
+}
+
+function normalizeSource(value: unknown): JiraValueSource | null {
+	if (!isRecord(value) || !SOURCE_MODES.has(value.mode as JiraValueSourceMode)) return null;
+	return {
+		mode: value.mode as JiraValueSourceMode,
+		value: typeof value.value === "string" ? value.value : "",
+	};
+}
+
+function normalizeSources(value: unknown, fallback: JiraValueSource[]): JiraValueSource[] {
+	if (!Array.isArray(value)) return fallback.map((source) => ({ ...source }));
+	const normalized = value
+		.map(normalizeSource)
+		.filter((source): source is JiraValueSource => !!source);
+	return value.length > 0 && normalized.length === 0
+		? fallback.map((source) => ({ ...source }))
+		: normalized;
+}
+
+function normalizeRemaps(value: unknown): JiraEnumRemap[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.filter(isRecord)
+		.map((entry) => ({
+			taskValue: typeof entry.taskValue === "string" ? entry.taskValue.trim() : "",
+			jiraValues: flattenList(entry.jiraValues),
+		}))
+		.filter((entry) => entry.taskValue && entry.jiraValues.length);
+}
+
+function legacyFieldSources(
+	value: Record<string, unknown>,
+	field: JiraBuiltInFieldId
+): unknown {
+	const legacy = value[field];
+	if (Array.isArray(legacy)) return legacy;
+	return legacy === undefined ? undefined : [legacy];
+}
+
+/**
+ * Validates persisted settings and upgrades the unversioned legacy Jira mapping shape.
+ */
+export function normalizeJiraMappingSettings(value: unknown): JiraFieldMappingSettings {
+	const defaults = createDefaultJiraMappingSettings();
+	if (!isRecord(value)) return defaults;
+	const fieldsValue = isRecord(value.fields) ? value.fields : value;
+	const fields: JiraFieldMappingSettings["fields"] = {};
+
+	for (const field of BUILT_IN_FIELDS) {
+		const raw = isRecord(value.fields)
+			? fieldsValue[field]
+			: legacyFieldSources(fieldsValue, field);
+		fields[field] = normalizeSources(raw, defaults.fields[field] ?? []);
+	}
+
+	const rawUserFields = isRecord(value.userFields) ? value.userFields : {};
+	const userFields: Record<string, JiraValueSource[]> = {};
+	for (const [fieldId, sources] of Object.entries(rawUserFields)) {
+		if (fieldId && !UNSAFE_PATH_SEGMENTS.has(fieldId)) {
+			userFields[fieldId] = normalizeSources(sources, []);
+		}
+	}
+
+	const rawRemaps = isRecord(value.enumRemaps) ? value.enumRemaps : value;
+	return {
+		version: 1,
+		fields,
+		userFields,
+		enumRemaps: {
+			status: normalizeRemaps(rawRemaps.status ?? value.statusMap),
+			priority: normalizeRemaps(rawRemaps.priority ?? value.priorityMap),
+			contexts: normalizeRemaps(rawRemaps.contexts ?? value.contextsMap),
+		},
+	};
+}
+
+export function mapJiraIssueWithSettings(
+	issue: JiraIssue,
+	settings: JiraFieldMappingSettings,
+	userFields: readonly UserMappedField[]
+): TaskCreationData {
+	const config = normalizeJiraMappingSettings(settings);
+	const output: TaskCreationData = { creationContext: "import" };
+	const read = (field: JiraBuiltInFieldId): unknown =>
+		LIST_FIELDS.has(field)
+			? (config.fields[field] ?? []).flatMap((source) => flattenList(readSource(source, issue)))
+			: firstResolvedSource(config.fields[field] ?? [], issue);
+
+	output.id = coerceText(read("id"));
+	output.title =
+		coerceText(read("title")) || `${issue.key.trim()} ${issue.fields.summary.trim()}`;
+	output.details = jiraRichTextToMarkdown(read("details")) ?? coerceText(read("details"));
+	output.status = remapEnum(
+		coerceText(read("status")),
+		config.enumRemaps.status
+	);
+	output.priority = remapEnum(
+		coerceText(read("priority"))?.toLocaleLowerCase(),
+		config.enumRemaps.priority
+	);
+	output.due = coerceDate(read("due"));
+	output.scheduled = coerceDate(read("scheduled"));
+	const estimateSeconds = coerceNumber(read("timeEstimate"));
+	output.timeEstimate =
+		estimateSeconds !== undefined && estimateSeconds >= 0
+			? Math.floor(estimateSeconds / 60)
+			: undefined;
+	output.dateCreated = coerceDate(read("dateCreated"));
+	output.dateModified = coerceDate(read("dateModified"));
+	output.completedDate = coerceDate(read("completedDate"));
+	output.recurrence = coerceText(read("recurrence"));
+	const tags = flattenList(read("tags"));
+	const projects = flattenList(read("projects"));
+	const contexts = flattenList(read("contexts")).map(
+		(value) => remapEnum(value, config.enumRemaps.contexts) ?? value
+	);
+	if (tags.length) output.tags = tags;
+	if (projects.length) output.projects = projects;
+	if (contexts.length) output.contexts = contexts;
+
+	const customFrontmatter: Record<string, unknown> = {};
+	for (const field of userFields) {
+		const sources = config.userFields[field.id] ?? [];
+		const rawValue =
+			field.type === "list"
+				? sources.flatMap((source) => flattenList(readSource(source, issue)))
+				: firstResolvedSource(sources, issue);
+		const value = coerceUserField(rawValue, field);
+		if (
+			value !== undefined &&
+			(!Array.isArray(value) || value.length > 0)
+		) {
+			customFrontmatter[field.key] = value;
+		}
+	}
+	if (Object.keys(customFrontmatter).length) output.customFrontmatter = customFrontmatter;
+
+	return output;
+}

--- a/src/integrations/jira/JiraFieldMapping.ts
+++ b/src/integrations/jira/JiraFieldMapping.ts
@@ -281,6 +281,52 @@ function coerceUserField(value: unknown, field: UserMappedField): unknown {
 	}
 }
 
+function getJiraIssueUrl(issue: JiraIssue): string | undefined {
+	const host =
+		typeof issue.account?.host === "string" ? issue.account.host.trim() : "";
+	const self = typeof issue.self === "string" ? issue.self.trim() : "";
+	const candidate = host || self;
+	if (!candidate) return undefined;
+
+	try {
+		const base = new URL(
+			/^[a-z][a-z\d+.-]*:/i.test(candidate) ? candidate : `https://${candidate}`
+		);
+		if (base.protocol !== "https:" && base.protocol !== "http:") return undefined;
+		base.username = "";
+		base.password = "";
+		return new URL(`/browse/${encodeURIComponent(issue.key)}`, base.origin).toString();
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Creates the companion Jira plugin's macro backlink, or a direct browser URL when
+ * the fetched issue includes a trustworthy HTTP(S) account host.
+ */
+export function buildJiraIssueBacklink(issue: JiraIssue): string {
+	const url = getJiraIssueUrl(issue);
+	return url ? `[Jira ${issue.key}](<${url}>)` : `JIRA:${issue.key}`;
+}
+
+export function prependJiraIssueBacklink(
+	details: string | undefined,
+	issue: JiraIssue
+): string {
+	const existing = details?.trim() ?? "";
+	const url = getJiraIssueUrl(issue);
+	const escapedKey = issue.key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const hasReference =
+		new RegExp(`\\bJIRA\\s*:\\s*${escapedKey}\\b`, "i").test(existing) ||
+		new RegExp(`/browse/${escapedKey}(?:[)>\\s]|$)`, "i").test(existing) ||
+		(!!url && existing.toLocaleLowerCase().includes(url.toLocaleLowerCase()));
+	if (hasReference) return existing;
+
+	const backlink = buildJiraIssueBacklink(issue);
+	return existing ? `${backlink}\n\n${existing}` : backlink;
+}
+
 function normalizeSource(value: unknown): JiraValueSource | null {
 	if (!isRecord(value) || !SOURCE_MODES.has(value.mode as JiraValueSourceMode)) return null;
 	return {
@@ -371,7 +417,9 @@ export function mapJiraIssueWithSettings(
 	output.id = coerceText(read("id"));
 	output.title =
 		coerceText(read("title")) || `${issue.key.trim()} ${issue.fields.summary.trim()}`;
-	output.details = jiraRichTextToMarkdown(read("details")) ?? coerceText(read("details"));
+	const mappedDetails =
+		jiraRichTextToMarkdown(read("details")) ?? coerceText(read("details"));
+	output.details = prependJiraIssueBacklink(mappedDetails, issue);
 	output.status = remapEnum(
 		coerceText(read("status")),
 		config.enumRemaps.status

--- a/src/integrations/jira/JiraFieldMapping.ts
+++ b/src/integrations/jira/JiraFieldMapping.ts
@@ -281,33 +281,11 @@ function coerceUserField(value: unknown, field: UserMappedField): unknown {
 	}
 }
 
-function getJiraIssueUrl(issue: JiraIssue): string | undefined {
-	const host =
-		typeof issue.account?.host === "string" ? issue.account.host.trim() : "";
-	const self = typeof issue.self === "string" ? issue.self.trim() : "";
-	const candidate = host || self;
-	if (!candidate) return undefined;
-
-	try {
-		const base = new URL(
-			/^[a-z][a-z\d+.-]*:/i.test(candidate) ? candidate : `https://${candidate}`
-		);
-		if (base.protocol !== "https:" && base.protocol !== "http:") return undefined;
-		base.username = "";
-		base.password = "";
-		return new URL(`/browse/${encodeURIComponent(issue.key)}`, base.origin).toString();
-	} catch {
-		return undefined;
-	}
-}
-
 /**
- * Creates the companion Jira plugin's macro backlink, or a direct browser URL when
- * the fetched issue includes a trustworthy HTTP(S) account host.
+ * Creates the companion Jira plugin's canonical issue backlink macro.
  */
 export function buildJiraIssueBacklink(issue: JiraIssue): string {
-	const url = getJiraIssueUrl(issue);
-	return url ? `[Jira ${issue.key}](<${url}>)` : `JIRA:${issue.key}`;
+	return `JIRA:${issue.key}`;
 }
 
 export function prependJiraIssueBacklink(
@@ -315,12 +293,11 @@ export function prependJiraIssueBacklink(
 	issue: JiraIssue
 ): string {
 	const existing = details?.trim() ?? "";
-	const url = getJiraIssueUrl(issue);
 	const escapedKey = issue.key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	const hasReference =
-		new RegExp(`\\bJIRA\\s*:\\s*${escapedKey}\\b`, "i").test(existing) ||
-		new RegExp(`/browse/${escapedKey}(?:[)>\\s]|$)`, "i").test(existing) ||
-		(!!url && existing.toLocaleLowerCase().includes(url.toLocaleLowerCase()));
+	const hasReference = new RegExp(
+		`\\bJIRA\\s*:\\s*${escapedKey}\\b`,
+		"i"
+	).test(existing);
 	if (hasReference) return existing;
 
 	const backlink = buildJiraIssueBacklink(issue);

--- a/src/integrations/jira/JiraIssueAdapter.ts
+++ b/src/integrations/jira/JiraIssueAdapter.ts
@@ -1,0 +1,129 @@
+import type { App } from "obsidian";
+
+export const JIRA_PLUGIN_ID = "obsidian-jira-issue";
+
+export type JiraIssueAdapterErrorCode =
+	| "invalid-issue-key"
+	| "dependency-unavailable"
+	| "fetch-failed"
+	| "invalid-response";
+
+export class JiraIssueAdapterError extends Error {
+	readonly cause?: unknown;
+
+	constructor(
+		public readonly code: JiraIssueAdapterErrorCode,
+		message: string,
+		options?: { cause?: unknown }
+	) {
+		super(message);
+		this.name = "JiraIssueAdapterError";
+		this.cause = options?.cause;
+	}
+}
+
+export interface JiraIssue {
+	key: string;
+	fields: {
+		summary: string;
+		description?: unknown;
+		status?: { name?: string | null } | null;
+		priority?: { name?: string | null } | null;
+		created?: string | null;
+		duedate?: string | null;
+		timeestimate?: number | null;
+		labels?: unknown;
+	};
+}
+
+interface JiraPluginApi {
+	api: {
+		base: {
+			getIssue(issueKey: string): Promise<unknown>;
+		};
+	};
+}
+
+function isJiraPluginApi(value: unknown): value is JiraPluginApi {
+	if (!value || typeof value !== "object") return false;
+	const api = Reflect.get(value, "api");
+	if (!api || typeof api !== "object") return false;
+	const base = Reflect.get(api, "base");
+	return (
+		!!base &&
+		typeof base === "object" &&
+		typeof Reflect.get(base, "getIssue") === "function"
+	);
+}
+
+function parseJiraIssue(value: unknown): JiraIssue {
+	if (!value || typeof value !== "object") {
+		throw new JiraIssueAdapterError("invalid-response", "Jira returned an invalid issue.");
+	}
+
+	const key = Reflect.get(value, "key");
+	const fields = Reflect.get(value, "fields");
+	const summary =
+		fields && typeof fields === "object" ? Reflect.get(fields, "summary") : undefined;
+
+	if (
+		typeof key !== "string" ||
+		!key.trim() ||
+		!fields ||
+		typeof fields !== "object" ||
+		typeof summary !== "string" ||
+		!summary.trim()
+	) {
+		throw new JiraIssueAdapterError(
+			"invalid-response",
+			"Jira returned an issue without a key or summary."
+		);
+	}
+
+	return value as JiraIssue;
+}
+
+export function normalizeJiraIssueKey(issueKey: string): string {
+	const normalized = issueKey.trim().toUpperCase();
+	if (!/^[A-Z][A-Z0-9_]*-\d+$/.test(normalized)) {
+		throw new JiraIssueAdapterError(
+			"invalid-issue-key",
+			`Invalid Jira issue key: ${issueKey}`
+		);
+	}
+	return normalized;
+}
+
+/**
+ * Isolates TaskNotes from the optional obsidian-jira-issue dependency and validates
+ * the small part of its runtime API used by issue import.
+ */
+export class JiraIssueAdapter {
+	constructor(private readonly getPlugin: () => unknown) {}
+
+	static fromApp(app: App): JiraIssueAdapter {
+		return new JiraIssueAdapter(() => app.plugins.getPlugin(JIRA_PLUGIN_ID));
+	}
+
+	async getIssue(issueKey: string): Promise<JiraIssue> {
+		const normalizedKey = normalizeJiraIssueKey(issueKey);
+		const plugin = this.getPlugin();
+		if (!isJiraPluginApi(plugin)) {
+			throw new JiraIssueAdapterError(
+				"dependency-unavailable",
+				"The obsidian-jira-issue plugin is unavailable or has an incompatible API."
+			);
+		}
+
+		try {
+			return parseJiraIssue(await plugin.api.base.getIssue(normalizedKey));
+		} catch (error) {
+			if (error instanceof JiraIssueAdapterError) throw error;
+			throw new JiraIssueAdapterError(
+				"fetch-failed",
+				`Failed to fetch Jira issue ${normalizedKey}.`,
+				{ cause: error }
+			);
+		}
+	}
+}

--- a/src/integrations/jira/JiraIssueAdapter.ts
+++ b/src/integrations/jira/JiraIssueAdapter.ts
@@ -24,6 +24,10 @@ export class JiraIssueAdapterError extends Error {
 
 export interface JiraIssue {
 	key: string;
+	self?: string;
+	account?: {
+		host?: string;
+	};
 	fields: {
 		[key: string]: unknown;
 		summary: string;

--- a/src/integrations/jira/JiraIssueAdapter.ts
+++ b/src/integrations/jira/JiraIssueAdapter.ts
@@ -25,6 +25,7 @@ export class JiraIssueAdapterError extends Error {
 export interface JiraIssue {
 	key: string;
 	fields: {
+		[key: string]: unknown;
 		summary: string;
 		description?: unknown;
 		status?: { name?: string | null } | null;

--- a/src/integrations/jira/JiraIssueAdapter.ts
+++ b/src/integrations/jira/JiraIssueAdapter.ts
@@ -24,10 +24,6 @@ export class JiraIssueAdapterError extends Error {
 
 export interface JiraIssue {
 	key: string;
-	self?: string;
-	account?: {
-		host?: string;
-	};
 	fields: {
 		[key: string]: unknown;
 		summary: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1191,7 +1191,7 @@ export default class TaskNotesPlugin extends Plugin {
 		}).open();
 	}
 
-	private applyParentNoteProjectDefault(
+	applyParentNoteProjectDefault(
 		prePopulatedValues: Partial<TaskInfo> | undefined,
 		context: ParentNoteProjectDefaultContext
 	): Partial<TaskInfo> | undefined {

--- a/src/services/JiraImportService.ts
+++ b/src/services/JiraImportService.ts
@@ -1,9 +1,11 @@
 import type { TaskCreationData, TaskInfo } from "../types";
+import type { JiraFieldMappingSettings, UserMappedField } from "../types/settings";
 import {
 	JiraIssueAdapter,
 	JiraIssueAdapterError,
 	type JiraIssue,
 } from "../integrations/jira/JiraIssueAdapter";
+import { mapJiraIssueWithSettings } from "../integrations/jira/JiraFieldMapping";
 
 export type JiraImportErrorCode =
 	| "invalid-issue-key"
@@ -32,59 +34,6 @@ export interface JiraTaskCreator {
 	): Promise<{ taskInfo: TaskInfo }>;
 }
 
-function getOptionalString(value: unknown): string | undefined {
-	return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function jiraDescriptionToMarkdown(value: unknown): string | undefined {
-	if (typeof value === "string") return value.trim() || undefined;
-	if (!value || typeof value !== "object") return undefined;
-
-	const textParts: string[] = [];
-	const visit = (node: unknown): void => {
-		if (!node || typeof node !== "object") return;
-		const text = Reflect.get(node, "text");
-		if (typeof text === "string") textParts.push(text);
-		const content = Reflect.get(node, "content");
-		if (Array.isArray(content)) {
-			for (const child of content) visit(child);
-			if (Reflect.get(node, "type") === "paragraph") textParts.push("\n");
-		}
-	};
-	visit(value);
-	return textParts.join("").trim() || undefined;
-}
-
-/**
- * Maps the stable baseline Jira fields needed by the first import slice. Configurable
- * paths and value remapping intentionally remain separate for porting-plan section 1.2.
- */
-export function mapJiraIssueToTaskCreationData(issue: JiraIssue): TaskCreationData {
-	const labels = Array.isArray(issue.fields.labels)
-		? issue.fields.labels.filter(
-				(value): value is string => typeof value === "string" && !!value.trim()
-			)
-		: undefined;
-	const estimateSeconds = issue.fields.timeestimate;
-
-	return {
-		title: `${issue.key.trim()} ${issue.fields.summary.trim()}`,
-		details: jiraDescriptionToMarkdown(issue.fields.description),
-		status: getOptionalString(issue.fields.status?.name),
-		priority: getOptionalString(issue.fields.priority?.name)?.toLowerCase(),
-		dateCreated: getOptionalString(issue.fields.created),
-		due: getOptionalString(issue.fields.duedate),
-		timeEstimate:
-			typeof estimateSeconds === "number" &&
-			Number.isFinite(estimateSeconds) &&
-			estimateSeconds > 0
-				? Math.floor(estimateSeconds / 60)
-				: undefined,
-		tags: labels,
-		creationContext: "import",
-	};
-}
-
 /**
  * Coordinates Jira retrieval and TaskNotes creation without exposing the optional
  * dependency to command registration or the core task-creation service.
@@ -92,7 +41,9 @@ export function mapJiraIssueToTaskCreationData(issue: JiraIssue): TaskCreationDa
 export class JiraImportService {
 	constructor(
 		private readonly adapter: JiraIssueAdapter,
-		private readonly taskCreator: JiraTaskCreator
+		private readonly taskCreator: JiraTaskCreator,
+		private readonly mappingSettings: JiraFieldMappingSettings,
+		private readonly userFields: readonly UserMappedField[]
 	) {}
 
 	async importIssue(issueKey: string): Promise<TaskInfo> {
@@ -112,7 +63,7 @@ export class JiraImportService {
 
 		try {
 			const result = await this.taskCreator.createTask(
-				mapJiraIssueToTaskCreationData(issue),
+				mapJiraIssueWithSettings(issue, this.mappingSettings, this.userFields),
 				{ applyDefaults: true, applyTemplate: true }
 			);
 			return result.taskInfo;

--- a/src/services/JiraImportService.ts
+++ b/src/services/JiraImportService.ts
@@ -1,0 +1,127 @@
+import type { TaskCreationData, TaskInfo } from "../types";
+import {
+	JiraIssueAdapter,
+	JiraIssueAdapterError,
+	type JiraIssue,
+} from "../integrations/jira/JiraIssueAdapter";
+
+export type JiraImportErrorCode =
+	| "invalid-issue-key"
+	| "dependency-unavailable"
+	| "fetch-failed"
+	| "creation-failed";
+
+export class JiraImportError extends Error {
+	readonly cause?: unknown;
+
+	constructor(
+		public readonly code: JiraImportErrorCode,
+		message: string,
+		options?: { cause?: unknown }
+	) {
+		super(message);
+		this.name = "JiraImportError";
+		this.cause = options?.cause;
+	}
+}
+
+export interface JiraTaskCreator {
+	createTask(
+		taskData: TaskCreationData,
+		options?: { applyDefaults?: boolean; applyTemplate?: boolean }
+	): Promise<{ taskInfo: TaskInfo }>;
+}
+
+function getOptionalString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function jiraDescriptionToMarkdown(value: unknown): string | undefined {
+	if (typeof value === "string") return value.trim() || undefined;
+	if (!value || typeof value !== "object") return undefined;
+
+	const textParts: string[] = [];
+	const visit = (node: unknown): void => {
+		if (!node || typeof node !== "object") return;
+		const text = Reflect.get(node, "text");
+		if (typeof text === "string") textParts.push(text);
+		const content = Reflect.get(node, "content");
+		if (Array.isArray(content)) {
+			for (const child of content) visit(child);
+			if (Reflect.get(node, "type") === "paragraph") textParts.push("\n");
+		}
+	};
+	visit(value);
+	return textParts.join("").trim() || undefined;
+}
+
+/**
+ * Maps the stable baseline Jira fields needed by the first import slice. Configurable
+ * paths and value remapping intentionally remain separate for porting-plan section 1.2.
+ */
+export function mapJiraIssueToTaskCreationData(issue: JiraIssue): TaskCreationData {
+	const labels = Array.isArray(issue.fields.labels)
+		? issue.fields.labels.filter(
+				(value): value is string => typeof value === "string" && !!value.trim()
+			)
+		: undefined;
+	const estimateSeconds = issue.fields.timeestimate;
+
+	return {
+		title: `${issue.key.trim()} ${issue.fields.summary.trim()}`,
+		details: jiraDescriptionToMarkdown(issue.fields.description),
+		status: getOptionalString(issue.fields.status?.name),
+		priority: getOptionalString(issue.fields.priority?.name)?.toLowerCase(),
+		dateCreated: getOptionalString(issue.fields.created),
+		due: getOptionalString(issue.fields.duedate),
+		timeEstimate:
+			typeof estimateSeconds === "number" &&
+			Number.isFinite(estimateSeconds) &&
+			estimateSeconds > 0
+				? Math.floor(estimateSeconds / 60)
+				: undefined,
+		tags: labels,
+		creationContext: "import",
+	};
+}
+
+/**
+ * Coordinates Jira retrieval and TaskNotes creation without exposing the optional
+ * dependency to command registration or the core task-creation service.
+ */
+export class JiraImportService {
+	constructor(
+		private readonly adapter: JiraIssueAdapter,
+		private readonly taskCreator: JiraTaskCreator
+	) {}
+
+	async importIssue(issueKey: string): Promise<TaskInfo> {
+		let issue: JiraIssue;
+		try {
+			issue = await this.adapter.getIssue(issueKey);
+		} catch (error) {
+			if (error instanceof JiraIssueAdapterError) {
+				const code =
+					error.code === "invalid-response" ? "fetch-failed" : error.code;
+				throw new JiraImportError(code, error.message, { cause: error });
+			}
+			throw new JiraImportError("fetch-failed", "Failed to fetch Jira issue.", {
+				cause: error,
+			});
+		}
+
+		try {
+			const result = await this.taskCreator.createTask(
+				mapJiraIssueToTaskCreationData(issue),
+				{ applyDefaults: true, applyTemplate: true }
+			);
+			return result.taskInfo;
+		} catch (error) {
+			throw new JiraImportError(
+				"creation-failed",
+				`Failed to create a task for Jira issue ${issue.key}.`,
+				{ cause: error }
+			);
+		}
+	}
+}

--- a/src/services/JiraImportService.ts
+++ b/src/services/JiraImportService.ts
@@ -34,6 +34,8 @@ export interface JiraTaskCreator {
 	): Promise<{ taskInfo: TaskInfo }>;
 }
 
+export type JiraTaskDataPreparer = (taskData: TaskCreationData) => TaskCreationData;
+
 /**
  * Coordinates Jira retrieval and TaskNotes creation without exposing the optional
  * dependency to command registration or the core task-creation service.
@@ -43,7 +45,8 @@ export class JiraImportService {
 		private readonly adapter: JiraIssueAdapter,
 		private readonly taskCreator: JiraTaskCreator,
 		private readonly mappingSettings: JiraFieldMappingSettings,
-		private readonly userFields: readonly UserMappedField[]
+		private readonly userFields: readonly UserMappedField[],
+		private readonly prepareTaskData: JiraTaskDataPreparer = (taskData) => taskData
 	) {}
 
 	async importIssue(issueKey: string): Promise<TaskInfo> {
@@ -62,8 +65,11 @@ export class JiraImportService {
 		}
 
 		try {
+			const taskData = this.prepareTaskData(
+				mapJiraIssueWithSettings(issue, this.mappingSettings, this.userFields)
+			);
 			const result = await this.taskCreator.createTask(
-				mapJiraIssueWithSettings(issue, this.mappingSettings, this.userFields),
+				taskData,
 				{ applyDefaults: true, applyTemplate: true }
 			);
 			return result.taskInfo;

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -7,8 +7,10 @@ import {
 	ProjectAutosuggestSettings,
 	NLPTriggersConfig,
 	GoogleCalendarExportSettings,
+	JiraFieldMappingSettings,
 } from "../types/settings";
 import { DEFAULT_FIELD_MAPPING } from "../core/defaultFieldMapping";
+import { createDefaultJiraMappingSettings } from "../integrations/jira/JiraFieldMapping";
 export { DEFAULT_FIELD_MAPPING } from "../core/defaultFieldMapping";
 
 /**
@@ -247,6 +249,9 @@ export const DEFAULT_NLP_TRIGGERS: NLPTriggersConfig = {
 	],
 };
 
+export const DEFAULT_JIRA_FIELD_MAPPING: JiraFieldMappingSettings =
+	createDefaultJiraMappingSettings();
+
 export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	tasksFolder: "TaskNotes/Tasks",
 	moveArchivedTasks: false,
@@ -394,6 +399,7 @@ export const DEFAULT_SETTINGS: TaskNotesSettings = {
 	},
 	// Recurring task behavior defaults
 	maintainDueDateOffsetInRecurring: false,
+	jiraMapping: DEFAULT_JIRA_FIELD_MAPPING,
 	resetCheckboxesOnRecurrence: false, // Off by default - user opts in
 	// Frontmatter link format defaults
 	useFrontmatterMarkdownLinks: false, // Default to wikilinks for compatibility

--- a/src/settings/settingsPersistence.ts
+++ b/src/settings/settingsPersistence.ts
@@ -4,6 +4,7 @@ import { hasMissingMigratedSettings } from "./settingsMigration";
 import type { TaskCreationDefaults, TaskNotesSettings } from "../types/settings";
 import { initializeFieldConfig } from "../utils/fieldConfigDefaults";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
+import { normalizeJiraMappingSettings } from "../integrations/jira/JiraFieldMapping";
 
 const tasknotesLogger = createTaskNotesLogger({ tag: "Settings/SettingsPersistence" });
 
@@ -195,6 +196,12 @@ function buildTaskCreationDefaults(
 
 export function buildSettingsFromLoadedData(data: LoadedSettingsData | null): SettingsBuildResult {
 	const loadedData = migrateLoadedSettingsData(data);
+	const rawJiraMapping: unknown = loadedData?.jiraMapping;
+	const migratedJiraMapping =
+		rawJiraMapping !== undefined &&
+		(!rawJiraMapping ||
+			typeof rawJiraMapping !== "object" ||
+			Reflect.get(rawJiraMapping, "version") !== 1);
 	const migratedLegacyCustomFilenameTemplate =
 		data?.taskFilenameFormat !== "custom" &&
 		data?.customFilenameTemplate === "{title}" &&
@@ -234,6 +241,7 @@ export function buildSettingsFromLoadedData(data: LoadedSettingsData | null): Se
 		customStatuses: loadedData?.customStatuses || DEFAULT_SETTINGS.customStatuses,
 		customPriorities: loadedData?.customPriorities || DEFAULT_SETTINGS.customPriorities,
 		savedViews: loadedData?.savedViews || DEFAULT_SETTINGS.savedViews,
+		jiraMapping: normalizeJiraMappingSettings(rawJiraMapping),
 	};
 
 	return {
@@ -241,7 +249,8 @@ export function buildSettingsFromLoadedData(data: LoadedSettingsData | null): Se
 		shouldPersistMigratedSettings:
 			hasMissingMigratedSettings(loadedData) ||
 			migratedLegacyCustomFilenameTemplate ||
-			migratedParentNoteTaskCreationDefault,
+			migratedParentNoteTaskCreationDefault ||
+			migratedJiraMapping,
 	};
 }
 

--- a/src/settings/tabs/integrationsTab.ts
+++ b/src/settings/tabs/integrationsTab.ts
@@ -33,6 +33,7 @@ import {
 	type CardSection,
 } from "../components/CardComponent";
 import { createTaskNotesLogger } from "../../utils/tasknotesLogger";
+import { renderJiraMappingSettings } from "./jiraMappingSettings";
 
 const tasknotesLogger = createTaskNotesLogger({ tag: "Settings/Tabs/IntegrationsTab" });
 
@@ -179,6 +180,8 @@ export function renderIntegrationsTab(
 	const calendarIntegrationDisabledOnMobile = isCalendarIntegrationDisabledOnMobile(
 		plugin.settings
 	);
+
+	renderJiraMappingSettings(container, plugin, save);
 
 	// mdbase-spec Section
 	createSettingGroup(

--- a/src/settings/tabs/jiraMappingSettings.ts
+++ b/src/settings/tabs/jiraMappingSettings.ts
@@ -1,0 +1,284 @@
+import { Setting } from "obsidian";
+import type TaskNotesPlugin from "../../main";
+import type {
+	JiraEnumRemap,
+	JiraValueSource,
+	JiraValueSourceMode,
+} from "../../types/settings";
+import {
+	createDefaultJiraMappingSettings,
+	JIRA_MAPPING_TARGETS,
+} from "../../integrations/jira/JiraFieldMapping";
+
+const MODE_OPTIONS: Record<JiraValueSourceMode, string> = {
+	path: "Jira path",
+	template: "Template",
+	fixed: "Fixed value",
+	off: "Disabled",
+};
+
+function humanizeFieldId(fieldId: string): string {
+	return fieldId
+		.replace(/([a-z])([A-Z])/g, "$1 $2")
+		.replace(/^./, (value) => value.toLocaleUpperCase());
+}
+
+function sourcePlaceholder(mode: JiraValueSourceMode): string {
+	switch (mode) {
+		case "path":
+			return "fields.components[].name";
+		case "template":
+			return "$key $fields.summary";
+		case "fixed":
+			return "Fixed TaskNotes value";
+		case "off":
+			return "";
+	}
+}
+
+function formatEnumRemaps(remaps: JiraEnumRemap[]): string {
+	return remaps
+		.map((entry) => `${entry.taskValue} = ${entry.jiraValues.join(", ")}`)
+		.join("\n");
+}
+
+export function parseJiraEnumRemaps(value: string): JiraEnumRemap[] {
+	return value
+		.split(/\r?\n/)
+		.map((line) => {
+			const separator = line.indexOf("=");
+			if (separator < 0) return null;
+			const taskValue = line.slice(0, separator).trim();
+			const jiraValues = line
+				.slice(separator + 1)
+				.split(",")
+				.map((item) => item.trim())
+				.filter(Boolean);
+			return taskValue && jiraValues.length ? { taskValue, jiraValues } : null;
+		})
+		.filter((entry): entry is JiraEnumRemap => !!entry);
+}
+
+function renderSourceSetting(
+	container: HTMLElement,
+	label: string,
+	source: JiraValueSource,
+	options: {
+		canRemove: boolean;
+		onChange: () => void;
+		onRemove: () => void;
+		save: () => void;
+	}
+): void {
+	const setting = new Setting(container).setName(label);
+	setting.addDropdown((dropdown) => {
+		for (const [mode, modeLabel] of Object.entries(MODE_OPTIONS)) {
+			dropdown.addOption(mode, modeLabel);
+		}
+		dropdown.setValue(source.mode).onChange((mode) => {
+			source.mode = mode as JiraValueSourceMode;
+			options.save();
+			options.onChange();
+		});
+	});
+	setting.addText((text) => {
+		text.inputEl.ariaLabel = `${label} mapping value`;
+		text
+			.setValue(source.value)
+			.setPlaceholder(sourcePlaceholder(source.mode))
+			.setDisabled(source.mode === "off")
+			.onChange((value) => {
+				source.value = value;
+				options.save();
+			});
+	});
+	if (options.canRemove) {
+		setting.addExtraButton((button) => {
+			button
+				.setIcon("trash-2")
+				.setTooltip("Remove source")
+				.onClick(options.onRemove);
+		});
+	}
+}
+
+function renderFieldSources(
+	container: HTMLElement,
+	fieldId: string,
+	sources: JiraValueSource[],
+	isList: boolean,
+	save: () => void,
+	rerender: () => void
+): void {
+	if (!isList && sources.length === 0) {
+		sources.push({ mode: "off", value: "" });
+	}
+
+	if (sources.length === 0) {
+		new Setting(container)
+			.setName(humanizeFieldId(fieldId))
+			.setDesc("No sources configured.")
+			.addButton((button) =>
+				button.setButtonText("Add source").onClick(() => {
+					sources.push({ mode: "path", value: "" });
+					save();
+					rerender();
+				})
+			);
+		return;
+	}
+
+	sources.forEach((source, index) => {
+		renderSourceSetting(
+			container,
+			index === 0 ? humanizeFieldId(fieldId) : `${humanizeFieldId(fieldId)} source ${index + 1}`,
+			source,
+			{
+				canRemove: isList,
+				onChange: rerender,
+				onRemove: () => {
+					sources.splice(index, 1);
+					save();
+					rerender();
+				},
+				save,
+			}
+		);
+	});
+
+	if (isList) {
+		new Setting(container).addButton((button) =>
+			button.setButtonText("Add source").onClick(() => {
+				sources.push({ mode: "path", value: "" });
+				save();
+				rerender();
+			})
+		);
+	}
+}
+
+function renderEnumRemapSetting(
+	container: HTMLElement,
+	label: string,
+	description: string,
+	remaps: JiraEnumRemap[],
+	onChange: (remaps: JiraEnumRemap[]) => void
+): void {
+	new Setting(container)
+		.setName(label)
+		.setDesc(description)
+		.addTextArea((text) => {
+			text.inputEl.rows = 4;
+			text.inputEl.ariaLabel = `${label} mappings`;
+			text
+				.setPlaceholder("In-progress = doing, in progress")
+				.setValue(formatEnumRemaps(remaps))
+				.onChange((value) => onChange(parseJiraEnumRemaps(value)));
+		});
+}
+
+/**
+ * Renders the configurable Jira-to-TaskNotes transformation independently of core
+ * field mapping. The section rerenders locally when its dynamic source lists change.
+ */
+export function renderJiraMappingSettings(
+	parent: HTMLElement,
+	plugin: TaskNotesPlugin,
+	save: () => void
+): void {
+	const container = parent.createDiv("tasknotes-jira-mapping-settings");
+
+	const render = (): void => {
+		container.empty();
+		new Setting(container)
+			.setName(plugin.i18n.translate("settings.integrations.jiraMapping.header"))
+			.setDesc(plugin.i18n.translate("settings.integrations.jiraMapping.description"))
+			.setHeading()
+			.addButton((button) =>
+				button
+					.setButtonText(
+						plugin.i18n.translate("settings.integrations.jiraMapping.reset")
+					)
+					.onClick(() => {
+						plugin.settings.jiraMapping = createDefaultJiraMappingSettings();
+						save();
+						render();
+					})
+			);
+
+		new Setting(container)
+			.setName(plugin.i18n.translate("settings.integrations.jiraMapping.sourcesHeader"))
+			.setDesc(plugin.i18n.translate("settings.integrations.jiraMapping.sourcesDescription"))
+			.setHeading();
+
+		for (const target of JIRA_MAPPING_TARGETS) {
+			const sources = (plugin.settings.jiraMapping.fields[target.id] ??= []);
+			renderFieldSources(
+				container,
+				target.id,
+				sources,
+				target.kind === "list",
+				save,
+				render
+			);
+		}
+
+		if ((plugin.settings.userFields ?? []).length > 0) {
+			new Setting(container)
+				.setName(plugin.i18n.translate("settings.integrations.jiraMapping.userFieldsHeader"))
+				.setDesc(
+					plugin.i18n.translate("settings.integrations.jiraMapping.userFieldsDescription")
+				)
+				.setHeading();
+			for (const userField of plugin.settings.userFields ?? []) {
+				const sources = (plugin.settings.jiraMapping.userFields[userField.id] ??= []);
+				renderFieldSources(
+					container,
+					userField.displayName,
+					sources,
+					userField.type === "list",
+					save,
+					render
+				);
+			}
+		}
+
+		new Setting(container)
+			.setName(plugin.i18n.translate("settings.integrations.jiraMapping.remapsHeader"))
+			.setDesc(plugin.i18n.translate("settings.integrations.jiraMapping.remapsDescription"))
+			.setHeading();
+		const remaps = plugin.settings.jiraMapping.enumRemaps;
+		renderEnumRemapSetting(
+			container,
+			"Status",
+			"One mapping per line: TaskNotes value = Jira value, alternate Jira value.",
+			remaps.status,
+			(value) => {
+				remaps.status = value;
+				save();
+			}
+		);
+		renderEnumRemapSetting(
+			container,
+			"Priority",
+			"One mapping per line: TaskNotes value = Jira value, alternate Jira value.",
+			remaps.priority,
+			(value) => {
+				remaps.priority = value;
+				save();
+			}
+		);
+		renderEnumRemapSetting(
+			container,
+			"Contexts",
+			"Context mappings are applied after all configured list sources are merged.",
+			remaps.contexts,
+			(value) => {
+				remaps.contexts = value;
+				save();
+			}
+		);
+	};
+
+	render();
+}

--- a/src/settings/tabs/jiraMappingSettings.ts
+++ b/src/settings/tabs/jiraMappingSettings.ts
@@ -1,4 +1,4 @@
-import { Setting } from "obsidian";
+import { Notice, Setting, setIcon } from "obsidian";
 import type TaskNotesPlugin from "../../main";
 import type {
 	JiraEnumRemap,
@@ -388,6 +388,40 @@ export function renderJiraMappingSettings(
 				text: plugin.i18n.translate(
 					"settings.integrations.jiraMapping.preview.rawJsonDescription"
 				),
+			});
+			const rawToolbar = details.createDiv(
+				"tasknotes-jira-mapping-preview__raw-toolbar"
+			);
+			const copyButton = rawToolbar.createEl("button", {
+				cls: "clickable-icon",
+				attr: {
+					type: "button",
+					"aria-label": plugin.i18n.translate(
+						"settings.integrations.jiraMapping.preview.copyRawJson"
+					),
+				},
+			});
+			setIcon(copyButton, "copy");
+			copyButton.addEventListener("click", (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				// Copy the complete payload even when the on-screen preview is truncated.
+				void navigator.clipboard
+					.writeText(JSON.stringify(sampleIssue, null, 2))
+					.then(() => {
+						new Notice(
+							plugin.i18n.translate(
+								"settings.integrations.jiraMapping.preview.copySuccess"
+							)
+						);
+					})
+					.catch(() => {
+						new Notice(
+							plugin.i18n.translate(
+								"settings.integrations.jiraMapping.preview.copyFailure"
+							)
+						);
+					});
 			});
 			// Jira content is untrusted; textContent keeps markup inert in the settings DOM.
 			details.createEl("pre", { text: raw.text });

--- a/src/settings/tabs/jiraMappingSettings.ts
+++ b/src/settings/tabs/jiraMappingSettings.ts
@@ -6,9 +6,38 @@ import type {
 	JiraValueSourceMode,
 } from "../../types/settings";
 import {
+	buildJiraMappingPreview,
 	createDefaultJiraMappingSettings,
 	JIRA_MAPPING_TARGETS,
 } from "../../integrations/jira/JiraFieldMapping";
+import {
+	JiraIssueAdapter,
+	type JiraIssue,
+} from "../../integrations/jira/JiraIssueAdapter";
+
+export const MAX_JIRA_RAW_PREVIEW_CHARS = 50_000;
+const MAX_JIRA_VALUE_PREVIEW_CHARS = 500;
+
+export function serializeJiraIssuePreview(
+	issue: JiraIssue,
+	maxChars = MAX_JIRA_RAW_PREVIEW_CHARS
+): { text: string; truncated: boolean } {
+	const json = JSON.stringify(issue, null, 2);
+	if (json.length <= maxChars) return { text: json, truncated: false };
+	return {
+		text: `${json.slice(0, maxChars)}\n…`,
+		truncated: true,
+	};
+}
+
+function formatPreviewValue(value: unknown): string {
+	const text =
+		typeof value === "string"
+			? value
+			: JSON.stringify(value, null, Array.isArray(value) ? 0 : 2);
+	if (text.length <= MAX_JIRA_VALUE_PREVIEW_CHARS) return text;
+	return `${text.slice(0, MAX_JIRA_VALUE_PREVIEW_CHARS)}…`;
+}
 
 const MODE_OPTIONS: Record<JiraValueSourceMode, string> = {
 	path: "Jira path",
@@ -187,6 +216,34 @@ export function renderJiraMappingSettings(
 	save: () => void
 ): void {
 	const container = parent.createDiv("tasknotes-jira-mapping-settings");
+	let issueKey = "";
+	let issueKeyInputEl: HTMLInputElement | null = null;
+	let sampleIssue: JiraIssue | null = null;
+	let previewStatus: "idle" | "loading" | "success" | "error" = "idle";
+	let previewError = "";
+	let rawExpanded = false;
+	let refreshPreview = (): void => {};
+
+	const fetchSampleIssue = async (): Promise<void> => {
+		issueKey = issueKeyInputEl?.value.trim() ?? issueKey.trim();
+		previewStatus = "loading";
+		previewError = "";
+		render();
+		try {
+			sampleIssue = await JiraIssueAdapter.fromApp(plugin.app).getIssue(issueKey);
+			previewStatus = "success";
+		} catch (error) {
+			sampleIssue = null;
+			previewStatus = "error";
+			previewError =
+				error instanceof Error
+					? error.message
+					: plugin.i18n.translate(
+							"settings.integrations.jiraMapping.preview.unknownError"
+						);
+		}
+		render();
+	};
 
 	const render = (): void => {
 		container.empty();
@@ -207,6 +264,150 @@ export function renderJiraMappingSettings(
 			);
 
 		new Setting(container)
+			.setName(
+				plugin.i18n.translate(
+					"settings.integrations.jiraMapping.preview.sampleIssue"
+				)
+			)
+			.setDesc(
+				plugin.i18n.translate(
+					"settings.integrations.jiraMapping.preview.sampleIssueDescription"
+				)
+			)
+			.addText((text) => {
+				issueKeyInputEl = text.inputEl;
+				text.inputEl.ariaLabel = plugin.i18n.translate(
+					"settings.integrations.jiraMapping.preview.issueKey"
+				);
+				text
+					.setPlaceholder(
+						plugin.i18n.translate(
+							"settings.integrations.jiraMapping.preview.issueKeyPlaceholder"
+						)
+					)
+					.setValue(issueKey)
+					.onChange((value) => {
+						issueKey = value;
+					});
+				text.inputEl.addEventListener("keydown", (event) => {
+					if (
+						event.key === "Enter" &&
+						text.inputEl.value.trim() &&
+						previewStatus !== "loading"
+					) {
+						event.preventDefault();
+						void fetchSampleIssue();
+					}
+				});
+			})
+			.addButton((button) =>
+				button
+					.setButtonText(
+						previewStatus === "loading"
+							? plugin.i18n.translate(
+									"settings.integrations.jiraMapping.preview.loading"
+								)
+							: plugin.i18n.translate(
+									"settings.integrations.jiraMapping.preview.fetch"
+								)
+					)
+					.setDisabled(previewStatus === "loading")
+					.onClick(() => void fetchSampleIssue())
+			);
+
+		const previewContainer = container.createDiv(
+			"tasknotes-jira-mapping-preview"
+		);
+		refreshPreview = (): void => {
+			previewContainer.empty();
+			if (previewStatus === "error") {
+				previewContainer.createDiv({
+					cls: "tasknotes-jira-mapping-preview__error",
+					text: previewError,
+				});
+				return;
+			}
+			if (!sampleIssue) return;
+
+			new Setting(previewContainer)
+				.setName(
+					plugin.i18n.translate(
+						"settings.integrations.jiraMapping.preview.resolvedValues"
+					)
+				)
+				.setDesc(
+					plugin.i18n.translate(
+						"settings.integrations.jiraMapping.preview.resolvedValuesDescription"
+					)
+				)
+				.setHeading();
+
+			const values = previewContainer.createDiv(
+				"tasknotes-jira-mapping-preview__values"
+			);
+			for (const entry of buildJiraMappingPreview(
+				sampleIssue,
+				plugin.settings.jiraMapping,
+				plugin.settings.userFields ?? []
+			)) {
+				const row = values.createDiv("tasknotes-jira-mapping-preview__row");
+				row.createDiv({
+					cls: "tasknotes-jira-mapping-preview__label",
+					text: humanizeFieldId(entry.label),
+				});
+				row.createEl("code", {
+					cls: `tasknotes-jira-mapping-preview__value is-${entry.status}`,
+					text:
+						entry.status === "missing"
+							? plugin.i18n.translate(
+									"settings.integrations.jiraMapping.preview.missing"
+								)
+							: entry.status === "invalid"
+								? plugin.i18n.translate(
+										"settings.integrations.jiraMapping.preview.invalid"
+									)
+								: formatPreviewValue(entry.value),
+				});
+			}
+
+			const raw = serializeJiraIssuePreview(sampleIssue);
+			const details = previewContainer.createEl("details", {
+				cls: "tasknotes-jira-mapping-preview__raw",
+			});
+			details.open = rawExpanded;
+			details.addEventListener("toggle", () => {
+				rawExpanded = details.open;
+			});
+			details.createEl("summary", {
+				text: plugin.i18n.translate(
+					"settings.integrations.jiraMapping.preview.rawJson"
+				),
+			});
+			details.createDiv({
+				cls: "setting-item-description",
+				text: plugin.i18n.translate(
+					"settings.integrations.jiraMapping.preview.rawJsonDescription"
+				),
+			});
+			// Jira content is untrusted; textContent keeps markup inert in the settings DOM.
+			details.createEl("pre", { text: raw.text });
+			if (raw.truncated) {
+				details.createDiv({
+					cls: "setting-item-description",
+					text: plugin.i18n.translate(
+						"settings.integrations.jiraMapping.preview.truncated"
+					),
+				});
+			}
+		};
+		refreshPreview();
+
+		const saveAndRefreshPreview = (): void => {
+			save();
+			refreshPreview();
+		};
+
+		new Setting(container)
 			.setName(plugin.i18n.translate("settings.integrations.jiraMapping.sourcesHeader"))
 			.setDesc(plugin.i18n.translate("settings.integrations.jiraMapping.sourcesDescription"))
 			.setHeading();
@@ -218,7 +419,7 @@ export function renderJiraMappingSettings(
 				target.id,
 				sources,
 				target.kind === "list",
-				save,
+				saveAndRefreshPreview,
 				render
 			);
 		}
@@ -237,7 +438,7 @@ export function renderJiraMappingSettings(
 					userField.displayName,
 					sources,
 					userField.type === "list",
-					save,
+					saveAndRefreshPreview,
 					render
 				);
 			}
@@ -255,7 +456,7 @@ export function renderJiraMappingSettings(
 			remaps.status,
 			(value) => {
 				remaps.status = value;
-				save();
+				saveAndRefreshPreview();
 			}
 		);
 		renderEnumRemapSetting(
@@ -265,7 +466,7 @@ export function renderJiraMappingSettings(
 			remaps.priority,
 			(value) => {
 				remaps.priority = value;
-				save();
+				saveAndRefreshPreview();
 			}
 		);
 		renderEnumRemapSetting(
@@ -275,7 +476,7 @@ export function renderJiraMappingSettings(
 			remaps.contexts,
 			(value) => {
 				remaps.contexts = value;
-				save();
+				saveAndRefreshPreview();
 			}
 		);
 	};

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -18,6 +18,50 @@ export interface UserMappedField {
 	defaultValue?: string | number | boolean | string[]; // Default value for the field
 }
 
+export type JiraValueSourceMode = "path" | "template" | "fixed" | "off";
+
+export interface JiraValueSource {
+	mode: JiraValueSourceMode;
+	value: string;
+}
+
+export interface JiraEnumRemap {
+	taskValue: string;
+	jiraValues: string[];
+}
+
+export type JiraBuiltInFieldId =
+	| "id"
+	| "title"
+	| "details"
+	| "status"
+	| "priority"
+	| "due"
+	| "scheduled"
+	| "timeEstimate"
+	| "dateCreated"
+	| "dateModified"
+	| "completedDate"
+	| "recurrence"
+	| "tags"
+	| "projects"
+	| "contexts";
+
+/**
+ * Versioned external-source mapping. User-field mappings are keyed by the stable
+ * UserMappedField.id so renaming a frontmatter key does not invalidate the mapping.
+ */
+export interface JiraFieldMappingSettings {
+	version: 1;
+	fields: Partial<Record<JiraBuiltInFieldId, JiraValueSource[]>>;
+	userFields: Record<string, JiraValueSource[]>;
+	enumRemaps: {
+		status: JiraEnumRemap[];
+		priority: JiraEnumRemap[];
+		contexts: JiraEnumRemap[];
+	};
+}
+
 /**
  * Field types for task modal configuration
  */
@@ -235,6 +279,7 @@ export interface TaskNotesSettings {
 	};
 	// Recurring task behavior
 	maintainDueDateOffsetInRecurring: boolean;
+	jiraMapping: JiraFieldMappingSettings;
 	resetCheckboxesOnRecurrence: boolean; // Reset markdown checkboxes in task body when recurring task completes
 	// Frontmatter link format settings
 	useFrontmatterMarkdownLinks: boolean; // Use markdown links in frontmatter (requires obsidian-frontmatter-markdown-links plugin)

--- a/styles/settings-view.css
+++ b/styles/settings-view.css
@@ -1384,6 +1384,57 @@ body.is-mobile .tasknotes-plugin .tasknotes-settings__card-action-btn {
     color: var(--text-warning);
 }
 
+/* Jira sample mapping preview */
+.tasknotes-jira-mapping-preview__values {
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+}
+
+.tasknotes-jira-mapping-preview__row {
+    display: grid;
+    grid-template-columns: minmax(8rem, 1fr) minmax(0, 2fr);
+    gap: 1rem;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.tasknotes-jira-mapping-preview__row:last-child {
+    border-bottom: 0;
+}
+
+.tasknotes-jira-mapping-preview__label {
+    font-weight: var(--font-semibold);
+}
+
+.tasknotes-jira-mapping-preview__value {
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.tasknotes-jira-mapping-preview__value.is-missing,
+.tasknotes-jira-mapping-preview__value.is-invalid {
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.tasknotes-jira-mapping-preview__error {
+    color: var(--text-error);
+    padding: 0.75rem 0;
+}
+
+.tasknotes-jira-mapping-preview__raw {
+    margin-top: 1rem;
+}
+
+.tasknotes-jira-mapping-preview__raw pre {
+    max-height: 24rem;
+    overflow: auto;
+    padding: 0.75rem;
+    background: var(--background-secondary);
+    border-radius: var(--radius-s);
+    white-space: pre-wrap;
+}
+
 /* ================================================
    ACCESSIBILITY & REDUCED MOTION
    ================================================ */

--- a/styles/settings-view.css
+++ b/styles/settings-view.css
@@ -1426,6 +1426,12 @@ body.is-mobile .tasknotes-plugin .tasknotes-settings__card-action-btn {
     margin-top: 1rem;
 }
 
+.tasknotes-jira-mapping-preview__raw-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.5rem;
+}
+
 .tasknotes-jira-mapping-preview__raw pre {
     max-height: 24rem;
     overflow: auto;

--- a/tests/unit/commands/jiraImportCommandRegistration.test.ts
+++ b/tests/unit/commands/jiraImportCommandRegistration.test.ts
@@ -1,0 +1,18 @@
+import { createTaskNotesCommandDefinitions } from "../../../src/commands/taskNotesCommands";
+import type TaskNotesPlugin from "../../../src/main";
+
+describe("Jira import command registration", () => {
+	it("registers the translated Jira import command", () => {
+		const commands = createTaskNotesCommandDefinitions({} as TaskNotesPlugin);
+
+		expect(commands).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "import-jira-issue",
+					nameKey: "commands.importJiraIssue",
+				}),
+			])
+		);
+	});
+});
+

--- a/tests/unit/integrations/JiraFieldMapping.test.ts
+++ b/tests/unit/integrations/JiraFieldMapping.test.ts
@@ -4,11 +4,13 @@ import type {
 	UserMappedField,
 } from "../../../src/types/settings";
 import {
+	buildJiraIssueBacklink,
 	buildJiraMappingPreview,
 	createDefaultJiraMappingSettings,
 	getJiraValueByPath,
 	mapJiraIssueWithSettings,
 	normalizeJiraMappingSettings,
+	prependJiraIssueBacklink,
 	renderJiraTemplate,
 } from "../../../src/integrations/jira/JiraFieldMapping";
 
@@ -197,6 +199,39 @@ describe("configurable Jira mapping", () => {
 				expect.objectContaining({ id: "due", status: "invalid" }),
 			])
 		);
+	});
+});
+
+describe("Jira issue backlinks", () => {
+	it("builds a credential-free browser URL from the Jira account host", () => {
+		const hostedIssue: JiraIssue = {
+			...issue,
+			account: {
+				host: "https://wizard:secret@magic.atlassian.net/jira?token=hidden",
+			},
+		};
+
+		expect(buildJiraIssueBacklink(hostedIssue)).toBe(
+			"[Jira MAGIC-17](<https://magic.atlassian.net/browse/MAGIC-17>)"
+		);
+	});
+
+	it("falls back to the companion plugin macro for missing or unsafe hosts", () => {
+		expect(
+			buildJiraIssueBacklink({
+				...issue,
+				account: { host: "javascript:alert(1)" },
+			})
+		).toBe("JIRA:MAGIC-17");
+		expect(buildJiraIssueBacklink(issue)).toBe("JIRA:MAGIC-17");
+	});
+
+	it("preserves mapped details and does not duplicate backlinks on retries", () => {
+		const first = prependJiraIssueBacklink("Keep these details.", issue);
+		const second = prependJiraIssueBacklink(first, issue);
+
+		expect(first).toBe("JIRA:MAGIC-17\n\nKeep these details.");
+		expect(second).toBe(first);
 	});
 });
 

--- a/tests/unit/integrations/JiraFieldMapping.test.ts
+++ b/tests/unit/integrations/JiraFieldMapping.test.ts
@@ -4,6 +4,7 @@ import type {
 	UserMappedField,
 } from "../../../src/types/settings";
 import {
+	buildJiraMappingPreview,
 	createDefaultJiraMappingSettings,
 	getJiraValueByPath,
 	mapJiraIssueWithSettings,
@@ -173,6 +174,28 @@ describe("configurable Jira mapping", () => {
 				due: undefined,
 				timeEstimate: undefined,
 			})
+		);
+	});
+
+	it("distinguishes resolved, empty, missing, and invalid preview values", () => {
+		const settings = createDefaultJiraMappingSettings();
+		settings.fields.due = [{ mode: "fixed", value: "not-a-date" }];
+		settings.fields.projects = [{ mode: "path", value: "fields.emptyProjects" }];
+		settings.fields.contexts = [{ mode: "path", value: "fields.missing" }];
+		const issueWithEmptyList = {
+			...issue,
+			fields: { ...issue.fields, emptyProjects: [] },
+		};
+
+		const preview = buildJiraMappingPreview(issueWithEmptyList, settings, []);
+
+		expect(preview).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "title", status: "value" }),
+				expect.objectContaining({ id: "projects", status: "empty", value: [] }),
+				expect.objectContaining({ id: "contexts", status: "missing" }),
+				expect.objectContaining({ id: "due", status: "invalid" }),
+			])
 		);
 	});
 });

--- a/tests/unit/integrations/JiraFieldMapping.test.ts
+++ b/tests/unit/integrations/JiraFieldMapping.test.ts
@@ -203,26 +203,7 @@ describe("configurable Jira mapping", () => {
 });
 
 describe("Jira issue backlinks", () => {
-	it("builds a credential-free browser URL from the Jira account host", () => {
-		const hostedIssue: JiraIssue = {
-			...issue,
-			account: {
-				host: "https://wizard:secret@magic.atlassian.net/jira?token=hidden",
-			},
-		};
-
-		expect(buildJiraIssueBacklink(hostedIssue)).toBe(
-			"[Jira MAGIC-17](<https://magic.atlassian.net/browse/MAGIC-17>)"
-		);
-	});
-
-	it("falls back to the companion plugin macro for missing or unsafe hosts", () => {
-		expect(
-			buildJiraIssueBacklink({
-				...issue,
-				account: { host: "javascript:alert(1)" },
-			})
-		).toBe("JIRA:MAGIC-17");
+	it("uses the companion plugin's canonical issue macro", () => {
 		expect(buildJiraIssueBacklink(issue)).toBe("JIRA:MAGIC-17");
 	});
 

--- a/tests/unit/integrations/JiraFieldMapping.test.ts
+++ b/tests/unit/integrations/JiraFieldMapping.test.ts
@@ -1,0 +1,237 @@
+import type { JiraIssue } from "../../../src/integrations/jira/JiraIssueAdapter";
+import type {
+	JiraFieldMappingSettings,
+	UserMappedField,
+} from "../../../src/types/settings";
+import {
+	createDefaultJiraMappingSettings,
+	getJiraValueByPath,
+	mapJiraIssueWithSettings,
+	normalizeJiraMappingSettings,
+	renderJiraTemplate,
+} from "../../../src/integrations/jira/JiraFieldMapping";
+
+const issue: JiraIssue = {
+	key: "MAGIC-17",
+	fields: {
+		summary: "Audit enchanted broom inventory",
+		description: "Three brooms remain unaccounted for.",
+		status: { name: "Doing" },
+		priority: { name: "Major" },
+		created: "2026-07-30T12:00:00.000Z",
+		duedate: "2026-08-05",
+		timeestimate: 3600,
+		labels: ["inventory", "magic"],
+		components: [{ name: "Dungeon" }, { name: "Laboratory" }],
+		customfield_10090: "8",
+		customfield_boolean: "yes",
+	},
+};
+
+describe("safe Jira path lookup", () => {
+	it("supports nested properties, indexes, and array projection", () => {
+		expect(getJiraValueByPath(issue, "fields.status.name")).toBe("Doing");
+		expect(getJiraValueByPath(issue, "fields.components[1].name")).toBe("Laboratory");
+		expect(getJiraValueByPath(issue, "fields.components[].name")).toEqual([
+			"Dungeon",
+			"Laboratory",
+		]);
+	});
+
+	it.each([
+		"__proto__.polluted",
+		"constructor.prototype",
+		"fields.__proto__.polluted",
+		"fields[nope].summary",
+	])("rejects unsafe or malformed path %s", (path) => {
+		expect(getJiraValueByPath(issue, path)).toBeUndefined();
+	});
+
+	it("never reads inherited properties", () => {
+		const inherited = Object.create({ secret: "not allowed" }) as Record<string, unknown>;
+		inherited.own = "allowed";
+
+		expect(getJiraValueByPath(inherited, "own")).toBe("allowed");
+		expect(getJiraValueByPath(inherited, "secret")).toBeUndefined();
+	});
+});
+
+describe("Jira templates", () => {
+	it("renders aliases, paths, arrays, missing values, and escaped newlines", () => {
+		expect(
+			renderJiraTemplate(
+				"$key $summary\\n$fields.components[].name $fields.missing",
+				issue
+			)
+		).toBe("MAGIC-17 Audit enchanted broom inventory\nDungeon, Laboratory");
+	});
+
+	it("leaves malformed token syntax as literal text", () => {
+		expect(renderJiraTemplate("Cost is $ and ${fields.summary}", issue)).toBe(
+			"Cost is $ and ${fields.summary}"
+		);
+	});
+});
+
+describe("configurable Jira mapping", () => {
+	it("supports fixed, path, and template scalar sources", () => {
+		const settings = createDefaultJiraMappingSettings();
+		settings.fields.title = [
+			{ mode: "template", value: "[$key] $fields.summary" },
+		];
+		settings.fields.status = [{ mode: "fixed", value: "open" }];
+		settings.fields.due = [{ mode: "path", value: "fields.duedate" }];
+
+		expect(mapJiraIssueWithSettings(issue, settings, [])).toEqual(
+			expect.objectContaining({
+				title: "[MAGIC-17] Audit enchanted broom inventory",
+				status: "open",
+				due: "2026-08-05",
+			})
+		);
+	});
+
+	it("merges, flattens, trims, and deduplicates list sources", () => {
+		const settings = createDefaultJiraMappingSettings();
+		settings.fields.contexts = [
+			{ mode: "path", value: "fields.components[].name" },
+			{ mode: "fixed", value: " Laboratory " },
+		];
+		settings.fields.tags = [
+			{ mode: "path", value: "fields.labels" },
+			{ mode: "fixed", value: "demo" },
+		];
+
+		expect(mapJiraIssueWithSettings(issue, settings, [])).toEqual(
+			expect.objectContaining({
+				contexts: ["Dungeon", "Laboratory"],
+				tags: ["inventory", "magic", "demo"],
+			})
+		);
+	});
+
+	it("remaps enum values case-insensitively and preserves unmatched values", () => {
+		const settings = createDefaultJiraMappingSettings();
+		settings.fields.contexts = [
+			{ mode: "path", value: "fields.components[].name" },
+		];
+		settings.enumRemaps.status = [
+			{ taskValue: "in-progress", jiraValues: ["In Progress", "doing"] },
+		];
+		settings.enumRemaps.priority = [
+			{ taskValue: "high", jiraValues: ["major"] },
+		];
+		settings.enumRemaps.contexts = [
+			{ taskValue: "lab", jiraValues: ["laboratory"] },
+		];
+
+		expect(mapJiraIssueWithSettings(issue, settings, [])).toEqual(
+			expect.objectContaining({
+				status: "in-progress",
+				priority: "high",
+				contexts: ["Dungeon", "lab"],
+			})
+		);
+	});
+
+	it("uses stable user-field IDs and current frontmatter keys with type coercion", () => {
+		const settings = createDefaultJiraMappingSettings();
+		settings.userFields.storyPoints = [
+			{ mode: "path", value: "fields.customfield_10090" },
+		];
+		settings.userFields.requiresWand = [
+			{ mode: "path", value: "fields.customfield_boolean" },
+		];
+		const userFields: UserMappedField[] = [
+			{
+				id: "storyPoints",
+				displayName: "Story points",
+				key: "renamed_points_key",
+				type: "number",
+			},
+			{
+				id: "requiresWand",
+				displayName: "Requires wand",
+				key: "requires_wand",
+				type: "boolean",
+			},
+		];
+
+		expect(mapJiraIssueWithSettings(issue, settings, userFields).customFrontmatter).toEqual({
+			renamed_points_key: 8,
+			requires_wand: true,
+		});
+	});
+
+	it("drops invalid dates and numbers instead of writing surprising values", () => {
+		const settings = createDefaultJiraMappingSettings();
+		settings.fields.due = [{ mode: "fixed", value: "not-a-date" }];
+		settings.fields.timeEstimate = [{ mode: "fixed", value: "not-a-number" }];
+
+		expect(mapJiraIssueWithSettings(issue, settings, [])).toEqual(
+			expect.objectContaining({
+				due: undefined,
+				timeEstimate: undefined,
+			})
+		);
+	});
+});
+
+describe("Jira mapping settings normalization", () => {
+	it("fills malformed or missing settings from versioned defaults", () => {
+		const normalized = normalizeJiraMappingSettings({
+			version: 99,
+			fields: {
+				title: [{ mode: "unknown", value: 42 }],
+				tags: "not-an-array",
+			},
+			userFields: {
+				__proto__: [{ mode: "path", value: "unsafe" }],
+				valid: [{ mode: "fixed", value: "ok" }],
+			},
+		});
+
+		expect(normalized.version).toBe(1);
+		expect(normalized.fields.title).toEqual(
+			createDefaultJiraMappingSettings().fields.title
+		);
+		expect(normalized.fields.tags).toEqual(
+			createDefaultJiraMappingSettings().fields.tags
+		);
+		expect(normalized.userFields).toEqual({
+			valid: [{ mode: "fixed", value: "ok" }],
+		});
+	});
+
+	it("upgrades the legacy unversioned field and enum-map shape", () => {
+		const legacy = {
+			title: { mode: "template", value: "$key: $summary" },
+			tags: [{ mode: "path", value: "fields.labels" }],
+			statusMap: [{ taskValue: "done", jiraValues: ["Closed"] }],
+		};
+
+		const normalized = normalizeJiraMappingSettings(legacy);
+
+		expect(normalized.fields.title).toEqual([
+			{ mode: "template", value: "$key: $summary" },
+		]);
+		expect(normalized.fields.tags).toEqual([
+			{ mode: "path", value: "fields.labels" },
+		]);
+		expect(normalized.enumRemaps.status).toEqual([
+			{ taskValue: "done", jiraValues: ["Closed"] },
+		]);
+	});
+
+	it("normalizes a fully configured versioned shape without losing sources", () => {
+		const settings: JiraFieldMappingSettings = createDefaultJiraMappingSettings();
+		settings.fields.projects = [
+			{ mode: "path", value: "fields.project.name" },
+			{ mode: "fixed", value: "[[Imported work]]" },
+		];
+
+		expect(normalizeJiraMappingSettings(settings).fields.projects).toEqual(
+			settings.fields.projects
+		);
+	});
+});

--- a/tests/unit/integrations/JiraIssueAdapter.test.ts
+++ b/tests/unit/integrations/JiraIssueAdapter.test.ts
@@ -1,0 +1,78 @@
+import {
+	JiraIssueAdapter,
+	JiraIssueAdapterError,
+	normalizeJiraIssueKey,
+} from "../../../src/integrations/jira/JiraIssueAdapter";
+
+describe("JiraIssueAdapter", () => {
+	it("normalizes valid issue keys", () => {
+		expect(normalizeJiraIssueKey(" proj-123 ")).toBe("PROJ-123");
+	});
+
+	it("rejects invalid issue keys before resolving the plugin", async () => {
+		const getPlugin = jest.fn();
+		const adapter = new JiraIssueAdapter(getPlugin);
+
+		await expect(adapter.getIssue("not an issue key")).rejects.toMatchObject({
+			code: "invalid-issue-key",
+		});
+		expect(getPlugin).not.toHaveBeenCalled();
+	});
+
+	it("reports a missing or incompatible dependency", async () => {
+		const adapter = new JiraIssueAdapter(() => null);
+
+		await expect(adapter.getIssue("PROJ-123")).rejects.toMatchObject({
+			code: "dependency-unavailable",
+		});
+	});
+
+	it("wraps provider fetch failures", async () => {
+		const providerError = new Error("network unavailable");
+		const adapter = new JiraIssueAdapter(() => ({
+			api: {
+				base: {
+					getIssue: jest.fn().mockRejectedValue(providerError),
+				},
+			},
+		}));
+
+		await expect(adapter.getIssue("PROJ-123")).rejects.toMatchObject({
+			code: "fetch-failed",
+			cause: providerError,
+		});
+	});
+
+	it("rejects malformed provider responses", async () => {
+		const adapter = new JiraIssueAdapter(() => ({
+			api: {
+				base: {
+					getIssue: jest.fn().mockResolvedValue({ key: "PROJ-123", fields: {} }),
+				},
+			},
+		}));
+
+		await expect(adapter.getIssue("PROJ-123")).rejects.toBeInstanceOf(
+			JiraIssueAdapterError
+		);
+		await expect(adapter.getIssue("PROJ-123")).rejects.toMatchObject({
+			code: "invalid-response",
+		});
+	});
+
+	it("fetches a validated issue with the normalized key", async () => {
+		const issue = {
+			key: "PROJ-123",
+			fields: { summary: "Conjure release notes" },
+		};
+		const getIssue = jest.fn().mockResolvedValue(issue);
+		const adapter = new JiraIssueAdapter(() => ({
+			api: { base: { getIssue } },
+		}));
+
+		await expect(adapter.getIssue("proj-123")).resolves.toBe(issue);
+		expect(getIssue).toHaveBeenCalledTimes(1);
+		expect(getIssue).toHaveBeenCalledWith("PROJ-123");
+	});
+});
+

--- a/tests/unit/services/JiraImportService.test.ts
+++ b/tests/unit/services/JiraImportService.test.ts
@@ -1,0 +1,100 @@
+import type { TaskInfo } from "../../../src/types";
+import type { JiraIssue } from "../../../src/integrations/jira/JiraIssueAdapter";
+import {
+	JiraImportError,
+	JiraImportService,
+	mapJiraIssueToTaskCreationData,
+} from "../../../src/services/JiraImportService";
+
+const issue: JiraIssue = {
+	key: "WIZ-42",
+	fields: {
+		summary: "Teach the build dragon to whisper",
+		description: {
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [{ type: "text", text: "The CI flames are too loud." }],
+				},
+			],
+		},
+		status: { name: "In Progress" },
+		priority: { name: "HIGH" },
+		created: "2026-07-30T12:00:00.000Z",
+		duedate: "2026-08-04",
+		timeestimate: 2700,
+		labels: ["demo", 12, "dragon"],
+	},
+};
+
+describe("mapJiraIssueToTaskCreationData", () => {
+	it("maps the baseline Jira fields without involving core frontmatter mapping", () => {
+		expect(mapJiraIssueToTaskCreationData(issue)).toEqual({
+			title: "WIZ-42 Teach the build dragon to whisper",
+			details: "The CI flames are too loud.",
+			status: "In Progress",
+			priority: "high",
+			dateCreated: "2026-07-30T12:00:00.000Z",
+			due: "2026-08-04",
+			timeEstimate: 45,
+			tags: ["demo", "dragon"],
+			creationContext: "import",
+		});
+	});
+});
+
+describe("JiraImportService", () => {
+	it("fetches once and creates exactly one task through current creation defaults", async () => {
+		const adapter = { getIssue: jest.fn().mockResolvedValue(issue) };
+		const taskInfo = {
+			path: "Tasks/WIZ-42 Teach the build dragon to whisper.md",
+			title: "WIZ-42 Teach the build dragon to whisper",
+		} as TaskInfo;
+		const taskCreator = {
+			createTask: jest.fn().mockResolvedValue({ taskInfo }),
+		};
+		const service = new JiraImportService(adapter as never, taskCreator);
+
+		await expect(service.importIssue("WIZ-42")).resolves.toBe(taskInfo);
+		expect(adapter.getIssue).toHaveBeenCalledTimes(1);
+		expect(taskCreator.createTask).toHaveBeenCalledTimes(1);
+		expect(taskCreator.createTask).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "WIZ-42 Teach the build dragon to whisper",
+				creationContext: "import",
+			}),
+			{ applyDefaults: true, applyTemplate: true }
+		);
+	});
+
+	it("does not attempt creation after a fetch failure", async () => {
+		const adapter = {
+			getIssue: jest
+				.fn()
+				.mockRejectedValue(
+					new JiraImportError("fetch-failed", "Jira is unavailable")
+				),
+		};
+		const taskCreator = { createTask: jest.fn() };
+		const service = new JiraImportService(adapter as never, taskCreator as never);
+
+		await expect(service.importIssue("WIZ-42")).rejects.toMatchObject({
+			code: "fetch-failed",
+		});
+		expect(taskCreator.createTask).not.toHaveBeenCalled();
+	});
+
+	it("distinguishes task creation failures from fetch failures", async () => {
+		const adapter = { getIssue: jest.fn().mockResolvedValue(issue) };
+		const taskCreator = {
+			createTask: jest.fn().mockRejectedValue(new Error("vault is read-only")),
+		};
+		const service = new JiraImportService(adapter as never, taskCreator);
+
+		await expect(service.importIssue("WIZ-42")).rejects.toMatchObject({
+			code: "creation-failed",
+		});
+	});
+});
+

--- a/tests/unit/services/JiraImportService.test.ts
+++ b/tests/unit/services/JiraImportService.test.ts
@@ -3,8 +3,11 @@ import type { JiraIssue } from "../../../src/integrations/jira/JiraIssueAdapter"
 import {
 	JiraImportError,
 	JiraImportService,
-	mapJiraIssueToTaskCreationData,
 } from "../../../src/services/JiraImportService";
+import {
+	createDefaultJiraMappingSettings,
+	mapJiraIssueWithSettings,
+} from "../../../src/integrations/jira/JiraFieldMapping";
 
 const issue: JiraIssue = {
 	key: "WIZ-42",
@@ -28,9 +31,13 @@ const issue: JiraIssue = {
 	},
 };
 
-describe("mapJiraIssueToTaskCreationData", () => {
+describe("default Jira field mapping", () => {
 	it("maps the baseline Jira fields without involving core frontmatter mapping", () => {
-		expect(mapJiraIssueToTaskCreationData(issue)).toEqual({
+		expect(
+			mapJiraIssueWithSettings(issue, createDefaultJiraMappingSettings(), [])
+		).toEqual(
+			expect.objectContaining({
+			id: "WIZ-42",
 			title: "WIZ-42 Teach the build dragon to whisper",
 			details: "The CI flames are too loud.",
 			status: "In Progress",
@@ -38,9 +45,10 @@ describe("mapJiraIssueToTaskCreationData", () => {
 			dateCreated: "2026-07-30T12:00:00.000Z",
 			due: "2026-08-04",
 			timeEstimate: 45,
-			tags: ["demo", "dragon"],
+			tags: ["demo", "12", "dragon"],
 			creationContext: "import",
-		});
+			})
+		);
 	});
 });
 
@@ -54,7 +62,12 @@ describe("JiraImportService", () => {
 		const taskCreator = {
 			createTask: jest.fn().mockResolvedValue({ taskInfo }),
 		};
-		const service = new JiraImportService(adapter as never, taskCreator);
+		const service = new JiraImportService(
+			adapter as never,
+			taskCreator,
+			createDefaultJiraMappingSettings(),
+			[]
+		);
 
 		await expect(service.importIssue("WIZ-42")).resolves.toBe(taskInfo);
 		expect(adapter.getIssue).toHaveBeenCalledTimes(1);
@@ -77,7 +90,12 @@ describe("JiraImportService", () => {
 				),
 		};
 		const taskCreator = { createTask: jest.fn() };
-		const service = new JiraImportService(adapter as never, taskCreator as never);
+		const service = new JiraImportService(
+			adapter as never,
+			taskCreator as never,
+			createDefaultJiraMappingSettings(),
+			[]
+		);
 
 		await expect(service.importIssue("WIZ-42")).rejects.toMatchObject({
 			code: "fetch-failed",
@@ -90,11 +108,15 @@ describe("JiraImportService", () => {
 		const taskCreator = {
 			createTask: jest.fn().mockRejectedValue(new Error("vault is read-only")),
 		};
-		const service = new JiraImportService(adapter as never, taskCreator);
+		const service = new JiraImportService(
+			adapter as never,
+			taskCreator,
+			createDefaultJiraMappingSettings(),
+			[]
+		);
 
 		await expect(service.importIssue("WIZ-42")).rejects.toMatchObject({
 			code: "creation-failed",
 		});
 	});
 });
-

--- a/tests/unit/services/JiraImportService.test.ts
+++ b/tests/unit/services/JiraImportService.test.ts
@@ -1,4 +1,4 @@
-import type { TaskInfo } from "../../../src/types";
+import type { TaskCreationData, TaskInfo } from "../../../src/types";
 import type { JiraIssue } from "../../../src/integrations/jira/JiraIssueAdapter";
 import {
 	JiraImportError,
@@ -8,6 +8,7 @@ import {
 	createDefaultJiraMappingSettings,
 	mapJiraIssueWithSettings,
 } from "../../../src/integrations/jira/JiraFieldMapping";
+import { applyParentNoteProjectDefault } from "../../../src/utils/taskCreationPrepopulation";
 
 const issue: JiraIssue = {
 	key: "WIZ-42",
@@ -39,7 +40,7 @@ describe("default Jira field mapping", () => {
 			expect.objectContaining({
 			id: "WIZ-42",
 			title: "WIZ-42 Teach the build dragon to whisper",
-			details: "The CI flames are too loud.",
+			details: "JIRA:WIZ-42\n\nThe CI flames are too loud.",
 			status: "In Progress",
 			priority: "high",
 			dateCreated: "2026-07-30T12:00:00.000Z",
@@ -78,6 +79,43 @@ describe("JiraImportService", () => {
 				creationContext: "import",
 			}),
 			{ applyDefaults: true, applyTemplate: true }
+		);
+	});
+
+	it("uses the current-note project default only when Jira did not map projects", async () => {
+		const adapter = { getIssue: jest.fn().mockResolvedValue(issue) };
+		const taskCreator = {
+			createTask: jest.fn().mockResolvedValue({
+				taskInfo: { path: "Tasks/WIZ-42.md", title: "Imported" } as TaskInfo,
+			}),
+		};
+		const applyCurrentNoteProject = (taskData: TaskCreationData): TaskCreationData =>
+			(applyParentNoteProjectDefault(
+				taskData,
+				"[[Wizard laboratory]]"
+			) as TaskCreationData | undefined) ?? taskData;
+		const defaults = createDefaultJiraMappingSettings();
+		const service = new JiraImportService(
+			adapter as never,
+			taskCreator,
+			defaults,
+			[],
+			applyCurrentNoteProject
+		);
+
+		await service.importIssue("WIZ-42");
+		expect(taskCreator.createTask).toHaveBeenLastCalledWith(
+			expect.objectContaining({ projects: ["[[Wizard laboratory]]"] }),
+			expect.anything()
+		);
+
+		defaults.fields.projects = [
+			{ mode: "fixed", value: "[[Explicit Jira project]]" },
+		];
+		await service.importIssue("WIZ-42");
+		expect(taskCreator.createTask).toHaveBeenLastCalledWith(
+			expect.objectContaining({ projects: ["[[Explicit Jira project]]"] }),
+			expect.anything()
 		);
 	});
 

--- a/tests/unit/settings/jiraMappingSettings.test.ts
+++ b/tests/unit/settings/jiraMappingSettings.test.ts
@@ -22,6 +22,9 @@ describe("Jira mapping settings", () => {
 		"settings.integrations.jiraMapping.preview.invalid": "Invalid value",
 		"settings.integrations.jiraMapping.preview.rawJson": "Raw Jira issue JSON",
 		"settings.integrations.jiraMapping.preview.rawJsonDescription": "Sensitive data",
+		"settings.integrations.jiraMapping.preview.copyRawJson": "Copy raw Jira issue JSON",
+		"settings.integrations.jiraMapping.preview.copySuccess": "Copied",
+		"settings.integrations.jiraMapping.preview.copyFailure": "Copy failed",
 		"settings.integrations.jiraMapping.preview.truncated": "Truncated",
 	};
 
@@ -101,6 +104,11 @@ describe("Jira mapping settings", () => {
 			key: "MAGIC-17",
 			fields: { summary: '<img src=x onerror="alert(1)">' },
 		};
+		const clipboardWrite = jest.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: clipboardWrite },
+		});
 		const getIssue = jest.fn().mockResolvedValue(issue);
 		const plugin = {
 			app: {
@@ -139,6 +147,13 @@ describe("Jira mapping settings", () => {
 		expect(details?.open).toBe(false);
 		expect(save).not.toHaveBeenCalled();
 		expect(JSON.stringify(plugin.settings)).not.toContain("MAGIC-17");
+
+		const copyButton = container.querySelector(
+			'button[aria-label="Copy raw Jira issue JSON"]'
+		) as HTMLButtonElement;
+		copyButton.click();
+		await Promise.resolve();
+		expect(clipboardWrite).toHaveBeenCalledWith(JSON.stringify(issue, null, 2));
 	});
 
 	it("renders loading and fetch error states", async () => {

--- a/tests/unit/settings/jiraMappingSettings.test.ts
+++ b/tests/unit/settings/jiraMappingSettings.test.ts
@@ -3,9 +3,28 @@ import { createDefaultJiraMappingSettings } from "../../../src/integrations/jira
 import {
 	parseJiraEnumRemaps,
 	renderJiraMappingSettings,
+	serializeJiraIssuePreview,
 } from "../../../src/settings/tabs/jiraMappingSettings";
+import type { JiraIssue } from "../../../src/integrations/jira/JiraIssueAdapter";
 
 describe("Jira mapping settings", () => {
+	const previewTranslations: Record<string, string> = {
+		"settings.integrations.jiraMapping.preview.sampleIssue": "Sample issue",
+		"settings.integrations.jiraMapping.preview.sampleIssueDescription": "Fetch a sample",
+		"settings.integrations.jiraMapping.preview.issueKey": "Sample Jira issue key",
+		"settings.integrations.jiraMapping.preview.issueKeyPlaceholder": "PROJ-123",
+		"settings.integrations.jiraMapping.preview.fetch": "Fetch preview",
+		"settings.integrations.jiraMapping.preview.loading": "Loading…",
+		"settings.integrations.jiraMapping.preview.unknownError": "Unknown error",
+		"settings.integrations.jiraMapping.preview.resolvedValues": "Resolved values",
+		"settings.integrations.jiraMapping.preview.resolvedValuesDescription": "Mapped values",
+		"settings.integrations.jiraMapping.preview.missing": "Not set",
+		"settings.integrations.jiraMapping.preview.invalid": "Invalid value",
+		"settings.integrations.jiraMapping.preview.rawJson": "Raw Jira issue JSON",
+		"settings.integrations.jiraMapping.preview.rawJsonDescription": "Sensitive data",
+		"settings.integrations.jiraMapping.preview.truncated": "Truncated",
+	};
+
 	it("parses enum remap rows and ignores incomplete rows", () => {
 		expect(
 			parseJiraEnumRemaps(
@@ -38,6 +57,7 @@ describe("Jira mapping settings", () => {
 			"settings.integrations.jiraMapping.userFieldsDescription": "User field sources",
 			"settings.integrations.jiraMapping.remapsHeader": "Value remapping",
 			"settings.integrations.jiraMapping.remapsDescription": "Remaps",
+			...previewTranslations,
 		};
 		const plugin = {
 			settings: {
@@ -60,5 +80,105 @@ describe("Jira mapping settings", () => {
 			createDefaultJiraMappingSettings().fields.title
 		);
 		expect(save).toHaveBeenCalledTimes(1);
+	});
+
+	it("truncates large raw issue payloads", () => {
+		const issue = {
+			key: "MAGIC-1",
+			fields: { summary: "x".repeat(100) },
+		} as JiraIssue;
+
+		expect(serializeJiraIssuePreview(issue, 20)).toEqual({
+			text: expect.stringMatching(/^.{20}\n…$/s),
+			truncated: true,
+		});
+	});
+
+	it("fetches an ephemeral sample and renders raw JSON as inert text", async () => {
+		const container = document.createElement("div");
+		const save = jest.fn();
+		const issue = {
+			key: "MAGIC-17",
+			fields: { summary: '<img src=x onerror="alert(1)">' },
+		};
+		const getIssue = jest.fn().mockResolvedValue(issue);
+		const plugin = {
+			app: {
+				plugins: {
+					getPlugin: () => ({ api: { base: { getIssue } } }),
+				},
+			},
+			settings: {
+				jiraMapping: createDefaultJiraMappingSettings(),
+				userFields: [],
+			},
+			i18n: {
+				translate: (key: string) => previewTranslations[key] ?? key,
+			},
+		} as unknown as TaskNotesPlugin;
+
+		renderJiraMappingSettings(container, plugin, save);
+		const input = container.querySelector(
+			'input[placeholder="PROJ-123"]'
+		) as HTMLInputElement;
+		input.value = "magic-17";
+		input.dispatchEvent(new window.Event("input"));
+		const fetchButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent === "Fetch preview"
+		);
+		fetchButton?.click();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const raw = container.querySelector("pre");
+		const details = container.querySelector("details");
+		expect(getIssue).toHaveBeenCalledWith("MAGIC-17");
+		expect(raw?.textContent).toContain("<img src=x onerror=");
+		expect(raw?.textContent).toContain("alert(1)");
+		expect(container.querySelector("img")).toBeNull();
+		expect(details?.open).toBe(false);
+		expect(save).not.toHaveBeenCalled();
+		expect(JSON.stringify(plugin.settings)).not.toContain("MAGIC-17");
+	});
+
+	it("renders loading and fetch error states", async () => {
+		const container = document.createElement("div");
+		let rejectFetch: (error: Error) => void = () => {};
+		const getIssue = jest.fn(
+			() =>
+				new Promise((_resolve, reject) => {
+					rejectFetch = reject;
+				})
+		);
+		const plugin = {
+			app: {
+				plugins: {
+					getPlugin: () => ({ api: { base: { getIssue } } }),
+				},
+			},
+			settings: {
+				jiraMapping: createDefaultJiraMappingSettings(),
+				userFields: [],
+			},
+			i18n: {
+				translate: (key: string) => previewTranslations[key] ?? key,
+			},
+		} as unknown as TaskNotesPlugin;
+
+		renderJiraMappingSettings(container, plugin, jest.fn());
+		const input = container.querySelector(
+			'input[placeholder="PROJ-123"]'
+		) as HTMLInputElement;
+		input.value = "MAGIC-17";
+		input.dispatchEvent(new window.Event("input"));
+		Array.from(container.querySelectorAll("button"))
+			.find((button) => button.textContent === "Fetch preview")
+			?.click();
+
+		expect(container.textContent).toContain("Loading…");
+		rejectFetch(new Error("Jira is taking a nap"));
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(container.textContent).toContain("Failed to fetch Jira issue MAGIC-17");
 	});
 });

--- a/tests/unit/settings/jiraMappingSettings.test.ts
+++ b/tests/unit/settings/jiraMappingSettings.test.ts
@@ -1,0 +1,64 @@
+import type TaskNotesPlugin from "../../../src/main";
+import { createDefaultJiraMappingSettings } from "../../../src/integrations/jira/JiraFieldMapping";
+import {
+	parseJiraEnumRemaps,
+	renderJiraMappingSettings,
+} from "../../../src/settings/tabs/jiraMappingSettings";
+
+describe("Jira mapping settings", () => {
+	it("parses enum remap rows and ignores incomplete rows", () => {
+		expect(
+			parseJiraEnumRemaps(
+				"in-progress = In Progress, Doing\nhigh = Major\nmissing separator\n = Empty"
+			)
+		).toEqual([
+			{
+				taskValue: "in-progress",
+				jiraValues: ["In Progress", "Doing"],
+			},
+			{
+				taskValue: "high",
+				jiraValues: ["Major"],
+			},
+		]);
+	});
+
+	it("resets mappings and persists the restored defaults", () => {
+		const container = document.createElement("div");
+		const jiraMapping = createDefaultJiraMappingSettings();
+		jiraMapping.fields.title = [{ mode: "fixed", value: "Custom title" }];
+		const save = jest.fn();
+		const translations: Record<string, string> = {
+			"settings.integrations.jiraMapping.header": "Jira field mapping",
+			"settings.integrations.jiraMapping.description": "Description",
+			"settings.integrations.jiraMapping.reset": "Reset mappings",
+			"settings.integrations.jiraMapping.sourcesHeader": "Property sources",
+			"settings.integrations.jiraMapping.sourcesDescription": "Sources",
+			"settings.integrations.jiraMapping.userFieldsHeader": "User fields",
+			"settings.integrations.jiraMapping.userFieldsDescription": "User field sources",
+			"settings.integrations.jiraMapping.remapsHeader": "Value remapping",
+			"settings.integrations.jiraMapping.remapsDescription": "Remaps",
+		};
+		const plugin = {
+			settings: {
+				jiraMapping,
+				userFields: [],
+			},
+			i18n: {
+				translate: (key: string) => translations[key] ?? key,
+			},
+		} as unknown as TaskNotesPlugin;
+
+		renderJiraMappingSettings(container, plugin, save);
+		const resetButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent === "Reset mappings"
+		);
+		resetButton?.click();
+
+		expect(resetButton).toBeDefined();
+		expect(plugin.settings.jiraMapping.fields.title).toEqual(
+			createDefaultJiraMappingSettings().fields.title
+		);
+		expect(save).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/unit/settings/settingsPersistence.test.ts
+++ b/tests/unit/settings/settingsPersistence.test.ts
@@ -191,4 +191,44 @@ describe("settings persistence helpers", () => {
 			})
 		);
 	});
+
+	it("loads and preserves a valid versioned Jira mapping", () => {
+		const jiraMapping = {
+			...DEFAULT_SETTINGS.jiraMapping,
+			fields: {
+				...DEFAULT_SETTINGS.jiraMapping.fields,
+				title: [{ mode: "fixed" as const, value: "Imported task" }],
+			},
+		};
+
+		const { settings } = buildSettingsFromLoadedData({
+			jiraMapping,
+		});
+
+		expect(settings.jiraMapping.fields.title).toEqual([
+			{ mode: "fixed", value: "Imported task" },
+		]);
+	});
+
+	it("normalizes and marks legacy Jira mapping settings for persistence", () => {
+		const { settings, shouldPersistMigratedSettings } = buildSettingsFromLoadedData({
+			jiraMapping: {
+				title: { mode: "template", value: "$key $summary" },
+				statusMap: [{ taskValue: "done", jiraValues: ["Closed"] }],
+			},
+		} as never);
+
+		expect(settings.jiraMapping).toEqual(
+			expect.objectContaining({
+				version: 1,
+				fields: expect.objectContaining({
+					title: [{ mode: "template", value: "$key $summary" }],
+				}),
+				enumRemaps: expect.objectContaining({
+					status: [{ taskValue: "done", jiraValues: ["Closed"] }],
+				}),
+			})
+		);
+		expect(shouldPersistMigratedSettings).toBe(true);
+	});
 });


### PR DESCRIPTION
This PR adds Jira issue import support through the optional    
  obsidian-jira-issue plugin. Imported issues are converted into 
  TaskNotes tasks using configurable field mappings, including   
  Jira paths, templates, fixed values, list merging, enum        
  remapping, and user-defined fields. The settings UI includes an
  ephemeral sample-issue preview and a collapsible, resizable raw  JSON viewer with clipboard support.                            

  Imports use TaskNotes’ existing creation defaults and filename-
  sanitization pipeline. Each task includes a JIRA:PROJ-1234     
  backlink, preserves mapped issue details, and optionally       
  inherits the active note as its project when enabled—unless the
  Jira mapping explicitly supplies projects. 
                                                                 
<img width="1473" height="1110" alt="image" src="https://github.com/user-attachments/assets/0ea75421-b56e-449e-9913-5e9f699e4457" />

Jira issue fields are mapped into the new TaskNotes task
<img width="1351" height="929" alt="image" src="https://github.com/user-attachments/assets/f68a9308-c21e-448b-bbc3-76ae81613bba" />

<img width="1424" height="1143" alt="image" src="https://github.com/user-attachments/assets/ae232183-a32d-4e4c-836d-0212fa1746e4" />

<img width="1441" height="1170" alt="image" src="https://github.com/user-attachments/assets/9d048856-b361-4bf6-85eb-0cadc86d6fbf" />

<img width="1483" height="1188" alt="image" src="https://github.com/user-attachments/assets/ce021730-4514-4183-b7c2-2086c3af1cff" />
