### PR TITLE
Fix inline task Live Preview clicks on Obsidian 1.13

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -51,6 +51,10 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 ## Fixed
 
+- (#2180) Inline task cards in Live Preview now keep their click and context menu
+  handlers active on Obsidian 1.13, so clicking a rendered task link opens the
+  edit modal instead of revealing the raw wikilink. Thanks to @npondel for the
+  detailed diagnosis and @minchinweb for confirming the issue.
 - ([#2171](https://github.com/callumalpass/tasknotes/pull/2171)) Stopped recurring
   notification and status-bar scans from reading unindexed notes directly from
   disk while preserving the fallback for direct task lookups. Thanks to

--- a/src/editor/TaskLinkWidget.ts
+++ b/src/editor/TaskLinkWidget.ts
@@ -59,6 +59,21 @@ export class TaskLinkWidget extends WidgetType {
 		wrapper.classList.add("tn-static-display-inline-cccfa456");
 		wrapper.classList.add("tn-static-vertical-align-baseline-657d9c46");
 
+		// Keep CodeMirror from moving the selection onto the replaced link before
+		// the card receives its click/contextmenu event.
+		wrapper.addEventListener("pointerdown", (event) => {
+			event.stopPropagation();
+		});
+		wrapper.addEventListener("mousedown", (event) => {
+			event.stopPropagation();
+			if (event.button === 0) {
+				event.preventDefault();
+			}
+		});
+		wrapper.addEventListener("mouseup", (event) => {
+			event.stopPropagation();
+		});
+
 		// Use createTaskCard with inline layout
 		const card = createTaskCard(this.taskInfo, this.plugin, visibleProperties, {
 			layout: "inline",

--- a/tests/unit/issues/issue-2180-inline-task-live-preview-mousedown.test.ts
+++ b/tests/unit/issues/issue-2180-inline-task-live-preview-mousedown.test.ts
@@ -1,0 +1,85 @@
+import { EditorView } from "@codemirror/view";
+import { TaskLinkWidget } from "../../../src/editor/TaskLinkWidget";
+import type TaskNotesPlugin from "../../../src/main";
+import type { TaskInfo } from "../../../src/types";
+import { PluginFactory, TaskFactory } from "../../helpers/mock-factories";
+
+describe("Issue #2180: inline task Live Preview mouse press", () => {
+	it("prevents editor selection handling while keeping the title click active", async () => {
+		const task = TaskFactory.createTask({
+			path: "Tasks/Live Preview Click.md",
+			title: "Live Preview Click",
+		});
+		const openTaskEditModal = jest.fn();
+		const plugin = PluginFactory.createMockPlugin({
+			settings: {
+				inlineVisibleProperties: [],
+				singleClickAction: "edit",
+				doubleClickAction: "none",
+				showExpandableSubtasks: false,
+				calendarViewSettings: {
+					timeFormat: "12",
+				},
+			},
+			statusManager: {
+				isCompletedStatus: jest.fn(() => false),
+				getStatusConfig: jest.fn((status: string) => ({
+					value: status,
+					label: status,
+					color: "#666666",
+				})),
+				getNextStatus: jest.fn(() => "done"),
+			},
+			priorityManager: {
+				getPriorityConfig: jest.fn((priority: string) => ({
+					value: priority,
+					label: priority,
+					color: "#ff0000",
+				})),
+			},
+			fieldMapper: {
+				toUserField: jest.fn((field: string) => field),
+				toInternalField: jest.fn((field: string) => field),
+			},
+			projectSubtasksService: {
+				isTaskUsedAsProjectSync: jest.fn(() => false),
+			},
+			openTaskEditModal,
+			i18n: {
+				translate: jest.fn((key: string, vars?: Record<string, unknown>) => {
+					if (key === "ui.taskCard.priorityAriaLabel") {
+						return `Priority: ${String(vars?.label ?? "")}`;
+					}
+					if (key === "ui.taskCard.taskOptions") {
+						return "Task options";
+					}
+					return key;
+				}),
+			},
+		}) as unknown as TaskNotesPlugin;
+		const widget = new TaskLinkWidget(
+			task as TaskInfo,
+			plugin,
+			"[[Live Preview Click]]"
+		);
+		const wrapper = widget.toDOM({ dispatch: jest.fn() } as unknown as EditorView);
+		const editorParent = document.createElement("div");
+		const editorMouseDown = jest.fn();
+		editorParent.addEventListener("mousedown", editorMouseDown);
+		editorParent.appendChild(wrapper);
+
+		const title = wrapper.querySelector(".task-card__title-text") as HTMLElement;
+		const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+		title.dispatchEvent(event);
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(editorMouseDown).not.toHaveBeenCalled();
+
+		title.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+		await Promise.resolve();
+
+		expect(openTaskEditModal).toHaveBeenCalledWith(
+			expect.objectContaining({ path: task.path })
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- keep pointer and mouse press events inside Live Preview inline task widgets so CodeMirror does not unmount them mid-click
- preserve the existing edit-modal and context-menu activation handlers
- add focused regression coverage and thank both reporters in the unreleased notes

Addresses #2180.

## Validation

- 11 focused and adjacent suites: 59 passed, 13 skipped
- typecheck
- lint
- build:test
- Obsidian plugin reload and runtime error check