### PR TITLE
feat(calendar): opt-in durable UUID recovery for private Google Calendar projections

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -40,7 +40,6 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 ## Added
 
 - Add an optional **Rebuild private task projections** setting to recover missing Google Calendar task events and repair renamed links, duplicates and stale event details. It uses a persistent task ID, leaves unrelated or invited events alone, and skips unchanged events.
-  - Thanks to @martin-forge for the contribution.
 
 - (#2147) Added context-menu actions for recording task completion today, on the scheduled date, on the due date, or on a chosen date. The actions can be grouped in a submenu from Appearance settings. See [Completing Tasks](https://tasknotes.dev/features/task-management/#completing-tasks).
   - Rescheduling a recurring task can reactivate affected completed or skipped instances after confirmation. See [Recurring Tasks](https://tasknotes.dev/features/recurring-tasks/).

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -39,6 +39,9 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 ## Added
 
+- Add an optional **Rebuild private task projections** setting to recover missing Google Calendar task events and repair renamed links, duplicates and stale event details. It uses a persistent task ID, leaves unrelated or invited events alone, and skips unchanged events.
+  - Thanks to @martin-forge for the contribution.
+
 - (#2147) Added context-menu actions for recording task completion today, on the scheduled date, on the due date, or on a chosen date. The actions can be grouped in a submenu from Appearance settings. See [Completing Tasks](https://tasknotes.dev/features/task-management/#completing-tasks).
   - Rescheduling a recurring task can reactivate affected completed or skipped instances after confirmation. See [Recurring Tasks](https://tasknotes.dev/features/recurring-tasks/).
   - Thanks to @renatomen for the contribution.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -34,6 +34,8 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 ## Fixed
 
+- Keep private task projections when a source is missing, damaged or has lost its task ID. Cleanup now requires a readable retirement marker or an identical surviving event, including on retries.
+
 - (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
   - Thanks to @3zra47 for reporting and @YBKF for the contribution.
 

--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -58,6 +58,58 @@ type GoogleCalendarEventPayload = Record<string, unknown> & {
 	end?: GoogleCalendarDateTime;
 };
 
+export type TaskProjectionEvent = {
+	id: string;
+	etag?: string;
+	status?: string;
+	recurringEventId?: string;
+	attendees?: unknown[];
+	summary?: string;
+	description?: string;
+	location?: string;
+	start?: GoogleCalendarDateTime;
+	end?: GoogleCalendarDateTime;
+	recurrence?: string[];
+	reminders?: { useDefault: boolean; overrides?: Array<{ method: string; minutes: number }> };
+	colorId?: string;
+	transparency?: string;
+	visibility?: string;
+	extendedProperties?: { private?: Record<string, string> };
+};
+
+/** Compare the owned projection fields, allowing provider date normalisation. */
+export function taskProjectionMatches(
+	actual: Omit<TaskProjectionEvent, "id">,
+	expected: Omit<TaskProjectionEvent, "id">
+): boolean {
+	const date = (value?: GoogleCalendarDateTime) =>
+		value?.date ||
+		(value?.dateTime ? `${Date.parse(value.dateTime)}:${value.timeZone || ""}` : "");
+	const normalise = (value: Omit<TaskProjectionEvent, "id">) => ({
+		summary: value.summary || "",
+		description: value.description || "",
+		location: value.location || "",
+		start: date(value.start),
+		end: date(value.end),
+		recurrence: [...(value.recurrence || [])].sort(),
+		reminders: {
+			useDefault: value.reminders?.useDefault ?? true,
+			overrides: [...(value.reminders?.overrides || [])].sort(
+				(a, b) => a.method.localeCompare(b.method) || a.minutes - b.minutes
+			),
+		},
+		colorId: value.colorId || "",
+		transparency: value.transparency || "opaque",
+		visibility: value.visibility || "default",
+	});
+	return (
+		JSON.stringify(normalise(actual)) === JSON.stringify(normalise(expected)) &&
+		Object.entries(expected.extendedProperties?.private || {}).every(
+			([key, value]) => actual.extendedProperties?.private?.[key] === value
+		)
+	);
+}
+
 /**
  * GoogleCalendarService handles Google Calendar API interactions.
  * Uses OAuth for authentication and provides calendar event access.
@@ -674,6 +726,46 @@ export class GoogleCalendarService extends CalendarProvider {
 		this.lastManualRefresh = Date.now();
 	}
 
+	/** List only this vault's explicitly marked task projections, with all pages. */
+	async listTaskProjections(
+		calendarId: string,
+		vaultName: string
+	): Promise<TaskProjectionEvent[]> {
+		validateCalendarId(calendarId);
+		const token = await this.oauthService.getValidToken("google");
+		const events: TaskProjectionEvent[] = [];
+		let pageToken: string | undefined;
+		do {
+			const params = new URLSearchParams({
+				maxResults: "2500",
+				singleEvents: "false",
+				showDeleted: "false",
+			});
+			params.append("privateExtendedProperty", "tasknotesProjection=1");
+			params.append("privateExtendedProperty", `tasknotesVault=${vaultName}`);
+			if (pageToken) params.set("pageToken", pageToken);
+			const response = await this.withRetry(
+				() =>
+					requestUrl({
+						url: `${this.baseUrl}/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
+						method: "GET",
+						headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+					}),
+				"List owned task projections"
+			);
+			const page = response.json as { items?: TaskProjectionEvent[]; nextPageToken?: string };
+			if (!page || (page.items !== undefined && !Array.isArray(page.items)))
+				throw new Error("Incomplete task projection listing");
+			events.push(
+				...(page.items || []).filter(
+					(event) => event.status !== "cancelled" && !event.recurringEventId
+				)
+			);
+			pageToken = page.nextPageToken;
+		} while (pageToken);
+		return events;
+	}
+
 	/**
 	 * Clears the cache
 	 */
@@ -702,6 +794,9 @@ export class GoogleCalendarService extends CalendarProvider {
 			};
 			colorId?: string;
 			recurrence?: string[];
+			transparency?: "transparent";
+			visibility?: "private";
+			extendedProperties?: { private: Record<string, string> };
 		},
 		expectedConnectionGeneration?: number
 	): Promise<ICSEvent> {
@@ -730,8 +825,28 @@ export class GoogleCalendarService extends CalendarProvider {
 
 			const currentEvent = getResponse.json as GoogleCalendarEventPayload;
 
+			// Task projections are private and attendee-free; never overwrite an invitation.
+			if (
+				updates.extendedProperties &&
+				Array.isArray(currentEvent.attendees) &&
+				currentEvent.attendees.length
+			) {
+				throw new Error("A task projection has attendees; refusing to overwrite it");
+			}
 			// Build update payload
 			const payload: GoogleCalendarEventPayload = { ...currentEvent };
+			if (updates.extendedProperties && typeof currentEvent.etag !== "string")
+				throw new Error("Task projection has no concurrency token");
+			const currentOwner = (currentEvent as TaskProjectionEvent).extendedProperties?.private;
+			if (
+				updates.extendedProperties &&
+				currentOwner?.tasknotesUid &&
+				currentOwner.tasknotesUid !== updates.extendedProperties.private.tasknotesUid
+			)
+				throw new Error("Task projection belongs to another task");
+			if (updates.extendedProperties) payload.extendedProperties = updates.extendedProperties;
+			if (updates.transparency) payload.transparency = updates.transparency;
+			if (updates.visibility) payload.visibility = updates.visibility;
 			if (payload.status === "cancelled") {
 				payload.status = "confirmed";
 			}
@@ -809,6 +924,9 @@ export class GoogleCalendarService extends CalendarProvider {
 					method: "PUT",
 					headers: {
 						Authorization: `Bearer ${token}`,
+						...(updates.extendedProperties
+							? { "If-Match": currentEvent.etag as string }
+							: {}),
 						"Content-Type": "application/json",
 						Accept: "application/json",
 					},
@@ -817,6 +935,23 @@ export class GoogleCalendarService extends CalendarProvider {
 			}, `Update event ${eventId}`);
 
 			const updatedEvent = updateResponse.json;
+
+			if (updates.extendedProperties) {
+				const readback = await this.withRetry(
+					() =>
+						requestUrl({
+							url: `${this.baseUrl}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+							method: "GET",
+							headers: { Authorization: `Bearer ${token}` },
+						}),
+					"Verify task projection update"
+				);
+				if (
+					(readback.json as TaskProjectionEvent).attendees?.length ||
+					!taskProjectionMatches(readback.json as TaskProjectionEvent, payload)
+				)
+					throw new Error("Task projection update did not read back");
+			}
 
 			// Convert to ICSEvent for return
 			const icsEvent = this.convertToICSEvent(updatedEvent, calendarId);
@@ -865,6 +1000,9 @@ export class GoogleCalendarService extends CalendarProvider {
 			};
 			colorId?: string;
 			recurrence?: string[];
+			transparency?: "transparent";
+			visibility?: "private";
+			extendedProperties?: { private: Record<string, string> };
 		},
 		expectedConnectionGeneration?: number
 	): Promise<ICSEvent> {
@@ -889,6 +1027,9 @@ export class GoogleCalendarService extends CalendarProvider {
 				summary: summary,
 				description: event.description,
 				location: event.location,
+				...(event.extendedProperties && { extendedProperties: event.extendedProperties }),
+				...(event.transparency && { transparency: event.transparency }),
+				...(event.visibility && { visibility: event.visibility }),
 			};
 
 			// Add reminders if provided
@@ -940,6 +1081,23 @@ export class GoogleCalendarService extends CalendarProvider {
 
 			const createdEvent = response.json;
 
+			if (event.extendedProperties) {
+				const readback = await this.withRetry(
+					() =>
+						requestUrl({
+							url: `${this.baseUrl}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(createdEvent.id)}`,
+							method: "GET",
+							headers: { Authorization: `Bearer ${token}` },
+						}),
+					"Verify task projection creation"
+				);
+				if (
+					(readback.json as TaskProjectionEvent).attendees?.length ||
+					!taskProjectionMatches(readback.json as TaskProjectionEvent, payload)
+				)
+					throw new Error("Task projection creation did not read back");
+			}
+
 			// Convert to ICSEvent for return
 			const icsEvent = this.convertToICSEvent(createdEvent, calendarId);
 
@@ -984,12 +1142,42 @@ export class GoogleCalendarService extends CalendarProvider {
 				expectedConnectionGeneration
 			);
 
+			let etag: string | undefined;
+			if (
+				this.plugin.settings.googleCalendarExport.reconcileFromTasks &&
+				calendarId === this.plugin.settings.googleCalendarExport.targetCalendarId
+			) {
+				const response = await this.withRetry(
+					() =>
+						requestUrl({
+							url: `${this.baseUrl}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+							method: "GET",
+							headers: { Authorization: `Bearer ${token}` },
+						}),
+					"Read task projection before deletion"
+				);
+				const event = response.json as TaskProjectionEvent;
+				const owner = event.extendedProperties?.private;
+				if (
+					event.attendees?.length ||
+					owner?.tasknotesProjection !== "1" ||
+					owner.tasknotesVault !== this.plugin.app.vault.getName() ||
+					!owner.tasknotesUid ||
+					typeof event.etag !== "string"
+				)
+					throw new Error(
+						"Refusing to delete an unowned, invited or unversioned task projection"
+					);
+				etag = event.etag;
+			}
+
 			await this.withRetry(async () => {
 				return await requestUrl({
 					url: `${this.baseUrl}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
 					method: "DELETE",
 					headers: {
 						Authorization: `Bearer ${token}`,
+						...(etag ? { "If-Match": etag } : {}),
 					},
 				});
 			}, `Delete event ${eventId}`);

--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -1124,6 +1124,21 @@ export class GoogleCalendarService extends CalendarProvider {
 		}
 	}
 
+	/** Read an event directly; absence from the filtered projection list is not proof it is gone. */
+	async readTaskProjection(calendarId: string, eventId: string, expectedConnectionGeneration?: number): Promise<TaskProjectionEvent> {
+		validateCalendarId(calendarId);
+		validateEventId(eventId);
+		const token = await this.oauthService.getValidToken("google", expectedConnectionGeneration);
+		const response = await this.withRetry(() => requestUrl({
+			url: `${this.baseUrl}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+			method: "GET",
+			headers: { Authorization: `Bearer ${token}` },
+		}), "Read task projection");
+		const event = response.json as TaskProjectionEvent;
+		if (event?.status === "cancelled") throw new EventNotFoundError(eventId);
+		return event;
+	}
+
 	/**
 	 * Deletes a Google Calendar event
 	 */
@@ -1148,16 +1163,7 @@ export class GoogleCalendarService extends CalendarProvider {
 				this.plugin.settings.googleCalendarExport.reconcileFromTasks &&
 				calendarId === this.plugin.settings.googleCalendarExport.targetCalendarId
 			) {
-				const response = await this.withRetry(
-					() =>
-						requestUrl({
-							url: `${this.baseUrl}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
-							method: "GET",
-							headers: { Authorization: `Bearer ${token}` },
-						}),
-					"Read task projection before deletion"
-				);
-				const event = response.json as TaskProjectionEvent;
+				const event = await this.readTaskProjection(calendarId, eventId, expectedConnectionGeneration);
 				const owner = event.extendedProperties?.private;
 				if (
 					event.attendees?.length ||

--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -1130,7 +1130,8 @@ export class GoogleCalendarService extends CalendarProvider {
 	async deleteEvent(
 		calendarId: string,
 		eventId: string,
-		expectedConnectionGeneration?: number
+		expectedConnectionGeneration?: number,
+		expectedEtag?: string
 	): Promise<void> {
 		// Validate inputs
 		validateCalendarId(calendarId);
@@ -1168,6 +1169,8 @@ export class GoogleCalendarService extends CalendarProvider {
 					throw new Error(
 						"Refusing to delete an unowned, invited or unversioned task projection"
 					);
+				if (expectedEtag && event.etag !== expectedEtag)
+					throw new Error("Task projection changed after deletion was verified");
 				etag = event.etag;
 			}
 

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -1,7 +1,11 @@
-import { TFile, stringifyYaml } from "obsidian";
+import { TFile, stringifyYaml, parseYaml } from "obsidian";
 import { format } from "date-fns";
 import TaskNotesPlugin from "../main";
-import { GoogleCalendarService } from "./GoogleCalendarService";
+import {
+	GoogleCalendarService,
+	taskProjectionMatches,
+	type TaskProjectionEvent,
+} from "./GoogleCalendarService";
 import {
 	GoogleCalendarEventIndexEntry,
 	PendingGoogleCalendarDeletion,
@@ -55,6 +59,10 @@ const EVENT_INDEX_RECOVERY_INTERVAL_MS = 15 * 60 * 1000;
 type CalendarEventPayload = {
 	summary: string;
 	description?: string;
+	location?: string;
+	transparency?: "transparent";
+	visibility?: "private";
+	extendedProperties?: { private: Record<string, string> };
 	start: { date?: string; dateTime?: string; timeZone?: string };
 	end: { date?: string; dateTime?: string; timeZone?: string };
 	colorId?: string;
@@ -516,6 +524,7 @@ export class TaskCalendarSyncService {
 
 	private getCalendarRelevantFingerprint(task: TaskInfo): string {
 		return JSON.stringify({
+			path: task.path,
 			title: task.title || "",
 			status: task.status || "",
 			priority: task.priority || "",
@@ -909,8 +918,208 @@ export class TaskCalendarSyncService {
 		return !this.isTaskCalendarEligible(task);
 	}
 
+	/** A task's durable identity survives a rename, archival and provider cache loss. */
+	private async projectionIdentity(task: TaskInfo): Promise<string> {
+		const file = this.plugin.app.vault.getAbstractFileByPath(task.path);
+		if (!(file instanceof TFile)) throw new Error("Projection source disappeared");
+		let uid = "";
+		await withVaultFileMutation(file, () =>
+			processVaultFrontMatterWithinMutation(this.plugin.app, file, (fm) => {
+				if (
+					fm.tasknotesUid !== undefined &&
+					(typeof fm.tasknotesUid !== "string" ||
+						!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(
+							fm.tasknotesUid
+						))
+				) {
+					throw new Error("Invalid stable task identity");
+				}
+				uid = fm.tasknotesUid || crypto.randomUUID();
+				fm.tasknotesUid = uid;
+			})
+		);
+		return uid;
+	}
+
+	private ownedProjectionReconciliation: Promise<void> | null = null;
+
+	async reconcileOwnedTaskProjections(): Promise<void> {
+		if (this.ownedProjectionReconciliation) return this.ownedProjectionReconciliation;
+		const work = this.reconcileOwnedTaskProjectionsOnce();
+		this.ownedProjectionReconciliation = work;
+		try {
+			await work;
+		} finally {
+			this.ownedProjectionReconciliation = null;
+		}
+	}
+
+	private ownedProjectionPayload(
+		task: TaskInfo,
+		uid: string,
+		role: "series" | "exception"
+	): CalendarEventPayload | null {
+		const payload =
+			role === "series"
+				? this.taskToCalendarEvent(task, true)
+				: this.buildRecurringExceptionEvent(task);
+		if (!payload) return null;
+		payload.extendedProperties = {
+			private: {
+				tasknotesProjection: "1",
+				tasknotesRole: role,
+				tasknotesVault: this.plugin.app.vault.getName(),
+				tasknotesUid: uid,
+				...(role === "exception"
+					? { tasknotesOccurrence: task.googleCalendarExceptionOriginalScheduled || "" }
+					: {}),
+			},
+		};
+		payload.transparency = "transparent";
+		payload.visibility = "private";
+		payload.location = "";
+		payload.description ??= "";
+		if (!payload.reminders) payload.reminders = { useDefault: false };
+		return payload;
+	}
+
+	private ownedProjectionIsCurrent(
+		task: TaskInfo,
+		uid: string,
+		series: TaskProjectionEvent | undefined,
+		exception: TaskProjectionEvent | undefined
+	): boolean {
+		const expected = this.ownedProjectionPayload(task, uid, "series");
+		if (!series || !expected || !taskProjectionMatches(series, expected)) return false;
+		if (!this.shouldCreateDetachedRecurringException(task))
+			return (
+				!exception &&
+				!this.getTaskExceptionEventId(task) &&
+				!task.googleCalendarExceptionOriginalScheduled
+			);
+		const detached = this.ownedProjectionPayload(task, uid, "exception");
+		return !!(exception && detached && taskProjectionMatches(exception, detached));
+	}
+
+	/** Rebuild provider state from a complete, readable Markdown cohort. */
+	private async reconcileOwnedTaskProjectionsOnce(): Promise<void> {
+		if (!this.plugin.settings.googleCalendarExport.reconcileFromTasks || !this.isEnabled())
+			return;
+		const calendarId = this.plugin.settings.googleCalendarExport.targetCalendarId;
+		const vaultName = this.plugin.app.vault.getName();
+		const generation = this.getConnectionGeneration();
+		const tasks = await this.plugin.cacheManager.getAllTasks();
+		const byPath = new Map(tasks.map((task) => [task.path, task]));
+		const byUid = new Map<string, TaskInfo | null>();
+		const uidByPath = new Map<string, string>();
+		// Read every candidate before any remote mutation. Missing metadata or a
+		// duplicated identity must never look like permission to delete an event.
+		for (const file of this.plugin.app.vault.getMarkdownFiles()) {
+			const content = await this.plugin.app.vault.read(file);
+			const header = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(content);
+			if (!header || !header[1].includes("tasknotesUid")) continue;
+			const fm = parseYaml(header[1]) as Record<string, unknown> | null;
+			const uid = fm?.tasknotesUid;
+			if (uid === undefined) continue;
+			if (
+				typeof uid !== "string" ||
+				!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(uid) ||
+				byUid.has(uid)
+			) {
+				throw new Error(`Invalid or duplicated task identity: ${file.path}`);
+			}
+			const indexedTask = byPath.get(file.path);
+			if (!indexedTask) throw new Error(`Task identity is not indexed yet: ${file.path}`);
+			const task = {
+				path: file.path,
+				title: indexedTask.title,
+				status: indexedTask.status,
+				priority: indexedTask.priority,
+				archived: false,
+				...this.plugin.fieldMapper.mapFromFrontmatter(
+					fm,
+					file.path,
+					this.plugin.settings.storeTitleInFilename
+				),
+			};
+			byPath.set(file.path, task);
+			byUid.set(uid, task);
+			uidByPath.set(file.path, uid);
+		}
+		const events = await this.googleCalendarService.listTaskProjections(calendarId, vaultName);
+		const byTask = new Map<string, typeof events>();
+		const exceptions = new Map<string, typeof events>();
+		for (const event of events) {
+			const owner = event.extendedProperties?.private;
+			if (
+				owner?.tasknotesProjection !== "1" ||
+				owner.tasknotesVault !== vaultName ||
+				!owner.tasknotesUid
+			)
+				continue;
+			if (event.attendees?.length) throw new Error("An owned task projection has attendees");
+			const groups = owner.tasknotesRole === "exception" ? exceptions : byTask;
+			const group = groups.get(owner.tasknotesUid) || [];
+			group.push(event);
+			groups.set(owner.tasknotesUid, group);
+		}
+		await this.assertConnectionGenerationCurrent(generation);
+		for (const uid of new Set([...byTask.keys(), ...exceptions.keys()])) {
+			const group = byTask.get(uid) || [];
+			const detached = exceptions.get(uid) || [];
+			const task = byUid.get(uid);
+			if (!task || !this.isTaskCalendarEligible(task)) {
+				for (const event of [...group, ...detached])
+					await this.deleteOrQueueCalendarEvent(task?.path || "", calendarId, event.id);
+				continue;
+			}
+			const matchingExceptions = detached.filter(
+				(event) =>
+					event.extendedProperties?.private?.tasknotesOccurrence ===
+					task.googleCalendarExceptionOriginalScheduled
+			);
+			const exception =
+				matchingExceptions.find(
+					(event) => event.id === task.googleCalendarExceptionEventId
+				) || matchingExceptions[0];
+			if (exception && task.googleCalendarExceptionEventId !== exception.id) {
+				await this.saveTaskExceptionMetadata(
+					task.path,
+					{ googleCalendarExceptionEventId: exception.id },
+					calendarId,
+					generation
+				);
+				task.googleCalendarExceptionEventId = exception.id;
+			}
+			const existing =
+				group.find((event) => event.id === this.getTaskEventId(task)) || group[0];
+			if (existing && task.googleCalendarEventId !== existing.id) {
+				await this.saveTaskEventId(task.path, existing.id, calendarId, generation);
+				task.googleCalendarEventId = existing.id;
+			}
+			// First prove one correct survivor, then remove duplicate derived events.
+			if (
+				this.ownedProjectionIsCurrent(task, uid, existing, exception) ||
+				(await this.syncTaskToCalendar(task))
+			) {
+				for (const event of group)
+					if (event.id !== existing?.id)
+						await this.deleteOrQueueCalendarEvent(task.path, calendarId, event.id);
+				for (const event of detached)
+					if (event.id !== exception?.id)
+						await this.deleteOrQueueCalendarEvent(task.path, calendarId, event.id);
+			}
+		}
+		for (const task of byPath.values()) {
+			if (!this.isTaskCalendarEligible(task)) continue;
+			const uid = uidByPath.get(task.path) || (await this.projectionIdentity(task));
+			if (!byTask.has(uid) && !exceptions.has(uid)) await this.syncTaskToCalendar(task);
+		}
+	}
+
 	async processStartupRecovery(): Promise<void> {
 		await this.profileAsync("processStartupRecovery", async () => {
+			await this.reconcileOwnedTaskProjections();
 			await this.recoverDeletedTaskEventsFromIndex();
 			await this.processDeletionQueue();
 			await this.processPendingSyncQueue();
@@ -935,13 +1144,17 @@ export class TaskCalendarSyncService {
 			return;
 		}
 
+		await this.reconcileOwnedTaskProjections();
 		await this.recoverDeletedTaskEventsFromIndex();
 	}
 
 	async initializeExternalFileReconciliation(): Promise<void> {
 		await this.profileAsync("initializeExternalFileReconciliation", async () => {
 			const settings = this.plugin.settings.googleCalendarExport;
-			this.profileGauge("initializeExternalFileReconciliation.enabled", settings.enabled ? 1 : 0);
+			this.profileGauge(
+				"initializeExternalFileReconciliation.enabled",
+				settings.enabled ? 1 : 0
+			);
 			if (!settings.enabled) {
 				return;
 			}
@@ -2590,7 +2803,9 @@ export class TaskCalendarSyncService {
 			return;
 		}
 
-		const eventData = this.buildRecurringExceptionEvent(task);
+		const eventData = this.plugin.settings.googleCalendarExport.reconcileFromTasks
+			? this.ownedProjectionPayload(task, await this.projectionIdentity(task), "exception")
+			: this.buildRecurringExceptionEvent(task);
 		if (!eventData) {
 			return;
 		}
@@ -2726,7 +2941,9 @@ export class TaskCalendarSyncService {
 			// Check if recurrence was removed (previous had recurrence, current doesn't)
 			const clearRecurrence = !!(previous?.recurrence && !task.recurrence);
 
-			const eventData = this.taskToCalendarEvent(task, clearRecurrence);
+			const eventData = settings.reconcileFromTasks
+				? this.ownedProjectionPayload(task, await this.projectionIdentity(task), "series")
+				: this.taskToCalendarEvent(task, clearRecurrence);
 			if (!eventData) {
 				tasknotesLogger.warn("[TaskCalendarSync] Could not convert task to event:", {
 					category: "provider",

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -829,6 +829,70 @@ export class TaskCalendarSyncService {
 		});
 	}
 
+	/** Require current retirement evidence or a byte-equivalent surviving projection. */
+	private async projectionDeletionVersion(
+		calendarId: string,
+		eventId: string
+	): Promise<string | undefined> {
+		if (!this.plugin.settings.googleCalendarExport.reconcileFromTasks) return undefined;
+		const events = await this.googleCalendarService.listTaskProjections(
+			calendarId,
+			this.plugin.app.vault.getName()
+		);
+		const event = events.find((candidate) => candidate.id === eventId);
+		const owner = event?.extendedProperties?.private;
+		if (
+			!event?.etag ||
+			event.attendees?.length ||
+			owner?.tasknotesProjection !== "1" ||
+			owner.tasknotesVault !== this.plugin.app.vault.getName() ||
+			!owner.tasknotesUid
+		)
+			throw new Error("Cannot verify the task projection proposed for deletion");
+		const { byUid } = await this.readProjectionTasks();
+		const task = byUid.get(owner.tasknotesUid);
+		if (!task)
+			throw new Error("Keeping projection: no readable task with the same stable identity");
+		const occurrence = owner.tasknotesOccurrence;
+		const retiredOccurrence =
+			owner.tasknotesRole === "exception" &&
+			occurrence &&
+			(task.complete_instances?.includes(occurrence) ||
+				task.skipped_instances?.includes(occurrence));
+		if ((task.archived && !this.isTaskCalendarEligible(task)) || retiredOccurrence)
+			return event.etag;
+
+		const survivorId =
+			owner.tasknotesRole === "exception"
+				? this.getTaskExceptionEventId(task)
+				: this.getTaskEventId(task);
+		const survivor = events.find(
+			(candidate) => candidate.id === survivorId && candidate.id !== eventId
+		);
+		// Ignore only provider-generated record metadata. Unknown user fields (for
+		// example attachments) must match too, not just fields TaskNotes writes.
+		const content = (record: TaskProjectionEvent) =>
+			JSON.stringify(
+				Object.entries(record)
+					.filter(
+						([key]) =>
+							![
+								"id",
+								"etag",
+								"created",
+								"updated",
+								"htmlLink",
+								"iCalUID",
+								"sequence",
+							].includes(key)
+					)
+					.sort(([a], [b]) => a.localeCompare(b))
+			);
+		if (survivor && !survivor.attendees?.length && content(survivor) === content(event))
+			return event.etag;
+		throw new Error("Keeping projection: no retirement marker or identical surviving event");
+	}
+
 	private async deleteOrQueueCalendarEvent(
 		taskPath: string,
 		calendarId: string,
@@ -854,10 +918,12 @@ export class TaskCalendarSyncService {
 		try {
 			await this.withGoogleRateLimit(async () => {
 				await this.assertConnectionGenerationCurrent(connectionGeneration);
+				const version = await this.projectionDeletionVersion(calendarId, eventId);
 				return this.googleCalendarService.deleteEvent(
 					calendarId,
 					eventId,
-					connectionGeneration
+					connectionGeneration,
+					...(version ? [version] : [])
 				);
 			});
 			await this.removeFromDeletionQueue(calendarId, eventId);
@@ -1001,26 +1067,37 @@ export class TaskCalendarSyncService {
 		return !!(exception && detached && taskProjectionMatches(exception, detached));
 	}
 
-	/** Rebuild provider state from a complete, readable Markdown cohort. */
-	private async reconcileOwnedTaskProjectionsOnce(): Promise<void> {
-		if (!this.plugin.settings.googleCalendarExport.reconcileFromTasks || !this.isEnabled())
-			return;
-		const calendarId = this.plugin.settings.googleCalendarExport.targetCalendarId;
-		const vaultName = this.plugin.app.vault.getName();
-		const generation = this.getConnectionGeneration();
+	private async readProjectionTasks() {
 		const tasks = await this.plugin.cacheManager.getAllTasks();
-		const byPath = new Map(tasks.map((task) => [task.path, task]));
-		const byUid = new Map<string, TaskInfo | null>();
+		const indexedByPath = new Map(tasks.map((task) => [task.path, task]));
+		const byPath = new Map<string, TaskInfo>();
+		const byUid = new Map<string, TaskInfo>();
 		const uidByPath = new Map<string, string>();
 		// Read every candidate before any remote mutation. Missing metadata or a
 		// duplicated identity must never look like permission to delete an event.
 		for (const file of this.plugin.app.vault.getMarkdownFiles()) {
 			const content = await this.plugin.app.vault.read(file);
 			const header = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(content);
-			if (!header || !header[1].includes("tasknotesUid")) continue;
+			if (!header) {
+				if (indexedByPath.has(file.path) || content.includes("tasknotesUid:"))
+					throw new Error(`Unreadable task frontmatter: ${file.path}`);
+				continue;
+			}
+			if (!indexedByPath.has(file.path) && !header[1].includes("tasknotesUid")) continue;
 			const fm = parseYaml(header[1]) as Record<string, unknown> | null;
-			const uid = fm?.tasknotesUid;
-			if (uid === undefined) continue;
+			if (!fm || typeof fm !== "object" || Array.isArray(fm))
+				throw new Error(`Invalid task frontmatter: ${file.path}`);
+			const uid = fm.tasknotesUid;
+			if (uid === undefined) {
+				// A previously projected task must not receive a replacement identity.
+				const indexed = indexedByPath.get(file.path);
+				if (
+					indexed &&
+					(this.getTaskEventId(indexed) || this.getTaskExceptionEventId(indexed))
+				)
+					throw new Error(`Missing stable task identity: ${file.path}`);
+				continue;
+			}
 			if (
 				typeof uid !== "string" ||
 				!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(uid) ||
@@ -1028,7 +1105,7 @@ export class TaskCalendarSyncService {
 			) {
 				throw new Error(`Invalid or duplicated task identity: ${file.path}`);
 			}
-			const indexedTask = byPath.get(file.path);
+			const indexedTask = indexedByPath.get(file.path);
 			if (!indexedTask) throw new Error(`Task identity is not indexed yet: ${file.path}`);
 			const task = {
 				path: file.path,
@@ -1046,6 +1123,17 @@ export class TaskCalendarSyncService {
 			byUid.set(uid, task);
 			uidByPath.set(file.path, uid);
 		}
+		return { byPath, byUid, uidByPath };
+	}
+
+	/** Rebuild provider state without treating a missing task as a retirement. */
+	private async reconcileOwnedTaskProjectionsOnce(): Promise<void> {
+		if (!this.plugin.settings.googleCalendarExport.reconcileFromTasks || !this.isEnabled())
+			return;
+		const calendarId = this.plugin.settings.googleCalendarExport.targetCalendarId;
+		const vaultName = this.plugin.app.vault.getName();
+		const generation = this.getConnectionGeneration();
+		const { byPath, byUid, uidByPath } = await this.readProjectionTasks();
 		const events = await this.googleCalendarService.listTaskProjections(calendarId, vaultName);
 		const byTask = new Map<string, typeof events>();
 		const exceptions = new Map<string, typeof events>();
@@ -1068,7 +1156,18 @@ export class TaskCalendarSyncService {
 			const group = byTask.get(uid) || [];
 			const detached = exceptions.get(uid) || [];
 			const task = byUid.get(uid);
-			if (!task || !this.isTaskCalendarEligible(task)) {
+			if (!task) {
+				tasknotesLogger.warn(
+					"[TaskCalendarSync] Keeping projection without a readable task identity",
+					{
+						category: "provider",
+						operation: "reconcile-task-projections",
+						details: { taskUid: uid },
+					}
+				);
+				continue;
+			}
+			if (!this.isTaskCalendarEligible(task)) {
 				for (const event of [...group, ...detached])
 					await this.deleteOrQueueCalendarEvent(task?.path || "", calendarId, event.id);
 				continue;
@@ -1557,10 +1656,15 @@ export class TaskCalendarSyncService {
 
 					await this.withGoogleRateLimit(async () => {
 						await this.assertConnectionGenerationCurrent(connectionGeneration);
+						const version = await this.projectionDeletionVersion(
+							item.calendarId,
+							item.eventId
+						);
 						return this.googleCalendarService.deleteEvent(
 							item.calendarId,
 							item.eventId,
-							connectionGeneration
+							connectionGeneration,
+							...(version ? [version] : [])
 						);
 					});
 					await this.clearTaskEventIdIfMatching(item, connectionGeneration);

--- a/src/services/TaskCalendarSyncService.ts
+++ b/src/services/TaskCalendarSyncService.ts
@@ -839,7 +839,8 @@ export class TaskCalendarSyncService {
 			calendarId,
 			this.plugin.app.vault.getName()
 		);
-		const event = events.find((candidate) => candidate.id === eventId);
+		const event = events.find((candidate) => candidate.id === eventId) ||
+			await this.googleCalendarService.readTaskProjection(calendarId, eventId);
 		const owner = event?.extendedProperties?.private;
 		if (
 			!event?.etag ||

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -190,6 +190,7 @@ export const DEFAULT_ICS_INTEGRATION_SETTINGS: ICSIntegrationSettings = {
 };
 
 export const DEFAULT_GOOGLE_CALENDAR_EXPORT: GoogleCalendarExportSettings = {
+	reconcileFromTasks: false,
 	enabled: false, // Disabled by default - user must opt-in
 	targetCalendarId: "", // Empty = user must select a calendar
 	syncOnTaskCreate: true,

--- a/src/settings/tabs/integrationsTab.ts
+++ b/src/settings/tabs/integrationsTab.ts
@@ -830,6 +830,20 @@ export function renderIntegrationsTab(
 					})
 			);
 
+			group.addSetting(
+				(setting) =>
+					void configureToggleSetting(setting, {
+						name: "Rebuild private task projections",
+						desc: "Tasks own a private, free-busy-transparent projection. Repair edits, duplicates and missing events at startup and every 15 minutes; remove marked events when their task is archived or deleted. Adds a stable tasknotesUid property. Use a dedicated calendar.",
+						getValue: () =>
+							plugin.settings.googleCalendarExport.reconcileFromTasks ?? false,
+						setValue: async (value: boolean) => {
+							plugin.settings.googleCalendarExport.reconcileFromTasks = value;
+							save();
+						},
+					})
+			);
+
 			// Target calendar dropdown (populated dynamically)
 			group.addSetting((setting) => {
 				setting.setName(

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -328,6 +328,8 @@ export interface ICSIntegrationSettings {
  * Configuration for exporting tasks to Google Calendar
  */
 export interface GoogleCalendarExportSettings {
+	/** Opt-in one-way reconciliation on a dedicated projection calendar. */
+	reconcileFromTasks?: boolean;
 	enabled: boolean; // Master enable/disable for task export
 	targetCalendarId: string; // Which calendar to create events in
 	syncOnTaskCreate: boolean; // Auto-sync when task is created

--- a/tests/services/GoogleCalendarService.test.ts
+++ b/tests/services/GoogleCalendarService.test.ts
@@ -66,6 +66,7 @@ describe('GoogleCalendarService', () => {
 		mockPlugin = {
 			app: {} as any,
 			settings: {
+                googleCalendarExport: {reconcileFromTasks: false},
 				enabledGoogleCalendars: [],
 				googleCalendarSyncTokens: {}
 			} as any,

--- a/tests/services/TaskReliability.test.ts
+++ b/tests/services/TaskReliability.test.ts
@@ -1,0 +1,243 @@
+import { requestUrl } from "obsidian";
+import { GoogleCalendarService, taskProjectionMatches } from "../../src/services/GoogleCalendarService";
+import { TaskCalendarSyncService } from "../../src/services/TaskCalendarSyncService";
+
+const UID = "61d3d239-e29c-4295-aac2-a40be5ace641";
+const OTHER = "a0a38710-9c32-485a-bd39-9a049cc7e9ee";
+
+describe("Google Calendar projection recovery", () => {
+	function projectionFixture() {
+		const task: any = {
+			path: "Tasks/new-name.md",
+			title: "Example",
+			status: "ready",
+			scheduled: "2026-09-06",
+			archived: false,
+		};
+		const file: any = { path: task.path };
+		const plugin: any = {
+			app: {
+				vault: {
+					getName: () => "Example Vault",
+					getMarkdownFiles: () => [file],
+					read: async () => `---\ntasknotesUid: ${UID}\n---\n`,
+				},
+			},
+			settings: {
+				googleCalendarExport: {
+					enabled: true,
+					reconcileFromTasks: true,
+					targetCalendarId: "test-calendar",
+				},
+			},
+			fieldMapper: { mapFromFrontmatter: () => ({ ...task }) },
+			cacheManager: { getAllTasks: async () => [task] },
+		};
+		const owner = {
+			tasknotesProjection: "1",
+			tasknotesVault: "Example Vault",
+			tasknotesUid: UID,
+			tasknotesRole: "series",
+		};
+		const events: any[] = [{ id: "event1", extendedProperties: { private: owner } }];
+		const google: any = {
+			listTaskProjections: jest.fn(async () => events),
+			getConnectionGeneration: () => 0,
+		};
+		const service: any = new TaskCalendarSyncService(plugin, google);
+		service.isEnabled = () => true;
+		service.assertConnectionGenerationCurrent = async () => {};
+		service.projectionIdentity = async () => UID;
+		service.ownedProjectionIsCurrent = () => false;
+		service.isTaskCalendarEligible = (t: any) => !t.archived;
+		service.getTaskEventId = (t: any) => t.googleCalendarEventId;
+		service.saveTaskEventId = jest.fn(async () => {});
+		service.saveTaskExceptionMetadata = jest.fn(async () => {});
+		service.syncTaskToCalendar = jest.fn(async () => true);
+		service.deleteOrQueueCalendarEvent = jest.fn(async () => true);
+		return { task, file, plugin, google, service, events, owner };
+	}
+
+	it("recovers a moved task's event link without a local provider index", async () => {
+		const { task, service } = projectionFixture();
+		await service.reconcileOwnedTaskProjections();
+		expect(service.saveTaskEventId).toHaveBeenCalledWith(
+			task.path,
+			"event1",
+			"test-calendar",
+			0
+		);
+		expect(service.syncTaskToCalendar).toHaveBeenCalledTimes(1);
+		expect(service.deleteOrQueueCalendarEvent).not.toHaveBeenCalled();
+	});
+
+	it("repairs a survivor before removing duplicate projections and cleans owned orphans", async () => {
+		const { service, events, owner } = projectionFixture();
+		events.push(
+			{ id: "duplicate", extendedProperties: { private: owner } },
+			{ id: "orphan", extendedProperties: { private: { ...owner, tasknotesUid: OTHER } } },
+			{ id: "unowned", extendedProperties: { private: {} } }
+		);
+		await service.reconcileOwnedTaskProjections();
+		expect(service.deleteOrQueueCalendarEvent.mock.calls.map((call: any[]) => call[2])).toEqual(
+			["duplicate", "orphan"]
+		);
+		expect(service.syncTaskToCalendar.mock.invocationCallOrder[0]).toBeLessThan(
+			service.deleteOrQueueCalendarEvent.mock.invocationCallOrder[0]
+		);
+	});
+
+	it("keeps duplicate events if the canonical survivor cannot be repaired", async () => {
+		const { service, events, owner } = projectionFixture();
+		events.push({ id: "duplicate", extendedProperties: { private: owner } });
+		service.syncTaskToCalendar.mockResolvedValue(false);
+		await service.reconcileOwnedTaskProjections();
+		expect(service.deleteOrQueueCalendarEvent).not.toHaveBeenCalled();
+	});
+
+	it("deletes the projection of an archived task while retaining its identity", async () => {
+		const { task, service } = projectionFixture();
+		task.archived = true;
+		await service.reconcileOwnedTaskProjections();
+		expect(service.deleteOrQueueCalendarEvent).toHaveBeenCalledWith(
+			task.path,
+			"test-calendar",
+			"event1"
+		);
+		expect(service.syncTaskToCalendar).not.toHaveBeenCalled();
+	});
+
+	it.each(["duplicate identity", "unreadable source", "attendees"])(
+		"refuses cleanup on %s",
+		async (kind) => {
+			const { plugin, service, file, events } = projectionFixture();
+			if (kind === "duplicate identity")
+				plugin.app.vault.getMarkdownFiles = () => [file, { path: "Tasks/copy.md" }];
+			if (kind === "unreadable source")
+				plugin.app.vault.read = async () => {
+					throw Error("unavailable");
+				};
+			if (kind === "attendees") events[0].attendees = [{ email: "invitee@example.com" }];
+			await expect(service.reconcileOwnedTaskProjections()).rejects.toThrow();
+			expect(service.saveTaskEventId).not.toHaveBeenCalled();
+			expect(service.deleteOrQueueCalendarEvent).not.toHaveBeenCalled();
+			expect(service.syncTaskToCalendar).not.toHaveBeenCalled();
+		}
+	);
+
+	it("recovers a detached recurrence event separately from its parent series", async () => {
+		const { task, service, events, owner } = projectionFixture();
+		task.googleCalendarExceptionOriginalScheduled = "2026-09-06";
+		events.push({
+			id: "detached",
+			extendedProperties: {
+				private: {
+					...owner,
+					tasknotesRole: "exception",
+					tasknotesOccurrence: "2026-09-06",
+				},
+			},
+		});
+		await service.reconcileOwnedTaskProjections();
+		expect(service.saveTaskExceptionMetadata).toHaveBeenCalledWith(
+			task.path,
+			{ googleCalendarExceptionEventId: "detached" },
+			"test-calendar",
+			0
+		);
+		expect(service.deleteOrQueueCalendarEvent).not.toHaveBeenCalled();
+	});
+});
+
+describe("owned provider projection safety", () => {
+	const owner = { tasknotesProjection: "1", tasknotesVault: "Example Vault", tasknotesUid: UID };
+	function fixture() {
+		const service: any = Object.create(GoogleCalendarService.prototype);
+		service.baseUrl = "https://www.googleapis.com/calendar/v3";
+		service.plugin = {
+			app: { vault: { getName: () => "Example Vault" } },
+			settings: {
+				googleCalendarExport: {
+					reconcileFromTasks: true,
+					targetCalendarId: "test-calendar",
+				},
+			},
+		};
+		service.oauthService = { getValidToken: async () => "fixture-token" };
+		service.withRetry = (fn: any) => fn();
+		service.refreshAllCalendars = jest.fn(async () => {});
+		service.convertToICSEvent = (event: any) => event;
+		(requestUrl as jest.Mock).mockReset();
+		return service;
+	}
+	it("pages through owned records, allowing a valid empty final page", async () => {
+		const service = fixture();
+		(requestUrl as jest.Mock)
+			.mockResolvedValueOnce({
+				json: {
+					items: [{ id: "one" }, { id: "cancelled", status: "cancelled" }],
+					nextPageToken: "next",
+				},
+			})
+			.mockResolvedValueOnce({ json: {} });
+		expect(await service.listTaskProjections("test-calendar", "Example Vault")).toEqual([
+			{ id: "one" },
+		]);
+		const url = new URL((requestUrl as jest.Mock).mock.calls[1][0].url);
+		expect(url.searchParams.getAll("privateExtendedProperty")).toEqual([
+			"tasknotesProjection=1",
+			"tasknotesVault=Example Vault",
+		]);
+		expect(url.searchParams.get("pageToken")).toBe("next");
+	});
+	it.each(["invitation", "unowned", "no etag"])(
+		"refuses to delete a changed %s record",
+		async (kind) => {
+			const service = fixture();
+			const event: any = {
+				id: "fixture",
+				etag: '"version1"',
+				extendedProperties: { private: owner },
+			};
+			if (kind === "invitation") event.attendees = [{ email: "fixture@example.com" }];
+			if (kind === "unowned") delete event.extendedProperties;
+			if (kind === "no etag") delete event.etag;
+			(requestUrl as jest.Mock).mockResolvedValue({ json: event });
+			await expect(service.deleteEvent("test-calendar", "fixture")).rejects.toThrow();
+			expect((requestUrl as jest.Mock).mock.calls.map((call) => call[0].method)).toEqual([
+				"GET",
+			]);
+		}
+	);
+	it("uses the freshly read etag for deletion, including saved retries", async () => {
+		const service = fixture();
+		(requestUrl as jest.Mock)
+			.mockResolvedValueOnce({
+				json: { id: "fixture", etag: '"version1"', extendedProperties: { private: owner } },
+			})
+			.mockResolvedValueOnce({ status: 204 });
+		await service.deleteEvent("test-calendar", "fixture");
+		expect((requestUrl as jest.Mock).mock.calls[1][0]).toMatchObject({
+			method: "DELETE",
+			headers: { "If-Match": '"version1"' },
+		});
+	});
+	it("detects remote edits even when the ownership marker is unchanged", () => {
+		const expected = {
+			summary: "Source",
+			start: { date: "2026-09-05" },
+			end: { date: "2026-09-06" },
+			reminders: { useDefault: false },
+			transparency: "transparent",
+			visibility: "private",
+			extendedProperties: { private: owner },
+		};
+		expect(taskProjectionMatches({ ...expected }, expected)).toBe(true);
+		expect(taskProjectionMatches({ ...expected, summary: "Remote drift" }, expected)).toBe(
+			false
+		);
+		expect(
+			taskProjectionMatches({ ...expected, recurrence: ["RRULE:FREQ=DAILY"] }, expected)
+		).toBe(false);
+	});
+});

--- a/tests/services/TaskReliability.test.ts
+++ b/tests/services/TaskReliability.test.ts
@@ -1,5 +1,8 @@
 import { requestUrl } from "obsidian";
-import { GoogleCalendarService, taskProjectionMatches } from "../../src/services/GoogleCalendarService";
+import {
+	GoogleCalendarService,
+	taskProjectionMatches,
+} from "../../src/services/GoogleCalendarService";
 import { TaskCalendarSyncService } from "../../src/services/TaskCalendarSyncService";
 
 const UID = "61d3d239-e29c-4295-aac2-a40be5ace641";
@@ -20,7 +23,8 @@ describe("Google Calendar projection recovery", () => {
 				vault: {
 					getName: () => "Example Vault",
 					getMarkdownFiles: () => [file],
-					read: async () => `---\ntasknotesUid: ${UID}\n---\n`,
+					read: async () =>
+						`---\ntasknotesUid: ${UID}\ntags: ${task.archived ? "[archived]" : "[]"}\n---\n`,
 				},
 			},
 			settings: {
@@ -30,8 +34,8 @@ describe("Google Calendar projection recovery", () => {
 					targetCalendarId: "test-calendar",
 				},
 			},
-			fieldMapper: { mapFromFrontmatter: () => ({ ...task }) },
-			cacheManager: { getAllTasks: async () => [task] },
+			fieldMapper: { mapFromFrontmatter: (fm: any) => ({ ...task, archived: Array.isArray(fm.tags) && fm.tags.includes("archived") }) },
+			cacheManager: { getAllTasks: async () => [task], getTaskInfo: async () => task },
 		};
 		const owner = {
 			tasknotesProjection: "1",
@@ -39,7 +43,9 @@ describe("Google Calendar projection recovery", () => {
 			tasknotesUid: UID,
 			tasknotesRole: "series",
 		};
-		const events: any[] = [{ id: "event1", extendedProperties: { private: owner } }];
+		const events: any[] = [
+			{ id: "event1", etag: "v1", extendedProperties: { private: owner } },
+		];
 		const google: any = {
 			listTaskProjections: jest.fn(async () => events),
 			getConnectionGeneration: () => 0,
@@ -71,7 +77,7 @@ describe("Google Calendar projection recovery", () => {
 		expect(service.deleteOrQueueCalendarEvent).not.toHaveBeenCalled();
 	});
 
-	it("repairs a survivor before removing duplicate projections and cleans owned orphans", async () => {
+	it("repairs a survivor before duplicate cleanup and keeps projections with missing sources", async () => {
 		const { service, events, owner } = projectionFixture();
 		events.push(
 			{ id: "duplicate", extendedProperties: { private: owner } },
@@ -80,7 +86,7 @@ describe("Google Calendar projection recovery", () => {
 		);
 		await service.reconcileOwnedTaskProjections();
 		expect(service.deleteOrQueueCalendarEvent.mock.calls.map((call: any[]) => call[2])).toEqual(
-			["duplicate", "orphan"]
+			["duplicate"]
 		);
 		expect(service.syncTaskToCalendar.mock.invocationCallOrder[0]).toBeLessThan(
 			service.deleteOrQueueCalendarEvent.mock.invocationCallOrder[0]
@@ -124,6 +130,116 @@ describe("Google Calendar projection recovery", () => {
 			expect(service.syncTaskToCalendar).not.toHaveBeenCalled();
 		}
 	);
+
+	it.each([
+		"missing source",
+		"missing UUID",
+		"unclosed frontmatter",
+		"invalid YAML",
+		"empty YAML",
+	])("does not infer deletion from %s", async (kind) => {
+		const { plugin, service } = projectionFixture();
+		if (kind === "missing source") plugin.app.vault.getMarkdownFiles = () => [];
+		else
+			plugin.app.vault.read = async () =>
+				({
+					"missing UUID": "---\nstatus: ready\n---\n",
+					"unclosed frontmatter": `---\ntasknotesUid: ${UID}\n`,
+					"invalid YAML": `---\ntasknotesUid: [\n---\n`,
+					"empty YAML": "---\n\n---\n",
+				})[kind];
+		await service.reconcileOwnedTaskProjections().catch(() => {});
+		expect(service.deleteOrQueueCalendarEvent).not.toHaveBeenCalled();
+	});
+
+	function deletionFixture() {
+		const fixture = projectionFixture();
+		const { service, plugin, google } = fixture;
+		plugin.settings.googleCalendarExport.syncOnTaskDelete = true;
+		service.isDeletionQueueReady = () => true;
+		service.withGoogleRateLimit = (fn: any) => fn();
+		service.queueCalendarDeletion = jest.fn(async () => {});
+		service.removeFromDeletionQueue = jest.fn(async () => {});
+		google.deleteEvent = jest.fn(async () => {});
+		delete service.deleteOrQueueCalendarEvent;
+		return fixture;
+	}
+
+	it.each(["immediate", "queued"])(
+		"keeps a damaged source safe through %s deletion",
+		async (route) => {
+			const { service, plugin, task, google } = deletionFixture();
+			plugin.app.vault.read = async () => "---\nstatus: ready\n---\n";
+			const item = {
+				taskPath: task.path,
+				calendarId: "test-calendar",
+				eventId: "event1",
+				attempts: 0,
+				createdAt: 1,
+			};
+			if (route === "immediate") {
+				expect(
+					await service.deleteOrQueueCalendarEvent(task.path, "test-calendar", "event1")
+				).toBe(false);
+				expect(service.queueCalendarDeletion.mock.calls[0][3].message).toMatch(
+					/stable identity/
+				);
+			} else {
+				service.getDeletionQueue = async () => [item];
+				service.mutateDeletionQueue = async (mutate: any) => mutate([item]);
+				const result = await service.processDeletionQueue();
+				expect(result).toEqual({ deleted: 0, failed: 1, remaining: 1 });
+			}
+			expect(google.deleteEvent).not.toHaveBeenCalled();
+		}
+	);
+
+	it("requires a fresh archive tag rather than a cached archived flag", async () => {
+		const { service, plugin, task, google } = deletionFixture();
+		task.archived = true;
+		plugin.app.vault.read = async () => `---\ntasknotesUid: ${UID}\n---\n`;
+		expect(await service.deleteOrQueueCalendarEvent(task.path, "test-calendar", "event1")).toBe(
+			false
+		);
+		expect(google.deleteEvent).not.toHaveBeenCalled();
+	});
+
+	it("deletes only a verified retirement, carrying its provider revision", async () => {
+		const { service, task, google } = deletionFixture();
+		task.archived = true;
+		expect(await service.deleteOrQueueCalendarEvent(task.path, "test-calendar", "event1")).toBe(
+			true
+		);
+		expect(google.deleteEvent).toHaveBeenCalledWith("test-calendar", "event1", 0, "v1");
+	});
+
+	it.each([false, true])(
+		"deletes a duplicate only when all event content matches (changed=%s)",
+		async (changed) => {
+			const { service, task, google, events } = deletionFixture();
+			task.googleCalendarEventId = "survivor";
+			events.push({ ...events[0], id: "survivor", etag: "v2" });
+			if (changed) events[0].attachments = [{ fileUrl: "https://example.com/attachment" }];
+			expect(
+				await service.deleteOrQueueCalendarEvent(task.path, "test-calendar", "event1")
+			).toBe(!changed);
+			expect(google.deleteEvent).toHaveBeenCalledTimes(changed ? 0 : 1);
+		}
+	);
+
+	it("retires a detached occurrence only with an explicit completion or skip marker", async () => {
+		const { service, task, events, google, owner } = deletionFixture();
+		events[0].extendedProperties.private = {
+			...owner,
+			tasknotesRole: "exception",
+			tasknotesOccurrence: "2026-09-06",
+		};
+		task.complete_instances = ["2026-09-06"];
+		expect(await service.deleteOrQueueCalendarEvent(task.path, "test-calendar", "event1")).toBe(
+			true
+		);
+		expect(google.deleteEvent).toHaveBeenCalledTimes(1);
+	});
 
 	it("recovers a detached recurrence event separately from its parent series", async () => {
 		const { task, service, events, owner } = projectionFixture();
@@ -190,6 +306,20 @@ describe("owned provider projection safety", () => {
 		]);
 		expect(url.searchParams.get("pageToken")).toBe("next");
 	});
+
+	it("refuses deletion if the provider changed after retirement was verified", async () => {
+		const service = fixture();
+		(requestUrl as jest.Mock).mockResolvedValue({
+			json: { id: "event1", etag: "changed", extendedProperties: { private: owner } },
+		});
+		await expect(service.deleteEvent("test-calendar", "event1", 0, "verified")).rejects.toThrow(
+			/changed/
+		);
+		expect((requestUrl as jest.Mock).mock.calls.map((call: any[]) => call[0].method)).toEqual([
+			"GET",
+		]);
+	});
+
 	it.each(["invitation", "unowned", "no etag"])(
 		"refuses to delete a changed %s record",
 		async (kind) => {

--- a/tests/services/TaskReliability.test.ts
+++ b/tests/services/TaskReliability.test.ts
@@ -194,6 +194,25 @@ describe("Google Calendar projection recovery", () => {
 		}
 	);
 
+
+	it.each([404, 410])("settles an already deleted projection after a direct provider read (%s)", async (status) => {
+		const { service, task, google, events } = deletionFixture();
+		events.length = 0;
+		google.readTaskProjection = jest.fn(async () => { throw Object.assign(new Error("Gone"), { status }); });
+		expect(await service.deleteOrQueueCalendarEvent(task.path, "test-calendar", "event1")).toBe(true);
+		expect(google.readTaskProjection).toHaveBeenCalledWith("test-calendar", "event1");
+		expect(google.deleteEvent).not.toHaveBeenCalled();
+		expect(service.queueCalendarDeletion).not.toHaveBeenCalled();
+	});
+
+	it("keeps an unmarked event absent from the filtered listing", async () => {
+		const { service, task, google, events } = deletionFixture();
+		events.length = 0;
+		google.readTaskProjection = jest.fn(async () => ({ id: "event1", etag: "v1" }));
+		expect(await service.deleteOrQueueCalendarEvent(task.path, "test-calendar", "event1")).toBe(false);
+		expect(google.deleteEvent).not.toHaveBeenCalled();
+	});
+
 	it("requires a fresh archive tag rather than a cached archived flag", async () => {
 		const { service, plugin, task, google } = deletionFixture();
 		task.archived = true;


### PR DESCRIPTION
### Problem
Google task events can go missing, duplicate, or link to an old path after task files move or the local event index is lost. A damaged or missing task file must not make recovery delete its Calendar event.

### Solution
Add an optional **Rebuild private task projections** setting, off by default. Exported tasks receive a persistent UUID. Startup and the existing recovery loop use it to repair event links, missing events and stale details.

Cleanup requires a readable task with the same UUID and either a retirement marker or an identical surviving event. Missing IDs and unreadable files preserve events. The same check protects queued retries, and deletion refuses a provider revision that changed after verification. Unrelated and invited events remain untouched.

### Testing
- 30 recovery and provider-safety tests pass, including damaged files, retries, retirement, differing duplicate content and changed provider revisions.
- Lint and `build:test` pass. Live Obsidian checks against disposable Google events confirm that malformed frontmatter and missing task IDs preserve the events.
- Two local filtering/locale failures also reproduce on the unchanged parent branch.
- [GitHub CI passed: tests, lint, type checks and build](https://github.com/callumalpass/tasknotes/actions/runs/33996089980).
