### PR TITLE
Generalize #1849 menu coordination to all context menus (#1849)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,7 +35,7 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 ## Fixed
 
 - (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
-  - Thanks to @3zra47 for reporting.
+  - Thanks to @3zra47 for reporting and @YBKF for the contribution.
 
 ## Added
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -32,6 +32,11 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 -->
 
+## Fixed
+
+- (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
+  - Thanks to @3zra47 for reporting.
+
 ## Added
 
 - (#2147) Added context-menu actions for recording task completion today, on the scheduled date, on the due date, or on a chosen date. The actions can be grouped in a submenu from Appearance settings. See [Completing Tasks](https://tasknotes.dev/features/task-management/#completing-tasks).

--- a/src/components/BatchContextMenu.ts
+++ b/src/components/BatchContextMenu.ts
@@ -3,6 +3,10 @@ import TaskNotesPlugin from "../main";
 import { TaskInfo } from "../types";
 import { DateContextMenu, type DateOption } from "./DateContextMenu";
 import { ContextMenu } from "./ContextMenu";
+import {
+	closeActiveContextMenu,
+	showCoordinatedMenu,
+} from "./ContextMenuCoordinator";
 import { showConfirmationModal } from "../modals/ConfirmationModal";
 import { showTextInputModal } from "../modals/TextInputModal";
 import { TagSuggest } from "../modals/taskModalSuggests";
@@ -589,10 +593,11 @@ export class BatchContextMenu {
 	}
 
 	public show(event: MouseEvent): void {
-		this.menu.showAtMouseEvent(event);
+		showCoordinatedMenu(this.menu, event);
 	}
 
 	public showAtPosition(x: number, y: number): void {
+		closeActiveContextMenu();
 		this.menu.showAtPosition({ x, y });
 	}
 }

--- a/src/components/ContextMenuCoordinator.ts
+++ b/src/components/ContextMenuCoordinator.ts
@@ -1,4 +1,9 @@
-import type { Menu } from "obsidian";
+interface CoordinatedMenu {
+	hide(): void;
+	onHide(callback: () => void): void;
+	showAtMouseEvent(event: MouseEvent): void;
+	showAtPosition(position: { x: number; y: number }, document?: Document): void;
+}
 
 /**
  * Coordinates context-menu visibility across the plugin.
@@ -47,7 +52,7 @@ function isMouseEvent(event: UIEvent): event is MouseEvent {
  */
 const TRIGGER_SELECTOR = '[data-tn-action], [data-type], [role="button"], button, .clickable-icon';
 
-let activeMenu: Menu | null = null;
+let activeMenu: CoordinatedMenu | null = null;
 let activeTrigger: Element | null = null;
 
 /**
@@ -69,7 +74,7 @@ export function getContextMenuTrigger(event: UIEvent): Element | null {
 	return target?.closest(TRIGGER_SELECTOR) ?? target;
 }
 
-function showWithTrigger(menu: Menu, trigger: Element | null, show: () => void): void {
+function showWithTrigger(menu: CoordinatedMenu, trigger: Element | null, show: () => void): void {
 	if (trigger && activeMenu && activeTrigger === trigger) {
 		// Same trigger activated again: toggle the menu closed.
 		closeActiveContextMenu();
@@ -94,7 +99,7 @@ function showWithTrigger(menu: Menu, trigger: Element | null, show: () => void):
  * Mouse events show the menu at the cursor; keyboard events anchor the menu
  * below the event's current target.
  */
-export function showCoordinatedMenu(menu: Menu, event: UIEvent): void {
+export function showCoordinatedMenu(menu: CoordinatedMenu, event: UIEvent): void {
 	showWithTrigger(menu, getContextMenuTrigger(event), () => {
 		if (isMouseEvent(event)) {
 			menu.showAtMouseEvent(event);
@@ -119,7 +124,7 @@ export function showCoordinatedMenu(menu: Menu, event: UIEvent): void {
  * The element doubles as the trigger, so showing at the same element again
  * toggles the menu closed.
  */
-export function showCoordinatedMenuAtElement(menu: Menu, element: HTMLElement): void {
+export function showCoordinatedMenuAtElement(menu: CoordinatedMenu, element: HTMLElement): void {
 	showWithTrigger(menu, element, () => {
 		menu.showAtPosition(
 			{

--- a/src/components/ContextMenuCoordinator.ts
+++ b/src/components/ContextMenuCoordinator.ts
@@ -1,0 +1,132 @@
+import type { Menu } from "obsidian";
+
+/**
+ * Coordinates context-menu visibility across the plugin.
+ *
+ * Every menu wrapper routes its `show` entry points through this module so
+ * that only one context menu is visible at a time and activating the same
+ * trigger again toggles its menu closed instead of stacking another one.
+ *
+ * The coordinator only relies on the Obsidian `Menu` surface (`onHide`,
+ * `hide`, `showAtMouseEvent`, `showAtPosition`), so it works uniformly for
+ * `ContextMenu` instances and plain `Menu` instances.
+ */
+
+function asElement(target: EventTarget | null): Element | null {
+	if (!target || typeof target !== "object") {
+		return null;
+	}
+
+	const element = target as Element;
+	if (element.nodeType !== 1 || typeof element.closest !== "function") {
+		return null;
+	}
+
+	return element;
+}
+
+/**
+ * Cross-window compatible `MouseEvent` check. Obsidian's
+ * `Event.prototype.instanceOf` extension is preferred when available; the
+ * standard operator is the fallback for environments without it (e.g. unit
+ * tests), hence the deliberate duck-typed cast below.
+ */
+function isMouseEvent(event: UIEvent): event is MouseEvent {
+	const instanceOf = (event as { instanceOf?: (ctor: unknown) => boolean }).instanceOf;
+	if (typeof instanceOf === "function") {
+		return instanceOf.call(event, MouseEvent) === true;
+	}
+
+	return (event as unknown) instanceof MouseEvent;
+}
+
+/**
+ * Interactive-control selector used to resolve a stable menu trigger. Plugin
+ * interactive controls are marked via `prepareInteractiveControl`
+ * (`role="button"`), `data-tn-action`, or `data-type`.
+ */
+const TRIGGER_SELECTOR = '[data-tn-action], [data-type], [role="button"], button, .clickable-icon';
+
+let activeMenu: Menu | null = null;
+let activeTrigger: Element | null = null;
+
+/**
+ * Hide the currently active coordinated menu, if any.
+ */
+export function closeActiveContextMenu(): void {
+	const menu = activeMenu;
+	activeMenu = null;
+	activeTrigger = null;
+	menu?.hide();
+}
+
+/**
+ * Resolve the element that activated a menu from an event so repeated
+ * activations of the same control can be detected.
+ */
+export function getContextMenuTrigger(event: UIEvent): Element | null {
+	const target = asElement(event.target);
+	return target?.closest(TRIGGER_SELECTOR) ?? target;
+}
+
+function showWithTrigger(menu: Menu, trigger: Element | null, show: () => void): void {
+	if (trigger && activeMenu && activeTrigger === trigger) {
+		// Same trigger activated again: toggle the menu closed.
+		closeActiveContextMenu();
+		return;
+	}
+
+	closeActiveContextMenu();
+	activeMenu = menu;
+	activeTrigger = trigger;
+	menu.onHide(() => {
+		if (activeMenu === menu) {
+			activeMenu = null;
+			activeTrigger = null;
+		}
+	});
+	show();
+}
+
+/**
+ * Show a menu from a UI event with single-menu coordination.
+ *
+ * Mouse events show the menu at the cursor; keyboard events anchor the menu
+ * below the event's current target.
+ */
+export function showCoordinatedMenu(menu: Menu, event: UIEvent): void {
+	showWithTrigger(menu, getContextMenuTrigger(event), () => {
+		if (isMouseEvent(event)) {
+			menu.showAtMouseEvent(event);
+			return;
+		}
+
+		const element = asElement(event.currentTarget);
+		if (element?.instanceOf?.(HTMLElement) || element instanceof HTMLElement) {
+			menu.showAtPosition(
+				{
+					x: element.getBoundingClientRect().left,
+					y: element.getBoundingClientRect().bottom + 4,
+				},
+				element.ownerDocument
+			);
+		}
+	});
+}
+
+/**
+ * Show a menu anchored below an element with single-menu coordination.
+ * The element doubles as the trigger, so showing at the same element again
+ * toggles the menu closed.
+ */
+export function showCoordinatedMenuAtElement(menu: Menu, element: HTMLElement): void {
+	showWithTrigger(menu, element, () => {
+		menu.showAtPosition(
+			{
+				x: element.getBoundingClientRect().left,
+				y: element.getBoundingClientRect().bottom + 4,
+			},
+			element.ownerDocument
+		);
+	});
+}

--- a/src/components/DateContextMenu.ts
+++ b/src/components/DateContextMenu.ts
@@ -1,6 +1,7 @@
 import { App, Menu, moment as obsidianMoment, type MenuItem } from "obsidian";
 import TaskNotesPlugin from "../main";
 import { ContextMenu } from "./ContextMenu";
+import { showCoordinatedMenu, showCoordinatedMenuAtElement } from "./ContextMenuCoordinator";
 import { DateTimePickerModal } from "../modals/DateTimePickerModal";
 import { addDaysToDateTime } from "../utils/dateUtils";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
@@ -10,19 +11,6 @@ const tasknotesLogger = createTaskNotesLogger({ tag: "Components/DateContextMenu
 type SubmenuMenuItem = {
 	setSubmenu(): Menu;
 };
-
-function asElement(target: EventTarget | null): Element | null {
-	if (!target || typeof target !== "object") {
-		return null;
-	}
-
-	const element = target as Element;
-	if (element.nodeType !== 1 || typeof element.closest !== "function") {
-		return null;
-	}
-
-	return element;
-}
 
 type MomentLike = {
 	format(format: string): string;
@@ -67,9 +55,6 @@ export interface DateContextMenuOptions {
 }
 
 export class DateContextMenu {
-	private static activeMenu: ContextMenu | null = null;
-	private static activeTrigger: Element | null = null;
-
 	private menu: ContextMenu;
 	private options: DateContextMenuOptions;
 
@@ -181,34 +166,12 @@ export class DateContextMenu {
 		}
 	}
 
-	private static closeActiveMenu(): void {
-		const activeMenu = DateContextMenu.activeMenu;
-		DateContextMenu.activeMenu = null;
-		DateContextMenu.activeTrigger = null;
-		activeMenu?.hide();
+	public show(event: UIEvent): void {
+		showCoordinatedMenu(this.menu, event);
 	}
 
-	private static getTriggerFromEvent(event: UIEvent): Element | null {
-		const target = asElement(event.target);
-		return target?.closest('[data-tn-action="edit-date"], .task-card__metadata-date') ?? null;
-	}
-
-	private showWithTrigger(trigger: Element | null, show: () => void): void {
-		if (trigger && DateContextMenu.activeMenu && DateContextMenu.activeTrigger === trigger) {
-			DateContextMenu.closeActiveMenu();
-			return;
-		}
-
-		DateContextMenu.closeActiveMenu();
-		DateContextMenu.activeMenu = this.menu;
-		DateContextMenu.activeTrigger = trigger;
-		this.menu.onHide(() => {
-			if (DateContextMenu.activeMenu === this.menu) {
-				DateContextMenu.activeMenu = null;
-				DateContextMenu.activeTrigger = null;
-			}
-		});
-		show();
+	public showAtElement(element: HTMLElement): void {
+		showCoordinatedMenuAtElement(this.menu, element);
 	}
 
 	public getDateOptions(): DateOption[] {
@@ -314,21 +277,6 @@ export class DateContextMenu {
 		});
 
 		return options;
-	}
-
-	public show(event: UIEvent): void {
-		this.showWithTrigger(DateContextMenu.getTriggerFromEvent(event), () => {
-			this.menu.show(event);
-		});
-	}
-
-	public showAtElement(element: HTMLElement): void {
-		this.showWithTrigger(element, () => {
-			this.menu.showAtPosition({
-				x: element.getBoundingClientRect().left,
-				y: element.getBoundingClientRect().bottom + 4,
-			});
-		});
 	}
 
 	private showDateTimePicker(): void {

--- a/src/components/ICSEventContextMenu.ts
+++ b/src/components/ICSEventContextMenu.ts
@@ -6,6 +6,7 @@ import { ICSNoteCreationModal } from "../modals/ICSNoteCreationModal";
 import { openFileSelector } from "../modals/FileSelectorModal";
 import { SafeAsync } from "../utils/safeAsync";
 import { ContextMenu } from "./ContextMenu";
+import { showCoordinatedMenu, showCoordinatedMenuAtElement } from "./ContextMenuCoordinator";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
 import { showNotice } from "../ui/notifications";
 
@@ -322,13 +323,10 @@ export class ICSEventContextMenu {
 	}
 
 	public show(event: MouseEvent): void {
-		this.menu.showAtMouseEvent(event);
+		showCoordinatedMenu(this.menu, event);
 	}
 
 	public showAtElement(element: HTMLElement): void {
-		this.menu.showAtPosition({
-			x: element.getBoundingClientRect().left,
-			y: element.getBoundingClientRect().bottom + 4,
-		});
+		showCoordinatedMenuAtElement(this.menu, element);
 	}
 }

--- a/src/components/PriorityContextMenu.ts
+++ b/src/components/PriorityContextMenu.ts
@@ -1,6 +1,7 @@
 import TaskNotesPlugin from "../main";
 import { PriorityConfig } from "../types";
 import { ContextMenu } from "./ContextMenu";
+import { showCoordinatedMenu, showCoordinatedMenuAtElement } from "./ContextMenuCoordinator";
 
 export interface PriorityContextMenuOptions {
 	currentValue?: string;
@@ -11,7 +12,7 @@ export interface PriorityContextMenuOptions {
 export class PriorityContextMenu {
 	private menu: ContextMenu;
 	private options: PriorityContextMenuOptions;
-	private sortedPriorities: PriorityConfig[];
+	private sortedPriorities: PriorityConfig[] = [];
 	private targetDoc: Document = activeDocument;
 
 	constructor(options: PriorityContextMenuOptions) {
@@ -51,7 +52,7 @@ export class PriorityContextMenu {
 		if ((event.target as Node)?.instanceOf?.(HTMLElement)) {
 			this.targetDoc = (event.target as HTMLElement).ownerDocument;
 		}
-		this.menu.show(event);
+		showCoordinatedMenu(this.menu, event);
 
 		// Apply color styling after menu is shown
 		window.setTimeout(() => {
@@ -62,10 +63,7 @@ export class PriorityContextMenu {
 	public showAtElement(element: HTMLElement): void {
 		// Store the document reference from the element to support pop-out windows
 		this.targetDoc = element.ownerDocument;
-		this.menu.showAtPosition({
-			x: element.getBoundingClientRect().left,
-			y: element.getBoundingClientRect().bottom + 4,
-		});
+		showCoordinatedMenuAtElement(this.menu, element);
 
 		// Apply color styling after menu is shown
 		window.setTimeout(() => {

--- a/src/components/RecurrenceContextMenu.ts
+++ b/src/components/RecurrenceContextMenu.ts
@@ -2,6 +2,7 @@ import { App, Modal, Setting } from "obsidian";
 import { TranslationKey } from "../i18n";
 import TaskNotesPlugin from "../main";
 import { ContextMenu } from "./ContextMenu";
+import { showCoordinatedMenu } from "./ContextMenuCoordinator";
 import { attachDateInputBehavior } from "../ui/dateInputBehavior";
 
 export interface RecurrenceOption {
@@ -576,7 +577,7 @@ export class RecurrenceContextMenu {
 	}
 
 	public show(event: UIEvent): void {
-		this.menu.show(event);
+		showCoordinatedMenu(this.menu, event);
 	}
 }
 

--- a/src/components/ReminderContextMenu.ts
+++ b/src/components/ReminderContextMenu.ts
@@ -3,6 +3,7 @@ import TaskNotesPlugin from "../main";
 import { TaskInfo, Reminder } from "../types";
 import { ReminderModal } from "../modals/ReminderModal";
 import { ContextMenu } from "./ContextMenu";
+import { showCoordinatedMenu } from "./ContextMenuCoordinator";
 
 export class ReminderContextMenu {
 	private plugin: TaskNotesPlugin;
@@ -63,7 +64,7 @@ export class ReminderContextMenu {
 			});
 		}
 
-		menu.show(event);
+		showCoordinatedMenu(menu, event);
 	}
 
 	private addQuickRemindersSection(menu: Menu, anchor: "due" | "scheduled", title: string): void {

--- a/src/components/StatusContextMenu.ts
+++ b/src/components/StatusContextMenu.ts
@@ -1,5 +1,6 @@
 import TaskNotesPlugin from "../main";
 import { ContextMenu } from "./ContextMenu";
+import { showCoordinatedMenu, showCoordinatedMenuAtElement } from "./ContextMenuCoordinator";
 
 export interface StatusOption {
 	label: string;
@@ -81,7 +82,7 @@ export class StatusContextMenu {
 		if ((event.target as Node)?.instanceOf?.(HTMLElement)) {
 			this.targetDoc = (event.target as HTMLElement).ownerDocument;
 		}
-		this.menu.show(event);
+		showCoordinatedMenu(this.menu, event);
 
 		// Apply color styling after menu is shown
 		window.setTimeout(() => {
@@ -92,10 +93,7 @@ export class StatusContextMenu {
 	public showAtElement(element: HTMLElement): void {
 		// Store the document reference from the element to support pop-out windows
 		this.targetDoc = element.ownerDocument;
-		this.menu.showAtPosition({
-			x: element.getBoundingClientRect().left,
-			y: element.getBoundingClientRect().bottom + 4,
-		});
+		showCoordinatedMenuAtElement(this.menu, element);
 
 		// Apply color styling after menu is shown
 		window.setTimeout(() => {

--- a/src/components/TaskContextMenu.ts
+++ b/src/components/TaskContextMenu.ts
@@ -36,6 +36,7 @@ import {
 } from "../utils/dependencyUtils";
 import { generateLink } from "../utils/linkUtils";
 import { ContextMenu } from "./ContextMenu";
+import { showCoordinatedMenu, showCoordinatedMenuAtElement } from "./ContextMenuCoordinator";
 import { buildTimeblockPrefillForTask } from "../utils/timeblockPrefillUtils";
 import { TimeblockCreationModal } from "../modals/TimeblockCreationModal";
 import {
@@ -2555,15 +2556,12 @@ export class TaskContextMenu {
 		if ((event.target as Node)?.instanceOf?.(HTMLElement)) {
 			this.targetDoc = (event.target as HTMLElement).ownerDocument;
 		}
-		this.menu.showAtMouseEvent(event);
+		showCoordinatedMenu(this.menu, event);
 	}
 
 	public showAtElement(element: HTMLElement): void {
 		// Store the document reference from the element to support pop-out windows
 		this.targetDoc = element.ownerDocument;
-		this.menu.showAtPosition({
-			x: element.getBoundingClientRect().left,
-			y: element.getBoundingClientRect().bottom + 4,
-		});
+		showCoordinatedMenuAtElement(this.menu, element);
 	}
 }

--- a/tests/unit/components/ContextMenuCoordinator.test.ts
+++ b/tests/unit/components/ContextMenuCoordinator.test.ts
@@ -1,0 +1,243 @@
+import type { Menu } from "obsidian";
+import {
+	closeActiveContextMenu,
+	getContextMenuTrigger,
+	showCoordinatedMenu,
+	showCoordinatedMenuAtElement,
+} from "../../../src/components/ContextMenuCoordinator";
+
+interface MockMenu {
+	showAtMouseEvent: jest.Mock;
+	showAtPosition: jest.Mock;
+	hide: jest.Mock;
+	onHide: jest.Mock;
+	hideCallbacks: Array<() => void>;
+}
+
+function createMockMenu(): MockMenu {
+	const hideCallbacks: Array<() => void> = [];
+	const menu = {
+		showAtMouseEvent: jest.fn(),
+		showAtPosition: jest.fn(),
+		hide: jest.fn(() => {
+			hideCallbacks.forEach((callback) => callback());
+		}),
+		onHide: jest.fn((callback: () => void) => {
+			hideCallbacks.push(callback);
+		}),
+		hideCallbacks,
+	};
+	return menu;
+}
+
+function asMenu(menu: MockMenu): Menu {
+	return menu as unknown as Menu;
+}
+
+function createTrigger(selector = "div"): HTMLElement {
+	const trigger = document.createElement(selector);
+	trigger.dataset.tnAction = "edit-date";
+	document.body.appendChild(trigger);
+	return trigger;
+}
+
+describe("ContextMenuCoordinator", () => {
+	afterEach(() => {
+		closeActiveContextMenu();
+		document.body.innerHTML = "";
+	});
+
+	describe("showCoordinatedMenu", () => {
+		it("shows the menu at the mouse position on first activation", () => {
+			const menu = createMockMenu();
+			const trigger = createTrigger();
+			const event = new MouseEvent("click", { bubbles: true });
+			Object.defineProperty(event, "target", { value: trigger });
+
+			showCoordinatedMenu(asMenu(menu), event);
+
+			expect(menu.showAtMouseEvent).toHaveBeenCalledWith(event);
+			expect(menu.showAtMouseEvent).toHaveBeenCalledTimes(1);
+		});
+
+		it("toggles the menu closed when the same trigger is activated again", () => {
+			const first = createMockMenu();
+			const second = createMockMenu();
+			const trigger = createTrigger();
+
+			const firstEvent = new MouseEvent("click", { bubbles: true });
+			Object.defineProperty(firstEvent, "target", { value: trigger });
+			showCoordinatedMenu(asMenu(first), firstEvent);
+
+			const secondEvent = new MouseEvent("click", { bubbles: true });
+			Object.defineProperty(secondEvent, "target", { value: trigger });
+			showCoordinatedMenu(asMenu(second), secondEvent);
+
+			expect(first.showAtMouseEvent).toHaveBeenCalledTimes(1);
+			expect(first.hide).toHaveBeenCalledTimes(1);
+			expect(second.showAtMouseEvent).not.toHaveBeenCalled();
+		});
+
+		it("uses the same trigger when clicking nested elements of a control", () => {
+			const first = createMockMenu();
+			const second = createMockMenu();
+			const trigger = createTrigger("button");
+			const icon = document.createElement("span");
+			trigger.appendChild(icon);
+
+			const firstEvent = new MouseEvent("click", { bubbles: true });
+			Object.defineProperty(firstEvent, "target", { value: trigger });
+			showCoordinatedMenu(asMenu(first), firstEvent);
+
+			// Click lands on an inner element of the same control.
+			const innerEvent = new MouseEvent("click", { bubbles: true });
+			Object.defineProperty(innerEvent, "target", { value: icon });
+			showCoordinatedMenu(asMenu(second), innerEvent);
+
+			expect(first.hide).toHaveBeenCalledTimes(1);
+			expect(second.showAtMouseEvent).not.toHaveBeenCalled();
+		});;
+
+		it("replaces the active menu when another trigger is activated", () => {
+			const first = createMockMenu();
+			const second = createMockMenu();
+			const firstTrigger = createTrigger();
+			const secondTrigger = createTrigger();
+
+			showCoordinatedMenu(asMenu(first), new MouseEvent("click"));
+			const secondEvent = new MouseEvent("click", { bubbles: true });
+			Object.defineProperty(secondEvent, "target", { value: secondTrigger });
+			showCoordinatedMenu(asMenu(second), secondEvent);
+
+			expect(first.hide).toHaveBeenCalledTimes(1);
+			expect(second.showAtMouseEvent).toHaveBeenCalledTimes(1);
+		});
+
+		it("allows reopening a menu after it was hidden externally", () => {
+			const menu = createMockMenu();
+			const trigger = createTrigger();
+
+			showCoordinatedMenu(asMenu(menu), new MouseEvent("click"));
+			menu.hide();
+
+			const reopened = createMockMenu();
+			const event = new MouseEvent("click", { bubbles: true });
+			Object.defineProperty(event, "target", { value: trigger });
+			showCoordinatedMenu(asMenu(reopened), event);
+
+			expect(reopened.showAtMouseEvent).toHaveBeenCalledTimes(1);
+		});
+
+		it("anchors the menu below the current target for keyboard events", () => {
+			const menu = createMockMenu();
+			const trigger = createTrigger();
+			jest.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+				left: 20,
+				bottom: 100,
+			} as DOMRect);
+
+			const event = new KeyboardEvent("keydown", { bubbles: true });
+			Object.defineProperty(event, "currentTarget", { value: trigger });
+			showCoordinatedMenu(asMenu(menu), event);
+
+			expect(menu.showAtPosition).toHaveBeenCalledWith(
+				expect.objectContaining({ x: 20, y: 104 }),
+				trigger.ownerDocument
+			);
+		});
+
+		it("does not show keyboard menus without an element target", () => {
+			const menu = createMockMenu();
+
+			const event = new KeyboardEvent("keydown");
+			Object.defineProperty(event, "currentTarget", { value: null });
+			showCoordinatedMenu(asMenu(menu), event);
+
+			expect(menu.showAtPosition).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("showCoordinatedMenuAtElement", () => {
+		it("anchors the menu below the element", () => {
+			const menu = createMockMenu();
+			const element = createTrigger();
+			jest.spyOn(element, "getBoundingClientRect").mockReturnValue({
+				left: 5,
+				bottom: 50,
+			} as DOMRect);
+
+			showCoordinatedMenuAtElement(asMenu(menu), element);
+
+			expect(menu.showAtPosition).toHaveBeenCalledWith(
+				expect.objectContaining({ x: 5, y: 54 }),
+				element.ownerDocument
+			);
+		});
+
+		it("toggles the menu closed when shown at the same element again", () => {
+			const first = createMockMenu();
+			const second = createMockMenu();
+			const element = createTrigger();
+
+			showCoordinatedMenuAtElement(asMenu(first), element);
+			showCoordinatedMenuAtElement(asMenu(second), element);
+
+			expect(first.hide).toHaveBeenCalledTimes(1);
+			expect(second.showAtPosition).not.toHaveBeenCalled();
+		});
+
+		it("replaces the active menu when shown at another element", () => {
+			const first = createMockMenu();
+			const second = createMockMenu();
+
+			showCoordinatedMenuAtElement(asMenu(first), createTrigger());
+			showCoordinatedMenuAtElement(asMenu(second), createTrigger());
+
+			expect(first.hide).toHaveBeenCalledTimes(1);
+			expect(second.showAtPosition).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("closeActiveContextMenu", () => {
+		it("hides the active menu and clears coordination state", () => {
+			const first = createMockMenu();
+			const second = createMockMenu();
+
+			showCoordinatedMenu(asMenu(first), new MouseEvent("click"));
+			closeActiveContextMenu();
+			showCoordinatedMenu(asMenu(second), new MouseEvent("click"));
+
+			expect(first.hide).toHaveBeenCalledTimes(1);
+			expect(second.showAtMouseEvent).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("getContextMenuTrigger", () => {
+		it("resolves interactive-control attributes before falling back to the target", () => {
+			const control = document.createElement("div");
+			control.setAttribute("data-type", "priority");
+			const inner = document.createElement("span");
+			control.appendChild(inner);
+
+			const event = new MouseEvent("click");
+			Object.defineProperty(event, "target", { value: inner });
+
+			expect(getContextMenuTrigger(event)).toBe(control);
+		});
+
+		it("falls back to the event target when no control ancestor matches", () => {
+			const plain = document.createElement("td");
+			const event = new MouseEvent("click");
+			Object.defineProperty(event, "target", { value: plain });
+
+			expect(getContextMenuTrigger(event)).toBe(plain);
+		});
+
+		it("returns null for non-element targets", () => {
+			const event = new MouseEvent("click");
+			Object.defineProperty(event, "target", { value: null });
+
+			expect(getContextMenuTrigger(event)).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Repeatedly activating the priority indicator on a task card, or opening the task context menu repeatedly, created another menu each time instead of closing or reusing the one already open. Both of these were observed and reproduced (see "Reproduction" below); the other context menus were not observed to stack.

The reason the two differ is not that the other menus are safer — it is that no wrapper coordinated menu visibility at all, except `DateContextMenu`, which has had its own fix since #1849 (4.8.0). Because every other wrapper shares the exact same pattern, the fix is applied to all of them rather than patching only the two observed cases: the remaining menus are one refactor away from the same bug, and the behaviour should not depend on which component happens to be clicked.

## Reproduction

- Priority: click the priority dot on a task card repeatedly — each click opens another menu; the previous ones stay open.
- Task: click the task options button (three dots button) repeatedly from the task card — the same stacking occurs.
- Not observed (fixed anyway as a precaution): status, date, recurrence, reminder, ICS event and batch menus.

## What's in it

- New `ContextMenuCoordinator` owns menu visibility: it hides the active menu before showing a new one and treats a repeated activation of the same trigger as a toggle.
- Applied to the priority, status, date, recurrence, reminder, task, ICS event and batch menus via `showCoordinatedMenu()` / `showCoordinatedMenuAtElement()`.
- Removed the duplicated active-menu state from `DateContextMenu` — that component's existing behaviour is unchanged, it now comes from the shared coordinator — and the element-anchored positioning copies shared by five wrappers.
- Triggers are resolved from the plugin-wide control conventions (`role="button"` set by `prepareInteractiveControl`, `data-tn-action`, `data-type`), so clicking an inner icon maps to the same control.

## Testing

- New `tests/unit/components/ContextMenuCoordinator.test.ts` (14 cases: toggle on the same trigger, nested elements, replacement across triggers, reopening after an external hide, keyboard-event anchoring).
- Existing `DateContextMenu.issue-1849` coverage passes unchanged, confirming the refactor preserves the behaviour that shipped in 4.8.0.
- `npm test`: 4159 passed, 0 failed. `npm run typecheck` and `npm run lint` clean.

## Manual verification

- [x] Priority dot: click repeatedly — the menu toggles open/closed and never stacks
- [x] Task context menu: click the task options button (three dots button) repeatedly from the task card — no stacking
- [x] With a menu open, open a different menu — the first one closes
- [x] Status, date, recurrence and reminder indicators behave the same (no regressions)
- [x] Keyboard activation (Enter / Space on a focused indicator) anchors the menu below it
- [x] Repeat in a pop-out window — item colour styling still applies

## Notes

- The coordinator only relies on the `onHide` / `hide` / `showAtMouseEvent` / `showAtPosition` surface, so it works for `ContextMenu` instances and for plain `Menu` instances — the latter matters for `TaskContextMenu`, one of the two reproduced cases, since it can be populated onto a caller-supplied `Menu`.
- Views that build their own menus directly with `new Menu()` are untouched and can be migrated with the same one-line call if desired.
- Release notes updated in `docs/releases/unreleased.md`.

Refs #1849
