### PR TITLE
Fix raw HTML in Google Calendar event descriptions

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,3 +35,7 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 ## Fixed
 
 - Fixed `PUT /api/tasks/:id` ignoring empty arrays for `contexts` and `blockedBy`: sending `{"contexts": []}` or `{"blockedBy": []}` now clears the corresponding frontmatter field instead of silently leaving the previous value in place. The deletion pass previously fired only on a literal `undefined`, which JSON cannot express, so HTTP clients had no way to clear these fields. Thanks to @tgrosinger for the contribution.
+- (#2193) Google Calendar event descriptions written with formatting now read as
+  plain text in event details, copied text, and generated notes, instead of
+  showing raw HTML tags. Paragraph breaks, list structure, and link addresses are
+  kept. Thanks to @martin-forge for the contribution.

--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -16,6 +16,7 @@ import { validateCalendarId, validateEventId, validateRequired } from "./validat
 import { CalendarProvider, ProviderCalendar } from "./CalendarProvider";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
 import { publishUserNotice } from "../core/userNotices";
+import { normalizeCalendarDescription } from "../utils/calendarDescription";
 
 const tasknotesLogger = createTaskNotesLogger({ tag: "Services/GoogleCalendarService" });
 
@@ -499,7 +500,7 @@ export class GoogleCalendarService extends CalendarProvider {
 			id: `google-${calendarId}-${googleEvent.id}`,
 			subscriptionId: `google-${calendarId}`,
 			title: googleEvent.summary || "Untitled Event",
-			description: googleEvent.description,
+			description: normalizeCalendarDescription(googleEvent.description),
 			start: start,
 			end: end,
 			allDay: allDay,

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -1,0 +1,259 @@
+import { sanitizeHTMLToDom } from "obsidian";
+
+/**
+ * Plain-text normalization for calendar event descriptions.
+ *
+ * The Google Calendar API documents the event `description` field as one that
+ * "can contain HTML". Google Calendar and third-party integrations therefore
+ * store markup such as `<p>`, `<br>`, `<ul><li>`, and `<a href>` in it.
+ *
+ * TaskNotes consumes that string as plain text everywhere: event tooltips, the
+ * ICS event info modal, "copy as markdown", the `{{icsEventDescription}}`
+ * template variable, generated note bodies, and folder templates. Several of
+ * those write the value into the vault, so raw markup does not merely look
+ * wrong on screen — it is persisted into notes and folder names.
+ *
+ * Normalizing at the Google provider boundary keeps every one of those
+ * consumers plain-text, rather than making each handle HTML independently.
+ * ICS subscriptions read descriptions through their own boundary and are not
+ * normalized here.
+ */
+
+/**
+ * Elements that separate paragraphs, rendered with a blank line between them.
+ */
+const PARAGRAPH_TAGS = new Set([
+	"ADDRESS",
+	"ARTICLE",
+	"ASIDE",
+	"BLOCKQUOTE",
+	"DL",
+	"FIELDSET",
+	"FIGURE",
+	"FOOTER",
+	"FORM",
+	"H1",
+	"H2",
+	"H3",
+	"H4",
+	"H5",
+	"H6",
+	"HEADER",
+	"HR",
+	"MAIN",
+	"NAV",
+	"OL",
+	"P",
+	"PRE",
+	"SECTION",
+	"TABLE",
+	"UL",
+]);
+
+/**
+ * Elements that start a new line without a blank line. List items and the
+ * `<div>`-per-line style emitted by Google's editors belong here — treating
+ * them as paragraphs would double-space every list.
+ */
+const LINE_TAGS = new Set([
+	"DD",
+	"DIV",
+	"DT",
+	"FIGCAPTION",
+	"LI",
+	"TBODY",
+	"TD",
+	"TFOOT",
+	"TH",
+	"THEAD",
+	"TR",
+]);
+
+/**
+ * Elements whose content is markup rather than prose.
+ */
+const NON_CONTENT_TAGS = new Set(["SCRIPT", "STYLE", "TEMPLATE", "HEAD"]);
+
+/**
+ * A closing tag is strong evidence that a string contains markup. Void tags
+ * cover common standalone elements such as `<br>`. Requiring one of those
+ * forms preserves ordinary text such as `Contact <user@example.com>` and
+ * placeholders such as `<TBC>`.
+ */
+const PAIRED_HTML_TAG_PATTERN = /<([a-z][\w:-]*)(?:\s[^>]*)?>[\s\S]*?<\/\1\s*>/i;
+const VOID_HTML_TAG_PATTERN =
+	/<(?:area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)(?:\s[^>]*)?\/?\s*>/i;
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/;
+
+/**
+ * Reports whether a description looks like HTML rather than plain text.
+ */
+export function looksLikeHtml(value: string): boolean {
+	return (
+		PAIRED_HTML_TAG_PATTERN.test(value) ||
+		VOID_HTML_TAG_PATTERN.test(value) ||
+		HTML_COMMENT_PATTERN.test(value)
+	);
+}
+
+/**
+ * A flattened fragment: literal text, or a line break whose `weight` is the
+ * number of newlines it requests. Adjacent breaks coalesce to their strongest
+ * weight, so nested block elements never stack up blank lines.
+ */
+type Fragment = string | { weight: number };
+
+function breakWeightOf(tag: string): number {
+	if (PARAGRAPH_TAGS.has(tag)) {
+		return 2;
+	}
+	if (LINE_TAGS.has(tag)) {
+		return 1;
+	}
+	return 0;
+}
+
+function flattenAnchor(element: Element, out: Fragment[]): void {
+	const labelFragments: Fragment[] = [];
+	element.childNodes.forEach((child) => flattenNode(child, labelFragments));
+	const label = tidy(joinFragments(labelFragments));
+	const href = (element.getAttribute("href") ?? "").trim();
+
+	if (!href || href === label) {
+		out.push(label);
+		return;
+	}
+
+	if (!label) {
+		out.push(href);
+		return;
+	}
+
+	// Keep the target reachable once the anchor markup is gone.
+	out.push(`${label} (${href})`);
+}
+
+function flattenNode(node: Node, out: Fragment[]): void {
+	if (node.nodeType === 3 /* TEXT_NODE */) {
+		out.push(node.textContent ?? "");
+		return;
+	}
+
+	if (node.nodeType !== 1 /* ELEMENT_NODE */) {
+		return;
+	}
+
+	const element = node as Element;
+	const tag = element.tagName.toUpperCase();
+
+	if (NON_CONTENT_TAGS.has(tag)) {
+		return;
+	}
+
+	if (tag === "BR") {
+		out.push({ weight: 1 });
+		return;
+	}
+
+	if (tag === "A") {
+		flattenAnchor(element, out);
+		return;
+	}
+
+	const weight = breakWeightOf(tag);
+	if (weight > 0) {
+		out.push({ weight });
+	}
+
+	if (tag === "LI") {
+		out.push("- ");
+	}
+
+	element.childNodes.forEach((child) => flattenNode(child, out));
+
+	if (weight > 0) {
+		out.push({ weight });
+	}
+}
+
+/**
+ * Joins fragments, coalescing runs of breaks into the strongest one and
+ * dropping whitespace that only exists to indent the source markup.
+ */
+function joinFragments(fragments: Fragment[]): string {
+	let result = "";
+	let pendingBreak = 0;
+
+	for (const fragment of fragments) {
+		if (typeof fragment !== "string") {
+			pendingBreak = Math.max(pendingBreak, fragment.weight);
+			continue;
+		}
+
+		if (fragment.length === 0) {
+			continue;
+		}
+
+		// Whitespace between block elements is markup indentation, not content.
+		if (pendingBreak > 0 && fragment.trim().length === 0) {
+			continue;
+		}
+
+		if (result.length > 0 && pendingBreak > 0) {
+			result += "\n".repeat(pendingBreak);
+		}
+		pendingBreak = 0;
+		result += fragment;
+	}
+
+	return result;
+}
+
+/**
+ * Collapses the flattened text into tidy plain text: normal spaces, no trailing
+ * whitespace, and at most one blank line between paragraphs.
+ */
+function tidy(text: string): string {
+	return text
+		.replace(/\u00a0/g, " ")
+		.replace(/\r\n?/g, "\n")
+		.split("\n")
+		.map((line) => line.replace(/[ \t]+/g, " ").trim())
+		.join("\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+}
+
+/**
+ * Converts an HTML event description to plain text, preserving paragraph
+ * breaks, list structure, and link targets.
+ *
+ * Obsidian sanitizes the markup into a detached fragment before it is read.
+ */
+export function htmlToPlainText(html: string): string {
+	const fragment = sanitizeHTMLToDom(html);
+	const fragments: Fragment[] = [];
+	fragment.childNodes.forEach((child) => flattenNode(child, fragments));
+	return tidy(joinFragments(fragments));
+}
+
+/**
+ * Normalizes a provider event description to plain text.
+ *
+ * Plain-text descriptions are returned unchanged. Descriptions containing HTML
+ * are flattened, with entities decoded as a side effect of DOM parsing. Returns
+ * `undefined` when there is no usable text left, so existing truthiness checks
+ * on the field continue to skip empty descriptions.
+ */
+export function normalizeCalendarDescription(value: string | undefined | null): string | undefined {
+	if (typeof value !== "string" || value.length === 0) {
+		return undefined;
+	}
+
+	if (!looksLikeHtml(value)) {
+		return value;
+	}
+
+	const plainText = htmlToPlainText(value);
+	return plainText.length > 0 ? plainText : undefined;
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1084,6 +1084,12 @@ export function setTooltip(element: HTMLElement, tooltip: string, options?: { pl
   element.classList.add('has-tooltip');
 }
 
+export function sanitizeHTMLToDom(html: string): DocumentFragment {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  return template.content;
+}
+
 // API version check utilities (added in Obsidian 1.11.0)
 export function requireApiVersion(version: string): boolean {
   // Mock implementation - returns true for testing purposes
@@ -1181,6 +1187,7 @@ export const MockObsidian = {
   Notice,
   setIcon,
   setTooltip,
+  sanitizeHTMLToDom,
 };
 
 // Simple debounce mock: return the original function for test determinism
@@ -1232,6 +1239,7 @@ export default {
   Events,
   setIcon,
   setTooltip,
+  sanitizeHTMLToDom,
   parseFrontMatterAliases,
   parseFrontMatterTags,
   parseLinktext,

--- a/tests/services/GoogleCalendarService.test.ts
+++ b/tests/services/GoogleCalendarService.test.ts
@@ -8,7 +8,12 @@ import { GoogleCalendarError, RateLimitError, EventNotFoundError } from '../../s
 jest.mock('obsidian', () => ({
 	Notice: jest.fn(),
 	requestUrl: jest.fn(),
-	Platform: { isDesktopApp: true }
+	Platform: { isDesktopApp: true },
+	sanitizeHTMLToDom: (html: string) => {
+		const template = document.createElement('template');
+		template.innerHTML = html;
+		return template.content;
+	}
 }));
 
 describe('GoogleCalendarService', () => {
@@ -155,6 +160,39 @@ describe('GoogleCalendarService', () => {
 			});
 			expect(events[0].allDay).toBe(false);
 			expect(events[1].allDay).toBe(true);
+		});
+
+		test('should normalize HTML descriptions without changing angle-bracketed text', async () => {
+			mockRequestUrl.mockResolvedValueOnce({
+				status: 200,
+				json: {
+					items: [
+						{
+							id: 'html-description',
+							summary: 'HTML description',
+							description: '<p>Agenda</p><ul><li>First item</li></ul>',
+							start: { date: '2025-10-22' },
+							end: { date: '2025-10-23' }
+						},
+						{
+							id: 'plain-description',
+							summary: 'Plain description',
+							description: 'Contact <user@example.com>; venue <TBC>',
+							start: { date: '2025-10-23' },
+							end: { date: '2025-10-24' }
+						}
+					],
+					nextSyncToken: 'sync-token-123'
+				},
+				text: '',
+				arrayBuffer: new ArrayBuffer(0),
+				headers: {}
+			});
+
+			const events = await service.getEvents('primary');
+
+			expect(events[0].description).toBe('Agenda\n\n- First item');
+			expect(events[1].description).toBe('Contact <user@example.com>; venue <TBC>');
 		});
 
 		test('should use sync token for incremental updates', async () => {

--- a/tests/unit/utils/calendarDescription.test.ts
+++ b/tests/unit/utils/calendarDescription.test.ts
@@ -1,0 +1,125 @@
+import {
+	htmlToPlainText,
+	looksLikeHtml,
+	normalizeCalendarDescription,
+} from "../../../src/utils/calendarDescription";
+
+describe("calendarDescription", () => {
+	describe("looksLikeHtml", () => {
+		it("detects markup", () => {
+			expect(looksLikeHtml("<p>Hello</p>")).toBe(true);
+			expect(looksLikeHtml("Line<br>Break")).toBe(true);
+			expect(looksLikeHtml('<a href="https://example.com">Link</a>')).toBe(true);
+			expect(looksLikeHtml("<custom-element>Text</custom-element>")).toBe(true);
+		});
+
+		it("does not treat comparison operators as markup", () => {
+			expect(looksLikeHtml("Bring < 10 items and > 2 bags")).toBe(false);
+			expect(looksLikeHtml("Budget: 5 < 10")).toBe(false);
+		});
+
+		it("does not treat angle-bracketed plain text as markup", () => {
+			expect(looksLikeHtml("Contact <user@example.com>")).toBe(false);
+			expect(looksLikeHtml("Venue: <TBC>")).toBe(false);
+		});
+
+		it("does not treat plain text as markup", () => {
+			expect(looksLikeHtml("Reference: ABC123\n\nGuests: 2")).toBe(false);
+		});
+	});
+
+	describe("normalizeCalendarDescription", () => {
+		it("returns plain-text descriptions unchanged", () => {
+			const plain =
+				"Appointment with the clinic\n\nContact: <user@example.com>\nVenue: <TBC>";
+			expect(normalizeCalendarDescription(plain)).toBe(plain);
+		});
+
+		it("returns undefined for missing or empty values", () => {
+			expect(normalizeCalendarDescription(undefined)).toBeUndefined();
+			expect(normalizeCalendarDescription(null)).toBeUndefined();
+			expect(normalizeCalendarDescription("")).toBeUndefined();
+		});
+
+		it("returns undefined when markup carries no text", () => {
+			expect(normalizeCalendarDescription("<p></p><div><br></div>")).toBeUndefined();
+		});
+
+		it("flattens paragraph markup", () => {
+			const html =
+				"<p>Reservation confirmed on 2024-05-01.</p>\n" +
+				"<p>Party of 4.\nDuration: 90 minutes.</p>";
+
+			expect(normalizeCalendarDescription(html)).toBe(
+				"Reservation confirmed on 2024-05-01.\n\nParty of 4.\nDuration: 90 minutes."
+			);
+		});
+
+		it("flattens list markup, as written by the Google Calendar editor", () => {
+			const html =
+				"<ul><li><strong>Matinee</strong> at the Example Cinema, Screen 2</li>" +
+				"<li>Reference: ABC123</li>" +
+				"<li>Adult (2)</li>" +
+				"<li>Seats: A1,A2</li></ul>";
+
+			expect(normalizeCalendarDescription(html)).toBe(
+				"- Matinee at the Example Cinema, Screen 2\n" +
+					"- Reference: ABC123\n" +
+					"- Adult (2)\n" +
+					"- Seats: A1,A2"
+			);
+		});
+
+		it("decodes entities so escaped punctuation is not shown literally", () => {
+			const html = "<p>Meet at the Queen&#x27;s Hall, tea &amp; cake after.</p>";
+			expect(normalizeCalendarDescription(html)).toBe(
+				"Meet at the Queen's Hall, tea & cake after."
+			);
+		});
+	});
+
+	describe("htmlToPlainText", () => {
+		it("turns line breaks into newlines", () => {
+			expect(htmlToPlainText("First<br>Second<br />Third")).toBe("First\nSecond\nThird");
+		});
+
+		it("keeps link targets reachable", () => {
+			expect(htmlToPlainText('<a href="https://example.com/booking">Booking</a>')).toBe(
+				"Booking (https://example.com/booking)"
+			);
+		});
+
+		it("does not duplicate a link whose label is its target", () => {
+			expect(htmlToPlainText('<a href="https://example.com">https://example.com</a>')).toBe(
+				"https://example.com"
+			);
+		});
+
+		it("preserves an Obsidian URI written by task export", () => {
+			const html =
+				"<p>Project: " +
+				'<a href="obsidian://open?vault=Example%20Vault&amp;file=Note.md">Note</a></p>';
+			expect(htmlToPlainText(html)).toBe(
+				"Project: Note (obsidian://open?vault=Example%20Vault&file=Note.md)"
+			);
+		});
+
+		it("drops script and style content", () => {
+			const html = "<div>Visible<script>alert(1)</script><style>.x{color:red}</style></div>";
+			expect(htmlToPlainText(html)).toBe("Visible");
+		});
+
+		it("drops non-content nested inside links", () => {
+			const html = '<a href="https://example.com">Visible<script>alert(1)</script></a>';
+			expect(htmlToPlainText(html)).toBe("Visible (https://example.com)");
+		});
+
+		it("collapses runs of blank lines", () => {
+			expect(htmlToPlainText("<p>One</p><p></p><p></p><p>Two</p>")).toBe("One\n\nTwo");
+		});
+
+		it("normalizes non-breaking spaces", () => {
+			expect(htmlToPlainText("<p>Room&nbsp;12</p>")).toBe("Room 12");
+		});
+	});
+});


### PR DESCRIPTION
## Problem

The Google Calendar API documents the event `description` field as one that can contain HTML, and Calendar's own editor stores markup there. TaskNotes consumes that string as plain text everywhere: event tooltips, the ICS event info modal, "copy as markdown", the `{{icsEventDescription}}` template variable, generated note bodies, and folder templates.

Several of those write the value into the vault, so raw markup was not only displayed — it was persisted into note bodies and folder names.

## Fix

Normalize the description once at the Google provider boundary, parsing it with Obsidian's HTML sanitizer. Paragraph breaks, list structure, and link addresses survive the flattening.

Plain text is returned unchanged, so descriptions that merely contain angle brackets — `Contact <user@example.com>`, placeholders such as `<TBC>` — are untouched. Normalizing at the boundary keeps every consumer plain-text rather than making each one handle HTML separately. ICS subscriptions read descriptions through their own path and are unaffected.

### Why not a plain `textContent` read

`textContent` drops paragraph and list breaks and discards `href` values, so a description holding a bulleted agenda and a meeting link collapses into one run-on line with the link gone. The flattening pass exists to keep those three things and nothing more.

### Descriptions sent back to Google

Writes are unaffected. `TaskCalendarSyncService` rebuilds the description from the task before every update, and the drag/resize path sends only start and end. The normalized value is never round-tripped into Calendar, so formatting a user has set there is not flattened by this change.

## Relationship to earlier work

This complements #1882, which fixed the TaskNotes-to-Google export; this covers the Google-to-TaskNotes input side. It is also the actual cause behind #2102, which I closed after testing: the entity handling I proposed there was a symptom of descriptions being read as plain text, not the underlying problem.

## Validation

```
npm test -- tests/unit/utils/calendarDescription.test.ts tests/services/GoogleCalendarService.test.ts
npm run typecheck
npm run lint
npm run build
```

50 focused tests pass. The full suite shows no new failures against current `main`. Rebased on current `main`.
