### PR TITLE
fix(calendar): preserve chronological placement with Bases sorting

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,6 +16,8 @@ Example:
 ```
 ## Fixed
 
+- Keep agenda events chronological when a Base sort is configured; use Base order at the same calendar time. Follow-up to #1411, reported by @ky1ejs.
+
 - (#768) Fixed calendar view appearing empty in week and day views due to invalid time configuration values
   - Added time validation in settings UI with proper error messages and debouncing
   - Prevents "Cannot read properties of null (reading 'years')" error from FullCalendar

--- a/src/bases/CalendarView.ts
+++ b/src/bases/CalendarView.ts
@@ -179,7 +179,9 @@ export function getTaskNotesCalendarEventOrder(sortConfig: unknown): string {
 	if (!hasBasesCalendarSortConfig(sortConfig)) {
 		return DEFAULT_CALENDAR_EVENT_ORDER;
 	}
-	return `${TASKNOTES_CALENDAR_SORT_INDEX},${DEFAULT_CALENDAR_EVENT_ORDER}`;
+	// Bases ranks break ties at the same placement. They must not put a timed
+	// task ahead of an earlier appointment that has no Bases result index.
+	return `start,allDay,${TASKNOTES_CALENDAR_SORT_INDEX},-duration,title`;
 }
 
 function getCalendarEventSortPath(event: EventInput): string | null {

--- a/tests/unit/issues/issue-1411-agenda-bases-sort.test.ts
+++ b/tests/unit/issues/issue-1411-agenda-bases-sort.test.ts
@@ -1,4 +1,5 @@
 import type { EventInput } from "@fullcalendar/core";
+import { execFileSync } from "node:child_process";
 import {
 	applyBasesSortIndexesToCalendarEvents,
 	getTaskNotesCalendarEventOrder,
@@ -13,13 +14,44 @@ describe("Issue #1411: Agenda Calendar Bases respect Bases sort order", () => {
 		expect(getTaskNotesCalendarEventOrder(undefined)).toBe("start,-duration,allDay,title");
 	});
 
-	it("puts the TaskNotes sort index first when the Base has a sort config", () => {
+	it("uses Bases order after event time, before duration and title", () => {
 		const sortConfig = [{ column: "note.status", direction: "ASC" }];
 
 		expect(hasBasesCalendarSortConfig(sortConfig)).toBe(true);
 		expect(getTaskNotesCalendarEventOrder(sortConfig)).toBe(
-			`${TASKNOTES_CALENDAR_SORT_INDEX},start,-duration,allDay,title`
+			`start,allDay,${TASKNOTES_CALENDAR_SORT_INDEX},-duration,title`
 		);
+	});
+
+	it("interleaves timed tasks with appointments while sorting untimed tasks by Bases rank", () => {
+		const order = getTaskNotesCalendarEventOrder([{ column: "status" }]);
+		const events = [
+			{ title: "Evening task", start: 20, tasknotesSortIndex: 0 },
+			{ title: "Morning appointment", start: 9 },
+			{ title: "Morning task", start: 8, tasknotesSortIndex: 3 },
+			{ title: "Ready", start: 0, tasknotesSortIndex: 2 },
+			{ title: "Doing", start: 0, tasknotesSortIndex: 1 },
+		];
+		// The suite mocks FullCalendar. Exercise its real comparator in Node.
+		const sorted = JSON.parse(
+			execFileSync(
+				process.execPath,
+				[
+					"-e",
+					"const {parseFieldSpecs,compareByFieldSpecs}=require('@fullcalendar/core/internal'); const events=JSON.parse(process.argv[2]); const specs=parseFieldSpecs(process.argv[1]); console.log(JSON.stringify(events.sort((a,b)=>compareByFieldSpecs(a,b,specs)).map(e=>e.title)));",
+					order,
+					JSON.stringify(events),
+				],
+				{ encoding: "utf8" }
+			)
+		);
+		expect(sorted).toEqual([
+			"Doing",
+			"Ready",
+			"Morning task",
+			"Morning appointment",
+			"Evening task",
+		]);
 	});
 
 	it("adds Bases result indexes to task and property-based events", () => {


### PR DESCRIPTION
A Base sort currently puts task result ranks ahead of calendar start times. In agenda view, this can place an evening task before an earlier appointment that has no Base result index.

Keep start time and all-day placement first, then use Base rank to order tasks at the same placement. Calendars without an explicit Base sort keep their existing order. This follows up on #1411.

Validation: the agenda sorting suite passes (4 tests), including the real FullCalendar comparator with morning/evening tasks and an intervening appointment. ESLint, the TypeScript/build check, and a reload in a disposable Obsidian vault also passed.
