### PR TITLE
fix: re-read frontmatter before modal save to prevent overwriting concurrent task edits

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -34,6 +34,9 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 ## Fixed
 
+- Preserve background task updates when saving an older task edit window, including recurring completion history and fields removed by another writer.
+  - Thanks to @martin-forge for the contribution.
+
 - (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
   - Thanks to @3zra47 for reporting and @YBKF for the contribution.
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,7 +35,6 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 ## Fixed
 
 - Preserve background task updates when saving an older task edit window, including recurring completion history and fields removed by another writer.
-  - Thanks to @martin-forge for the contribution.
 
 - (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
   - Thanks to @3zra47 for reporting and @YBKF for the contribution.

--- a/src/services/task-service/TaskUpdateService.ts
+++ b/src/services/task-service/TaskUpdateService.ts
@@ -130,20 +130,43 @@ export class TaskUpdateService {
 				newPath = parentPath ? `${parentPath}/${newFilename}.md` : `${newFilename}.md`;
 			}
 
-			const recurrenceUpdates = buildTaskUpdateRecurrenceUpdates({
-				originalTask,
-				updates: taskUpdates,
-				maintainDueDateOffsetInRecurring: runtime.settings.maintainDueDateOffsetInRecurring,
-			});
+			let recurrenceUpdates: Partial<TaskInfo> = {};
 			const normalizedDetails = normalizeTaskUpdateDetails(taskUpdates);
 			let finalTags: string[] | undefined;
 			const dateModified = getCurrentTimestamp();
 			const currentDateString =
-				taskUpdates.status !== undefined && !originalTask.recurrence
-					? getCurrentDateString()
-					: "";
+				taskUpdates.status !== undefined ? getCurrentDateString() : "";
 
 			await processVaultFrontMatter(runtime.app, file, (frontmatter) => {
+				// Rebase the caller's named changes on the bytes Obsidian is about
+				// to modify. A modal's TaskInfo can predate an external completion.
+				const current = runtime.fieldMapper.mapFromFrontmatter(
+					frontmatter,
+					originalTask.path,
+					runtime.settings.storeTitleInFilename
+				);
+				originalTask = {
+					// Retain derived view/body context; persisted fields come from the fresh mapping.
+					id: originalTask.id,
+					basesData: originalTask.basesData,
+					details: originalTask.details,
+					blocking: originalTask.blocking,
+					isBlocked: originalTask.isBlocked,
+					isBlocking: originalTask.isBlocking,
+					hasSubtasks: originalTask.hasSubtasks,
+					path: originalTask.path,
+					title: originalTask.title,
+					status: originalTask.status,
+					priority: originalTask.priority,
+					archived: false,
+					...current,
+				};
+				recurrenceUpdates = buildTaskUpdateRecurrenceUpdates({
+					originalTask,
+					updates: taskUpdates,
+					maintainDueDateOffsetInRecurring:
+						runtime.settings.maintainDueDateOffsetInRecurring,
+				});
 				const frontmatterResult = applyTaskUpdateFrontmatterChange({
 					frontmatter,
 					originalTask,

--- a/src/services/task-service/taskUpdatePlanning.ts
+++ b/src/services/task-service/taskUpdatePlanning.ts
@@ -1,8 +1,5 @@
 import type { FieldMappingKey, TaskInfo, TimeEntry } from "../../types";
-import {
-	addDTSTARTToRecurrenceRule,
-	updateToNextScheduledOccurrence,
-} from "../../core/recurrence";
+import { addDTSTARTToRecurrenceRule, updateToNextScheduledOccurrence } from "../../core/recurrence";
 import {
 	applyGoogleCalendarRecurringExceptionCleanup,
 	applyGoogleCalendarRecurringExceptionForScheduledChange,
@@ -18,6 +15,11 @@ export type TaskUpdateInput = Partial<TaskInfo> & {
 };
 
 export interface TaskUpdateFieldMapper {
+	mapFromFrontmatter: (
+		frontmatter: unknown,
+		filePath: string,
+		storeTitleInFilename?: boolean
+	) => Partial<TaskInfo>;
 	mapToFrontmatter: (
 		taskData: Partial<TaskInfo>,
 		taskTag?: string,
@@ -196,8 +198,9 @@ export function applyTaskUpdateFrontmatterChange({
 	storeTitleInFilename,
 	updateCompletedDateInFrontmatter,
 }: ApplyTaskUpdateFrontmatterChangeInput): ApplyTaskUpdateFrontmatterChangeResult {
+	// Publish only the named patch and its recurrence consequences.
 	const completeTaskData: Partial<TaskInfo> = {
-		...originalTask,
+		tags: getFrontmatterTags(frontmatter.tags),
 		...updates,
 		...recurrenceUpdates,
 		dateModified,

--- a/tests/services/TaskUpdateService.concurrent-edits.test.ts
+++ b/tests/services/TaskUpdateService.concurrent-edits.test.ts
@@ -1,0 +1,60 @@
+import { TFile } from "obsidian";
+import { TaskUpdateService } from "../../src/services/task-service/TaskUpdateService";
+
+describe("concurrent task edits", () => {
+	it("rebases a stale modal patch on current recurrence fields and returns that state", async () => {
+		const file = Object.assign(Object.create(TFile.prototype), { path: "Tasks/example.md" });
+		const fm: any = {
+			status: "ready",
+			priority: "normal",
+			scheduled: "2026-09-07",
+			recurrence: "DTSTART:20260905;FREQ=DAILY",
+			complete_instances: ["2026-09-05", "2026-09-06"],
+			timeEstimate: 5,
+			custom: "keep",
+		};
+		const runtime: any = {
+			app: {
+				vault: { getAbstractFileByPath: () => file },
+				fileManager: { processFrontMatter: async (_: unknown, fn: any) => fn(fm) },
+			},
+			settings: {
+				storeTitleInFilename: false,
+				maintainDueDateOffsetInRecurring: false,
+				taskIdentificationMethod: "property",
+				taskPropertyName: "type",
+				taskPropertyValue: "task",
+			},
+			fieldMapper: {
+				mapFromFrontmatter: (value: any) => ({ ...value }),
+				mapToFrontmatter: (value: any) => ({ ...value }),
+				toUserField: (key: string) => key,
+			},
+			cacheManager: { updateTaskInfoInCache: jest.fn() },
+			emitter: { trigger: jest.fn() },
+			statusManager: { isCompletedStatus: () => false },
+		};
+		const service = new TaskUpdateService({
+			runtime,
+			updateCompletedDateInFrontmatter: () => {},
+		});
+		const stale: any = {
+			...fm,
+			path: file.path,
+			title: "Example",
+			scheduled: "2026-09-06",
+			due: "2026-09-01",
+			complete_instances: ["2026-09-05"],
+		};
+		const result = await service.updateTask(stale, { timeEstimate: 10 });
+		expect(fm.scheduled).toBe("2026-09-07");
+		expect(fm.complete_instances).toEqual(["2026-09-05", "2026-09-06"]);
+		expect(fm.custom).toBe("keep");
+		expect(fm.due).toBeUndefined();
+		expect(result.due).toBeUndefined();
+		expect(result.scheduled).toBe("2026-09-07");
+		expect(result.complete_instances).toEqual(fm.complete_instances);
+		expect(result.timeEstimate).toBe(10);
+		expect(stale.scheduled).toBe("2026-09-06");
+	});
+});

--- a/tests/unit/issues/issue-1696-gcal-recurring-reschedule.test.ts
+++ b/tests/unit/issues/issue-1696-gcal-recurring-reschedule.test.ts
@@ -64,6 +64,7 @@ function createGoogleSyncPlugin(frontmatter: Record<string, unknown> = {}) {
 			},
 		},
 		fieldMapper: {
+			mapFromFrontmatter: (fm: Record<string, unknown>) => ({ ...fm }),
 			toUserField: jest.fn((field: string) => field),
 			mapToFrontmatter: jest.fn((taskData: Record<string, unknown>) => {
 				const mapped: Record<string, unknown> = {};
@@ -131,6 +132,7 @@ describe("Issue #1696: Google Calendar recurring reschedule sync", () => {
 			googleCalendarEventId: "master-event-id",
 		} as TaskInfo;
 
+		Object.assign(frontmatter, task);
 		const updatedTask = await taskService.updateTask(task, {
 			scheduled: "2026-04-15",
 		});

--- a/tests/unit/services/TaskService.test.ts
+++ b/tests/unit/services/TaskService.test.ts
@@ -1425,6 +1425,7 @@ describe('TaskService', () => {
         complete_instances: ['2024-12-30', '2024-12-31']
       });
 
+      mockPlugin.app.fileManager.processFrontMatter.mockImplementation(async (_file, fn) => fn({...recurringTask}));
       const result = await taskService.updateTask(recurringTask, { priority: 'high' });
 
       expect(result.complete_instances).toEqual(['2024-12-30', '2024-12-31']);
@@ -1465,6 +1466,7 @@ describe('TaskService', () => {
       const taskWithTags = TaskFactory.createTask({ tags: ['task', 'important'] });
       const updates = { priority: 'high' };
 
+      mockPlugin.app.fileManager.processFrontMatter.mockImplementation(async (_file, fn) => fn({...taskWithTags}));
       const result = await taskService.updateTask(taskWithTags, updates);
 
       expect(result.tags).toEqual(['task', 'important']);

--- a/tests/unit/services/taskUpdatePlanning.test.ts
+++ b/tests/unit/services/taskUpdatePlanning.test.ts
@@ -40,6 +40,7 @@ function createFieldMapper(): TaskUpdateFieldMapper {
 	};
 
 	return {
+		mapFromFrontmatter: (frontmatter) => frontmatter as Partial<TaskInfo>,
 		mapToFrontmatter: (taskData, taskTag, storeTitleInFilename) => {
 			const frontmatter: Record<string, unknown> = {
 				title: taskData.title,
@@ -162,6 +163,7 @@ describe("taskUpdatePlanning", () => {
 
 	it("applies mapped updates, custom frontmatter, removals, and task identification", () => {
 		const frontmatter: Record<string, unknown> = {
+			priority: "normal",
 			title: "Old",
 			status: "open",
 			due: "2026-05-19",


### PR DESCRIPTION
### Problem
A background update to a task file can be undone when an already-open task edit window saves an unrelated change. For example, changing an estimate can restore an old scheduled date after a recurring task was completed elsewhere.

### Solution
Read the latest frontmatter inside Obsidian's save callback and apply only the requested fields. Preserve background edits, completed occurrences and fields another writer removed. This changes the task update service only; it does not depend on the Calendar or security proposals.

### Testing
- 110 focused tests pass, including a stale-edit regression and existing task/recurrence tests.
- `npm run lint` and `npm run build:test` pass.
- Reloaded the standalone build in a disposable Obsidian vault; no captured errors.
- [GitHub CI: full test suite and build passed](https://github.com/callumalpass/tasknotes/actions/runs/33980772916).
