### PR TITLE
fix(google-calendar): resolve the primary calendar alias in every lookup

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -34,6 +34,11 @@ When a change has user-facing documentation, include a canonical tasknotes.dev l
 
 ## Fixed
 
+- (#2309) Fixed Google calendars enabled through the `primary` alias falling back to the
+  default blue instead of their own calendar color. The alias now also resolves for the
+  calendar's visibility toggle, which previously matched nothing, and for the calendar name
+  shown on mini calendar entries and event-linked notes.
+
 - (#1849) Fixed context menus stacking on top of each other. Only one menu stays open at a time, and clicking the same indicator again closes its menu. This previously applied to date fields only, and now covers priority, status, recurrence, reminders, task, ICS event, and batch menus.
   - Thanks to @3zra47 for reporting and @YBKF for the contribution.
 

--- a/src/bases/CalendarView.ts
+++ b/src/bases/CalendarView.ts
@@ -79,7 +79,7 @@ import {
 	getCalendarConfigValue as getCalendarConfigValueFromSnapshot,
 } from "./calendarConfigSnapshot";
 import { buildCalendarPropertyEvent } from "./calendarPropertyEvents";
-import { buildExternalCalendarEvents } from "./calendarExternalEvents";
+import { buildExternalCalendarEvents, setProviderCalendarToggle } from "./calendarExternalEvents";
 import {
 	decorateCalendarIcsEventElement,
 	getCalendarRelatedNoteTooltip,
@@ -918,7 +918,11 @@ export class CalendarView extends BasesViewBase {
 				const calendars = this.plugin.googleCalendarService.getAvailableCalendars();
 				for (const cal of calendars) {
 					const key = `showGoogleCalendar_${cal.id}`;
-					this.googleCalendarToggles.set(cal.id, this.getConfigOption(key, true));
+					setProviderCalendarToggle(
+						this.googleCalendarToggles,
+						cal,
+						this.getConfigOption(key, true)
+					);
 				}
 			}
 

--- a/src/bases/MiniCalendarView.ts
+++ b/src/bases/MiniCalendarView.ts
@@ -36,6 +36,8 @@ import {
 import { ICSEventInfoModal } from "../modals/ICSEventInfoModal";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
 import { createElementInDocument } from "../utils/documentDom";
+import { findProviderCalendar } from "../services/CalendarProvider";
+import { setProviderCalendarToggle } from "./calendarExternalEvents";
 
 const tasknotesLogger = createTaskNotesLogger({ tag: "Bases/MiniCalendarView" });
 
@@ -209,8 +211,9 @@ export class MiniCalendarView extends BasesViewBase {
 
 		if (this.plugin.googleCalendarService) {
 			for (const calendar of this.plugin.googleCalendarService.getAvailableCalendars()) {
-				this.googleCalendarToggles.set(
-					calendar.id,
+				setProviderCalendarToggle(
+					this.googleCalendarToggles,
+					calendar,
 					getToggleValue(`showGoogleCalendar_${calendar.id}`)
 				);
 			}
@@ -447,17 +450,13 @@ export class MiniCalendarView extends BasesViewBase {
 			return;
 		}
 
-		const calendars = new Map(
-			this.plugin.googleCalendarService
-				.getAvailableCalendars()
-				.map((calendar) => [calendar.id, calendar])
-		);
+		const calendars = this.plugin.googleCalendarService.getAvailableCalendars();
 
 		for (const icsEvent of this.plugin.googleCalendarService.getAllEvents()) {
 			const calendarId = icsEvent.subscriptionId.replace("google-", "");
 			if (this.googleCalendarToggles.get(calendarId) === false) continue;
 
-			const calendar = calendars.get(calendarId);
+			const calendar = findProviderCalendar(calendars, calendarId);
 			this.indexExternalEvent(
 				icsEvent,
 				calendar?.summary || "Google Calendar",

--- a/src/bases/calendarExternalEvents.ts
+++ b/src/bases/calendarExternalEvents.ts
@@ -2,6 +2,7 @@ import type { EventInput } from "@fullcalendar/core";
 import type TaskNotesPlugin from "../main";
 import type { ICSEvent } from "../types";
 import { createICSEvent } from "./calendar-core";
+import { PRIMARY_CALENDAR_ALIAS, ProviderCalendar } from "../services/CalendarProvider";
 
 export type ExternalCalendarProvider = "ics" | "google" | "microsoft";
 
@@ -33,6 +34,22 @@ export function getExternalCalendarToggleId(
 		return event.subscriptionId.replace("microsoft-", "");
 	}
 	return event.subscriptionId;
+}
+
+/**
+ * Registers a provider calendar's visibility toggle. Calendars fetched under the
+ * primary alias carry that alias as their calendar id, so the account's own
+ * calendar has to answer to both keys for its toggle to take effect.
+ */
+export function setProviderCalendarToggle(
+	toggles: Map<string, boolean>,
+	calendar: Pick<ProviderCalendar, "id" | "primary">,
+	visible: boolean
+): void {
+	toggles.set(calendar.id, visible);
+	if (calendar.primary) {
+		toggles.set(PRIMARY_CALENDAR_ALIAS, visible);
+	}
 }
 
 export function shouldIncludeExternalCalendarEvent(

--- a/src/services/CalendarProvider.ts
+++ b/src/services/CalendarProvider.ts
@@ -23,6 +23,29 @@ export interface ProviderCalendar {
 }
 
 /**
+ * Google accepts `primary` as an alias for the signed-in account's own calendar.
+ * A calendar configured that way is fetched under the alias, so its events carry
+ * `primary` as their calendar id while the provider's calendar list reports the
+ * account's real calendar id.
+ */
+export const PRIMARY_CALENDAR_ALIAS = "primary";
+
+/**
+ * Finds a provider calendar by id, resolving the primary alias to the account's
+ * own calendar so alias-configured events still match their calendar metadata.
+ */
+export function findProviderCalendar<T extends Pick<ProviderCalendar, "id" | "primary">>(
+	calendars: readonly T[],
+	calendarId: string
+): T | undefined {
+	return calendars.find(
+		(candidate) =>
+			candidate.id === calendarId ||
+			(calendarId === PRIMARY_CALENDAR_ALIAS && candidate.primary === true)
+	);
+}
+
+/**
  * Event date/time configuration
  * Supports both all-day events (date) and timed events (dateTime + timeZone)
  *

--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -13,7 +13,7 @@ import {
 	TokenExpiredError,
 } from "./errors";
 import { validateCalendarId, validateEventId, validateRequired } from "./validation";
-import { CalendarProvider, ProviderCalendar } from "./CalendarProvider";
+import { CalendarProvider, findProviderCalendar, ProviderCalendar } from "./CalendarProvider";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
 import { publishUserNotice } from "../core/userNotices";
 import { normalizeCalendarDescription } from "../utils/calendarDescription";
@@ -455,6 +455,20 @@ export class GoogleCalendarService extends CalendarProvider {
 	}
 
 	/**
+	 * Resolves a calendar's color, including for calendars fetched under the
+	 * primary alias, whose colors are cached under the account's real calendar id.
+	 */
+	private getCalendarColor(calendarId: string): string | undefined {
+		const directColor = this.calendarColors.get(calendarId);
+		if (directColor) {
+			return directColor;
+		}
+
+		const calendar = findProviderCalendar(this.availableCalendars, calendarId);
+		return calendar ? this.calendarColors.get(calendar.id) : undefined;
+	}
+
+	/**
 	 * Converts a Google Calendar event to TaskNotes ICSEvent format
 	 */
 	private convertToICSEvent(googleEvent: GoogleCalendarEvent, calendarId: string): ICSEvent {
@@ -492,7 +506,7 @@ export class GoogleCalendarService extends CalendarProvider {
 
 		// Priority 2: Calendar-level color (from calendar metadata)
 		if (!color) {
-			color = this.calendarColors.get(calendarId);
+			color = this.getCalendarColor(calendarId);
 		}
 
 		// Priority 3: Default Google Calendar blue

--- a/src/services/ICSNoteService.ts
+++ b/src/services/ICSNoteService.ts
@@ -15,6 +15,7 @@ import type { InterpolationValues, TranslationKey } from "../i18n";
 import { createTaskNotesLogger } from "../utils/tasknotesLogger";
 import { publishUserNotice } from "../core/userNotices";
 import { processVaultFrontMatter } from "./VaultMutationService";
+import { findProviderCalendar } from "./CalendarProvider";
 
 const tasknotesLogger = createTaskNotesLogger({ tag: "Services/ICSNoteService" });
 
@@ -60,10 +61,9 @@ export class ICSNoteService {
 			.find((event) => event.id === trimmedEventId);
 		if (googleEvent) {
 			const calendarId = googleEvent.subscriptionId.replace("google-", "");
+			const calendars = this.plugin.googleCalendarService?.getAvailableCalendars() ?? [];
 			const subscriptionName =
-				this.plugin.googleCalendarService
-					?.getAvailableCalendars()
-					.find((calendar) => calendar.id === calendarId)?.summary || "Google Calendar";
+				findProviderCalendar(calendars, calendarId)?.summary || "Google Calendar";
 			return { event: googleEvent, subscriptionName };
 		}
 

--- a/src/ui/ICSCard.ts
+++ b/src/ui/ICSCard.ts
@@ -4,6 +4,7 @@ import { ICSEvent, ICSSubscription } from "../types";
 import { ICSEventContextMenu } from "../components/ICSEventContextMenu";
 import { formatTime } from "../utils/dateUtils";
 import { ICSEventInfoModal } from "../modals/ICSEventInfoModal";
+import { findProviderCalendar } from "../services/CalendarProvider";
 
 export interface ICSCardOptions {
 	showDate: boolean;
@@ -58,13 +59,7 @@ function getEventSourceName(
 	const provider = plugin.calendarProviderRegistry?.findProviderForEvent(icsEvent);
 	if (provider) {
 		const { calendarId } = provider.extractEventIds(icsEvent);
-		const calendar = provider
-			.getAvailableCalendars()
-			.find(
-				(candidate) =>
-					candidate.id === calendarId ||
-					(calendarId === "primary" && candidate.primary === true)
-			);
+		const calendar = findProviderCalendar(provider.getAvailableCalendars(), calendarId);
 		return calendar?.summary || provider.providerName;
 	}
 

--- a/tests/unit/bases/calendarExternalEvents.test.ts
+++ b/tests/unit/bases/calendarExternalEvents.test.ts
@@ -1,6 +1,7 @@
 import {
 	buildExternalCalendarEvents,
 	getExternalCalendarToggleId,
+	setProviderCalendarToggle,
 	shouldIncludeExternalCalendarEvent,
 } from "../../../src/bases/calendarExternalEvents";
 import type TaskNotesPlugin from "../../../src/main";
@@ -50,6 +51,35 @@ describe("calendar external event assembly", () => {
 		expect(
 			shouldIncludeExternalCalendarEvent(
 				createEvent({ subscriptionId: "google-secondary" }),
+				"google",
+				toggles
+			)
+		).toBe(true);
+	});
+
+	it("applies a primary calendar's toggle to events fetched under the alias", () => {
+		const toggles = new Map<string, boolean>();
+
+		setProviderCalendarToggle(toggles, { id: "person@example.com", primary: true }, false);
+		setProviderCalendarToggle(toggles, { id: "team@example.com" }, true);
+
+		expect(
+			shouldIncludeExternalCalendarEvent(
+				createEvent({ subscriptionId: "google-primary" }),
+				"google",
+				toggles
+			)
+		).toBe(false);
+		expect(
+			shouldIncludeExternalCalendarEvent(
+				createEvent({ subscriptionId: "google-person@example.com" }),
+				"google",
+				toggles
+			)
+		).toBe(false);
+		expect(
+			shouldIncludeExternalCalendarEvent(
+				createEvent({ subscriptionId: "google-team@example.com" }),
 				"google",
 				toggles
 			)

--- a/tests/unit/issues/issue-google-primary-calendar-alias.test.ts
+++ b/tests/unit/issues/issue-google-primary-calendar-alias.test.ts
@@ -1,0 +1,112 @@
+import { requestUrl } from "obsidian";
+import type TaskNotesPlugin from "../../../src/main";
+import { GoogleCalendarService } from "../../../src/services/GoogleCalendarService";
+import { findProviderCalendar } from "../../../src/services/CalendarProvider";
+import type { OAuthService } from "../../../src/services/OAuthService";
+
+jest.mock("obsidian", () => ({
+	Platform: { isDesktopApp: true },
+	requestUrl: jest.fn(),
+}));
+
+const PRIMARY_CALENDAR = {
+	id: "person@example.com",
+	summary: "Personal",
+	primary: true,
+	backgroundColor: "#16a765",
+};
+
+function createPlugin(enabledGoogleCalendars: string[]): TaskNotesPlugin {
+	return {
+		settings: {
+			enabledGoogleCalendars,
+			googleCalendarSyncTokens: {},
+		},
+		saveSettingsDataOnly: jest.fn().mockResolvedValue(undefined),
+	} as unknown as TaskNotesPlugin;
+}
+
+function createOAuthService(): OAuthService {
+	return {
+		isConnected: jest.fn().mockResolvedValue(true),
+		getValidToken: jest.fn().mockResolvedValue("access-token"),
+	} as unknown as OAuthService;
+}
+
+function mockCalendarResponses(): void {
+	const requestMock = requestUrl as jest.MockedFunction<typeof requestUrl>;
+	requestMock.mockReset();
+	requestMock
+		.mockResolvedValueOnce({
+			status: 200,
+			json: { items: [PRIMARY_CALENDAR] },
+			text: "",
+			arrayBuffer: new ArrayBuffer(0),
+			headers: {},
+		})
+		.mockResolvedValueOnce({
+			status: 200,
+			json: {
+				items: [
+					{
+						id: "event-1",
+						summary: "Standup",
+						start: { date: "2026-09-12" },
+						end: { date: "2026-09-13" },
+					},
+				],
+				nextSyncToken: "next-sync-token",
+			},
+			text: "",
+			arrayBuffer: new ArrayBuffer(0),
+			headers: {},
+		});
+}
+
+describe("Google primary calendar alias", () => {
+	it("colors events from a calendar enabled through the primary alias", async () => {
+		mockCalendarResponses();
+		const service = new GoogleCalendarService(createPlugin(["primary"]), createOAuthService());
+
+		await service.refreshAllCalendars();
+
+		const [event] = service.getAllEvents();
+		expect(event.color).toBe("#16a765");
+	});
+
+	it("keeps alias-configured event ids stable", async () => {
+		mockCalendarResponses();
+		const service = new GoogleCalendarService(createPlugin(["primary"]), createOAuthService());
+
+		await service.refreshAllCalendars();
+
+		const [event] = service.getAllEvents();
+		expect(event.subscriptionId).toBe("google-primary");
+		expect(event.id).toBe("google-primary-event-1");
+	});
+
+	it("still colors events fetched under a calendar's own id", async () => {
+		mockCalendarResponses();
+		const service = new GoogleCalendarService(
+			createPlugin(["person@example.com"]),
+			createOAuthService()
+		);
+
+		await service.refreshAllCalendars();
+
+		const [event] = service.getAllEvents();
+		expect(event.color).toBe("#16a765");
+	});
+
+	it("resolves the primary alias to the account's own calendar", () => {
+		const calendars = [{ id: "team@example.com", summary: "Work" }, PRIMARY_CALENDAR];
+
+		expect(findProviderCalendar(calendars, "primary")?.summary).toBe("Personal");
+		expect(findProviderCalendar(calendars, "team@example.com")?.summary).toBe("Work");
+		expect(findProviderCalendar(calendars, "missing@example.com")).toBeUndefined();
+	});
+
+	it("has no primary calendar to resolve when none is marked", () => {
+		expect(findProviderCalendar([{ id: "team@example.com" }], "primary")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
When a Google calendar is enabled using the `primary` alias, fetched events carry that alias while the calendar list uses the account’s actual ID. Direct ID lookups then lose the calendar’s colour and name, and its visibility toggle fails to hide its events.

This change shares the alias lookup across calendar views, event cards and linked notes, and registers visibility toggles under both IDs. Event and subscription IDs stay unchanged so existing linked notes continue to resolve.

Validation:

- Regression tests cover alias and real-ID lookup, calendar colours and visibility toggles; the colour regression fails on the original base.
- Targeted calendar tests, ESLint and `npm run build:test` pass.
- Previously reproduced against a real account: alias-fetched events use the calendar’s own colour after the fix.

Rebased onto current main; the release-note conflict is resolved and unrelated formatting changes have been removed.
