### PR TITLE
Exclude cancelled TODOs from checklist progress bar

### DIFF
--- a/src/ui/taskCardProperties.ts
+++ b/src/ui/taskCardProperties.ts
@@ -222,8 +222,11 @@ function calculateChecklistProgress(cache: unknown): ChecklistProgress | null {
 		const isNested = typeof item.parent === "number" && item.parent >= 0;
 		if (isNested) continue;
 
+		const marker = item.task.toLowerCase();
+		if (marker === "-") continue; // cancelled — excluded from progress count
+
 		total += 1;
-		if (item.task.toLowerCase() === "x") {
+		if (marker === "x") {
 			completed += 1;
 		}
 	}

--- a/tests/unit/issues/issue-1576-display-progress-bar.test.ts
+++ b/tests/unit/issues/issue-1576-display-progress-bar.test.ts
@@ -199,7 +199,7 @@ describe("Issue #1576 - Display Progress Bar on task cards", () => {
 		expect((card.querySelector(".task-card__progress-fill") as HTMLElement).style.width).toBe("100%");
 	});
 
-	it("treats non-x task markers as incomplete", () => {
+	it("treats non-x, non-dash task markers as incomplete", () => {
 		const task = TaskFactory.createTask({
 			path: "tasks/custom-marker-task.md",
 			title: "Custom marker",
@@ -209,7 +209,7 @@ describe("Issue #1576 - Display Progress Bar on task cards", () => {
 		app.metadataCache.setCache(task.path, {
 			frontmatter: { title: task.title },
 			listItems: [
-				listItem("-", -1, 10), // not completed
+				listItem("/", -1, 10), // not completed
 				listItem("x", -1, 11), // completed
 			],
 		});
@@ -217,5 +217,46 @@ describe("Issue #1576 - Display Progress Bar on task cards", () => {
 		const card = createTaskCard(task, plugin, ["checklistProgress"]);
 		expect(card.querySelector(".task-card__progress-label")?.textContent).toBe("1/2");
 		expect((card.querySelector(".task-card__progress-fill") as HTMLElement).style.width).toBe("50%");
+	});
+
+	it("excludes cancelled (- [-]) items from both numerator and denominator", () => {
+		const task = TaskFactory.createTask({
+			path: "tasks/cancelled-marker-task.md",
+			title: "Cancelled marker",
+		});
+
+		MockObsidian.createTestFile(task.path, "# Cancelled marker");
+		app.metadataCache.setCache(task.path, {
+			frontmatter: { title: task.title },
+			listItems: [
+				listItem("-", -1, 10), // cancelled — excluded entirely
+				listItem("x", -1, 11), // completed
+			],
+		});
+
+		const card = createTaskCard(task, plugin, ["checklistProgress"]);
+		expect(card.querySelector(".task-card__progress-label")?.textContent).toBe("1/1");
+		expect((card.querySelector(".task-card__progress-fill") as HTMLElement).style.width).toBe("100%");
+	});
+
+	it("does not render checklist progress when only cancelled checkboxes exist", () => {
+		const task = TaskFactory.createTask({
+			path: "tasks/all-cancelled-task.md",
+			title: "All cancelled",
+		});
+
+		MockObsidian.createTestFile(task.path, "# All cancelled");
+		app.metadataCache.setCache(task.path, {
+			frontmatter: { title: task.title },
+			listItems: [
+				listItem("-", -1, 10),
+				listItem("-", -1, 11),
+			],
+		});
+
+		const card = createTaskCard(task, plugin, ["checklistProgress"]);
+		expect(card.querySelector(".task-card__progress")).toBeNull();
+		const metadata = card.querySelector(".task-card__metadata") as HTMLElement;
+		expect(metadata.style.display).toBe("none");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #2182

Cancelled inline checklist items (`- [-]`) were being counted toward the checklist progress bar's denominator, but never its numerator. This made tasks with cancelled TODO items appear less complete than they actually are.

Example from the issue: a task with one `- [x]` (completed) and one `- [-]` (cancelled) item showed `1/2` in the progress bar, when it should show `1/1` since the cancelled item shouldn't count at all.

## Changes

- `src/ui/taskCardProperties.ts`: In `calculateChecklistProgress`, skip list items whose marker is `-` (cancelled) before incrementing `total`, so cancelled items are excluded from both the numerator and denominator.
- `tests/unit/issues/issue-1576-display-progress-bar.test.ts`:
  - Renamed/adjusted the existing "treats non-x task markers as incomplete" test to use a marker other than `-` (e.g. `/`), since `-` is no longer treated as merely "incomplete."
  - Added a test verifying cancelled (`-`) items are excluded from both numerator and denominator (`1 done + 1 cancelled` → `1/1`, 100%).
  - Added a test verifying that when all items are cancelled, no progress bar is rendered (matches existing "no items" behavior).

## Testing

- `npx jest tests/unit/issues/issue-1576-display-progress-bar.test.ts` — all 6 tests pass.
- Full test suite run: no new failures introduced (pre-existing unrelated failures are due to a generated `src/releaseNotes.ts` file not being present outside of the build process).
- `npx eslint src/ui/taskCardProperties.ts --max-warnings=0` — clean.