### PR TITLE
fix(google-calendar): export tasks created while Obsidian was closed

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -38,6 +38,9 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 ## Fixed
 
+- (#2130) Tasks added by external sync while Obsidian is closed are now exported
+  to Google Calendar after TaskNotes starts. Thanks to @seththepeacock for
+  reporting this and @raphaelfaouakhiri for the contribution.
 - (#2246) Fixed materialized recurring occurrences hiding occurrence-template filename suffixes in TaskNotes views. Thanks to @raphaelfaouakhiri for reporting and fixing this issue.
 - Fixed `PUT /api/tasks/:id` ignoring empty arrays for `contexts` and `blockedBy`: sending `{"contexts": []}` or `{"blockedBy": []}` now clears the corresponding frontmatter field instead of silently leaving the previous value in place. The deletion pass previously fired only on a literal `undefined`, which JSON cannot express, so HTTP clients had no way to clear these fields. Thanks to @tgrosinger for the contribution.
 - (#2191) Completing or skipping a recurring occurrence that was moved earlier

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -874,6 +874,11 @@ export class TaskCalendarSyncService {
 			let changedTasks = 0;
 			let linkedTasks = 0;
 			let baselineTasks = 0;
+			let createdTasks = 0;
+
+			// An empty fingerprint map means this vault was never reconciled: every task is
+			// unknown, so baseline all of them instead of flooding the calendar on first run.
+			const isFirstReconciliation = fingerprints.size === 0;
 
 			for (const task of tasks) {
 				activeTaskPaths.add(task.path);
@@ -881,6 +886,21 @@ export class TaskCalendarSyncService {
 				const previousFingerprint = fingerprints.get(task.path);
 
 				if (previousFingerprint === undefined) {
+					// A task file that appeared while Obsidian was closed (external sync, git pull,
+					// another device) has no fingerprint yet. Treat it the way the live path in
+					// handleExternalTaskFileUpdated already does: export it, instead of baselining
+					// it into permanent invisibility.
+					if (
+						!isFirstReconciliation &&
+						settings.syncOnTaskCreate &&
+						!this.hasTaskCalendarLink(task) &&
+						this.isTaskCalendarEligible(task)
+					) {
+						createdTasks++;
+						await this.syncTaskToCalendar(task);
+						continue;
+					}
+
 					fingerprints.set(task.path, fingerprint);
 					changed = true;
 					baselineTasks++;
@@ -927,6 +947,7 @@ export class TaskCalendarSyncService {
 			this.profileGauge("initializeExternalFileReconciliation.linkedTasks", linkedTasks);
 			this.profileGauge("initializeExternalFileReconciliation.changedTasks", changedTasks);
 			this.profileGauge("initializeExternalFileReconciliation.baselineTasks", baselineTasks);
+			this.profileGauge("initializeExternalFileReconciliation.createdTasks", createdTasks);
 			this.profileGauge(
 				"initializeExternalFileReconciliation.removedFingerprints",
 				removedFingerprints

--- a/tests/unit/issues/issue-google-calendar-external-file-reconciliation.test.ts
+++ b/tests/unit/issues/issue-google-calendar-external-file-reconciliation.test.ts
@@ -294,6 +294,140 @@ describe("Google Calendar external file reconciliation", () => {
 		);
 	});
 
+	it("exports a task created while Obsidian was closed", async () => {
+		const knownTask = {
+			path: "TaskNotes/Tasks/already-known.md",
+			title: "Already known",
+			status: "ready",
+			priority: "3-medium",
+			archived: false,
+			scheduled: "2026-05-14",
+			googleCalendarEventId: "event-1",
+		} as TaskInfo;
+		const newTask = {
+			path: "TaskNotes/Tasks/created-offline.md",
+			title: "Created offline",
+			status: "ready",
+			priority: "3-medium",
+			archived: false,
+			scheduled: "2026-05-15",
+		} as TaskInfo;
+		const pluginData: Record<string, unknown> = {};
+		const plugin = createPlugin([knownTask, newTask], {}, pluginData);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+		pluginData.googleCalendarTaskFingerprints = {
+			[knownTask.path]: (syncService as any).getCalendarRelevantFingerprint(knownTask),
+		};
+
+		await syncService.initializeExternalFileReconciliation();
+
+		expect(googleCalendarService.createEvent).toHaveBeenCalledTimes(1);
+		expect(googleCalendarService.createEvent).toHaveBeenCalledWith(
+			"primary",
+			expect.objectContaining({ summary: "Created offline" })
+		);
+	});
+
+	it("does not export tasks on the first reconciliation of a vault", async () => {
+		const firstTask = {
+			path: "TaskNotes/Tasks/first-run-a.md",
+			title: "First run A",
+			status: "ready",
+			priority: "3-medium",
+			archived: false,
+			scheduled: "2026-05-14",
+		} as TaskInfo;
+		const secondTask = {
+			...firstTask,
+			path: "TaskNotes/Tasks/first-run-b.md",
+			title: "First run B",
+		} as TaskInfo;
+		const pluginData: Record<string, unknown> = {};
+		const plugin = createPlugin([firstTask, secondTask], {}, pluginData);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+
+		await syncService.initializeExternalFileReconciliation();
+
+		expect(googleCalendarService.createEvent).not.toHaveBeenCalled();
+		expect(pluginData.googleCalendarTaskFingerprints).toMatchObject({
+			[firstTask.path]: (syncService as any).getCalendarRelevantFingerprint(firstTask),
+			[secondTask.path]: (syncService as any).getCalendarRelevantFingerprint(secondTask),
+		});
+	});
+
+	it("does not duplicate an event when the new task already carries an event id", async () => {
+		const knownTask = {
+			path: "TaskNotes/Tasks/already-known.md",
+			title: "Already known",
+			status: "ready",
+			priority: "3-medium",
+			archived: false,
+			scheduled: "2026-05-14",
+			googleCalendarEventId: "event-1",
+		} as TaskInfo;
+		const newTaskWithEvent = {
+			path: "TaskNotes/Tasks/created-offline-with-event.md",
+			title: "Created offline with event",
+			status: "ready",
+			priority: "3-medium",
+			archived: false,
+			scheduled: "2026-05-15",
+			googleCalendarEventId: "event-created-elsewhere",
+		} as TaskInfo;
+		const pluginData: Record<string, unknown> = {};
+		const plugin = createPlugin([knownTask, newTaskWithEvent], {}, pluginData);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+		pluginData.googleCalendarTaskFingerprints = {
+			[knownTask.path]: (syncService as any).getCalendarRelevantFingerprint(knownTask),
+		};
+
+		await syncService.initializeExternalFileReconciliation();
+
+		expect(googleCalendarService.createEvent).not.toHaveBeenCalled();
+		expect(googleCalendarService.updateEvent).not.toHaveBeenCalled();
+		expect(pluginData.googleCalendarTaskFingerprints).toMatchObject({
+			[newTaskWithEvent.path]: (syncService as any).getCalendarRelevantFingerprint(
+				newTaskWithEvent
+			),
+		});
+	});
+
+	it("does not export an ineligible task created while Obsidian was closed", async () => {
+		const knownTask = {
+			path: "TaskNotes/Tasks/already-known.md",
+			title: "Already known",
+			status: "ready",
+			priority: "3-medium",
+			archived: false,
+			scheduled: "2026-05-14",
+			googleCalendarEventId: "event-1",
+		} as TaskInfo;
+		const undatedTask = {
+			path: "TaskNotes/Tasks/created-offline-undated.md",
+			title: "Created offline undated",
+			status: "ready",
+			priority: "3-medium",
+			archived: false,
+		} as TaskInfo;
+		const pluginData: Record<string, unknown> = {};
+		const plugin = createPlugin([knownTask, undatedTask], {}, pluginData);
+		const googleCalendarService = createGoogleCalendarService();
+		const syncService = new TaskCalendarSyncService(plugin, googleCalendarService as any);
+		pluginData.googleCalendarTaskFingerprints = {
+			[knownTask.path]: (syncService as any).getCalendarRelevantFingerprint(knownTask),
+		};
+
+		await syncService.initializeExternalFileReconciliation();
+
+		expect(googleCalendarService.createEvent).not.toHaveBeenCalled();
+		expect(pluginData.googleCalendarTaskFingerprints).toMatchObject({
+			[undatedTask.path]: (syncService as any).getCalendarRelevantFingerprint(undatedTask),
+		});
+	});
+
 	it("baselines missing startup fingerprints for linked tasks without API writes", async () => {
 		const task = {
 			path: "TaskNotes/Tasks/existing-linked.md",


### PR DESCRIPTION
## Problem

A task file that appears while Obsidian is **closed** is never exported to Google Calendar, and no later startup recovers it.

This is the case reported in #2130, where task files arrive on the desktop through an external sync tool. I hit the same thing with a vault synced by git: tasks are created by a headless agent on a server at 05:00 and pulled into the vault, and they never reach the calendar. Editing them by hand later does not help either — the fingerprint already matches, so the task stays invisible to export forever.

## Cause

`initializeExternalFileReconciliation()` baselines every task path it has never seen and then `continue`s, skipping the eligibility and sync decision entirely:

```ts
if (previousFingerprint === undefined) {
    fingerprints.set(task.path, fingerprint);
    changed = true;
    baselineTasks++;
    continue;
}
```

The live path, `handleExternalTaskFileUpdated()`, makes the opposite decision for the same input: an unknown fingerprint falls through to `isTaskCalendarEligible()` and, with `syncOnTaskCreate` on, calls `syncTaskToCalendar()`. So whether a task reaches the calendar depends on whether Obsidian happened to be running when the file landed — and the startup branch also makes the miss permanent, because the baseline it writes matches on every subsequent boot.

This also answers the open question in #2130 ("a remaining TaskNotes file-change bug vs. the sync tool not producing a metadata update"): it is a TaskNotes bug, and it is in the startup branch, not in the file-change event. Reproduced on 4.12.3.

## Change

Startup now makes the same decision the live path already makes: an unknown task that has no event link, is eligible, and has `syncOnTaskCreate` enabled gets exported instead of silently baselined.

The initial baseline is deliberately preserved. When the fingerprint map is empty, the vault has never been reconciled — every task is unknown, and exporting them all would flood the calendar the first time someone enables export. That case still baselines everything, exactly as before.

Tasks that already carry an event id still baseline without an API write, so a vault whose events were created elsewhere does not get duplicates.

## Tests

Four cases added to `tests/unit/issues/issue-google-calendar-external-file-reconciliation.test.ts`:

- exports a task created while Obsidian was closed — **fails without the fix**, passes with it
- does not export tasks on the first reconciliation of a vault (baseline preserved)
- does not duplicate an event when the new task already carries an event id
- does not export an ineligible task created while Obsidian was closed

```
npx jest tests/unit/issues/issue-google-calendar-external-file-reconciliation.test.ts
9 passed

# same file with the src change reverted
1 failed, 8 passed   ← only "exports a task created while Obsidian was closed"
```

`npx jest --testPathPatterns="[Cc]alendar"` → 435 passed. Five UI suites fail (`issue-859`, `issue-385`, `calendarMutationPlanning`, `issue-1377`, `issue-1183`), but they fail identically on an unpatched checkout, so they are pre-existing and unrelated.

`npx eslint src/services/TaskCalendarSyncService.ts --max-warnings=0` → clean. `tsc --noEmit` reports no error in this file (the errors it does report exist on main and are in other files). I left Prettier alone: it already flags both files on main, so running it would have buried the change in unrelated reformatting.

## Not tested

No live Google API call — the tests use the mocked calendar service, like the surrounding suite.

Closes #2130
