### PR TITLE
Adopt TaskNotes model rc.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@fullcalendar/multimonth": "^6.1.17",
 				"@fullcalendar/timegrid": "^6.1.17",
 				"@modelcontextprotocol/sdk": "^1.12.1",
-				"@tasknotes/model": "0.3.0-rc.8",
+				"@tasknotes/model": "^0.3.0-rc.9",
 				"chrono-node": "^2.7.5",
 				"date-fns": "^4.1.0",
 				"ical.js": "^2.2.1",
@@ -3573,9 +3573,9 @@
 			}
 		},
 		"node_modules/@tasknotes/model": {
-			"version": "0.3.0-rc.8",
-			"resolved": "https://registry.npmjs.org/@tasknotes/model/-/model-0.3.0-rc.8.tgz",
-			"integrity": "sha512-jx+qEauQf2RRN4kouy0J/7mSVTHKSrxp3Z8Ltudim0iQ/xw5wXL2meswL/kij8mjAGpVj3qCh9ke9+3ldpMmnw==",
+			"version": "0.3.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@tasknotes/model/-/model-0.3.0-rc.9.tgz",
+			"integrity": "sha512-wC0zwIhOnaxEJ3VuVnIoZqiKkQtY1YZqzGYDK8KONZf/aqegpy2cglyago0dlkkYttcm2yoHHHx7oca90HwxtA==",
 			"license": "MIT",
 			"dependencies": {
 				"rrule": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"@fullcalendar/multimonth": "^6.1.17",
 		"@fullcalendar/timegrid": "^6.1.17",
 		"@modelcontextprotocol/sdk": "^1.12.1",
-		"@tasknotes/model": "0.3.0-rc.8",
+		"@tasknotes/model": "^0.3.0-rc.9",
 		"chrono-node": "^2.7.5",
 		"date-fns": "^4.1.0",
 		"ical.js": "^2.2.1",


### PR DESCRIPTION
## Outcome

Moves the official plugin to model rc.9 / `tasknotes.task` 0.3.0-rc.3, where the portable manual-order role and generated mdbase field are consistently string ranks.

## Verification

- `npm run build:test`
- Full TaskNotes spec conformance: 4,994/4,994 passing
- Obsidian reload against the built `tasknotes-e2e-vault` plugin
- Obsidian developer error capture: no errors