### PR TITLE
fix: keep saved Pomodoro sessions paused on mobile startup

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -34,6 +34,9 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 ## Fixed
 
+- Keep a saved Pomodoro session paused when opening the mobile app, so synced timer state does not automatically restart an old session.
+  - Thanks to @martin-forge for the contribution.
+
 - (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
   - Thanks to @3zra47 for reporting and @YBKF for the contribution.
 

--- a/src/services/PomodoroService.ts
+++ b/src/services/PomodoroService.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion -- Pomodoro state transitions guard active sessions before dereferencing. */
-import { TFile, moment as obsidianMoment } from "obsidian";
+import { TFile, Platform, moment as obsidianMoment } from "obsidian";
 import TaskNotesPlugin from "../main";
 import {
 	createDailyNote,
@@ -92,6 +92,8 @@ export class PomodoroService {
 
 	async initialize() {
 		await this.loadState();
+		// Opening a phone presenter must not resume an old task writer.
+		if (Platform.isMobile) this.state.isRunning = false;
 		this.setupTicker();
 		this.subscribeToTaskFileRenames();
 

--- a/tests/services/PomodoroService.mobile-startup.test.ts
+++ b/tests/services/PomodoroService.mobile-startup.test.ts
@@ -1,0 +1,30 @@
+import { Platform } from "obsidian";
+import { PomodoroService } from "../../src/services/PomodoroService";
+
+describe("saved Pomodoro sessions on mobile", () => {
+	it("does not resume a persisted Pomodoro writer on mobile startup", async () => {
+		const previous = Platform.isMobile;
+		(Platform as any).isMobile = true;
+		try {
+			const service: any = new PomodoroService({
+				settings: { pomodoroWorkDuration: 25 },
+			} as any);
+			service.loadState = async () => {
+				service.state = {
+					isRunning: true,
+					currentSession: { id: "fixture" },
+					timeRemaining: 1,
+				};
+			};
+			service.setupTicker = () => {};
+			service.subscribeToTaskFileRenames = () => {};
+			service.resumeTimer = jest.fn();
+			await service.initialize();
+			expect(service.resumeTimer).not.toHaveBeenCalled();
+			expect(service.state.isRunning).toBe(false);
+			expect(service.state.currentSession.id).toBe("fixture");
+		} finally {
+			(Platform as any).isMobile = previous;
+		}
+	});
+});


### PR DESCRIPTION
### Problem
Opening the mobile app can automatically resume a saved Pomodoro session synced from another device, allowing an old session to run without a new start action.

### Solution
Restore the saved session in a paused state on mobile. Keep the session available for the user to resume; desktop startup behavior is unchanged.

### Testing
- Seven focused Pomodoro tests pass, including the mobile startup regression.
- `npm run lint` and `npm run build:test` pass.
- Reloaded the standalone build in a disposable Obsidian vault; no captured errors.
- [GitHub CI: full test suite and build passed](https://github.com/callumalpass/tasknotes/actions/runs/33979266712).
