### PR TITLE
Add today and future classes

### DIFF
--- a/src/ui/taskCardProperties.ts
+++ b/src/ui/taskCardProperties.ts
@@ -851,6 +851,12 @@ function renderDueDateProperty(
 	if (isDueOverdue) {
 		element.classList.add("task-card__metadata-date--overdue");
 	}
+	if (isDueToday) {
+		element.classList.add("task-card__metadata-date--today");
+	}
+	if (!isDueOverdue && !isDueToday) {
+		element.classList.add("task-card__metadata-date--future");
+	}
 	element.dataset.tnAction = "edit-date";
 	element.dataset.tnDateType = "due";
 
@@ -905,6 +911,12 @@ function renderScheduledDateProperty(
 	element.classList.add("task-card__metadata-date", "task-card__metadata-date--scheduled");
 	if (isScheduledPast) {
 		element.classList.add("task-card__metadata-date--past");
+	}
+	if (isScheduledToday) {
+		element.classList.add("task-card__metadata-date--today");
+	}
+	if (!isScheduledPast && !isScheduledToday) {
+		element.classList.add("task-card__metadata-date--future");
 	}
 	element.dataset.tnAction = "edit-date";
 	element.dataset.tnDateType = "scheduled";


### PR DESCRIPTION
From #2223 I added both `--today` and `--future` classes, so each state, today, past, future all have their own class names and can be targeted by CSS snippets.