### PR TITLE
fix: stop startup when an existing settings file cannot be read

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,7 +35,6 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 ## Fixed
 
 - Stop plugin startup when an existing settings file cannot be read, preserving it for recovery instead of starting services with default settings.
-  - Thanks to @martin-forge for the contribution.
 
 - (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
   - Thanks to @3zra47 for reporting and @YBKF for the contribution.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -34,6 +34,9 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 ## Fixed
 
+- Stop plugin startup when an existing settings file cannot be read, preserving it for recovery instead of starting services with default settings.
+  - Thanks to @martin-forge for the contribution.
+
 - (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
   - Thanks to @3zra47 for reporting and @YBKF for the contribution.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -744,6 +744,10 @@ export default class TaskNotesPlugin extends Plugin {
 				},
 			});
 		}
+		if (result.compromised)
+			throw new Error(
+				"TaskNotes settings are unreadable; restore settings before loading the plugin."
+			);
 		return result.data;
 	}
 

--- a/tests/unit/issues/issue-1591-settings-lost-on-update.test.ts
+++ b/tests/unit/issues/issue-1591-settings-lost-on-update.test.ts
@@ -38,8 +38,8 @@ describe("issue #1591 settings reset on update", () => {
 		const plugin = createPlugin({ dataFileExists: true });
 		plugin.loadData = jest.fn().mockResolvedValue(null);
 
-		await plugin.loadSettings();
-		await plugin.checkForVersionUpdate();
+		await expect(plugin.loadSettings()).rejects.toThrow("settings are unreadable");
+		await plugin.saveSettingsDataOnly();
 
 		expect(plugin.loadData).toHaveBeenCalledTimes(4);
 		expect(plugin.saveData).not.toHaveBeenCalled();


### PR DESCRIPTION
### Problem
When an existing settings file temporarily reads as null, TaskNotes blocks settings writes but can still start services using defaults. That can start background work with the wrong configuration.

### Solution
Stop loading the plugin after the existing recovery reads fail. Leave the unreadable file untouched so it can be restored. A new install with no settings file still starts normally. Follow-up to #1591.

### Testing
- All three settings-loss regression tests pass, including new-install behavior.
- `npm run lint` and `npm run build:test` pass.
- Reloaded the standalone build in a disposable Obsidian vault; no captured errors.
- The same startup guard passed a live null-settings check: no task, Calendar or timer services started and the damaged bytes stayed unchanged.
- [GitHub CI: full test suite and build passed](https://github.com/callumalpass/tasknotes/actions/runs/33980779493).
